### PR TITLE
Switch LLM provider to Azure OpenAI (GPT-5 family)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Node.js 18+
 - Python 3.11+
 - FFmpeg, Cairo, Pango (for Manim)
-- API keys for Dedalus Labs (or any Anthropic provider)
+- API keys for Azure OpenAI (GPT-5 family) — or Dedalus Labs as a fallback provider
 
 ### Frontend Setup
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,14 +8,27 @@
 # ---------------------------
 # LLM / AI
 # ---------------------------
+# Provider is auto-detected from which keys are set below.
+# Set LLM_PROVIDER=azure or LLM_PROVIDER=dedalus to force one.
+# LLM_PROVIDER=azure
 
 # ---------------------------
-# Dedalus SDK + MCP Gateway
+# Azure OpenAI (GPT-5 family) — primary provider
+# Billed against your Azure subscription (Microsoft for Startups credits apply).
+# Create a resource + deployment in Azure AI Foundry, then fill these in.
 # ---------------------------
-# REQUIRED: LLM calls are Dedalus-only in this project.
-# The official Dedalus SDK (dedalus-labs) reads this env var automatically.
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+AZURE_OPENAI_API_KEY=your-azure-openai-api-key
+# Deployment name you gave the model in Azure (defaults to gpt-5)
+AZURE_OPENAI_DEPLOYMENT=gpt-5
+# Reasoning depth: minimal | low | medium | high (default low = fast/cheap)
+# AZURE_OPENAI_REASONING_EFFORT=low
+
+# ---------------------------
+# Dedalus SDK + MCP Gateway — legacy fallback provider
 # Sign up at https://www.dedaluslabs.ai/dashboard/api-keys to get your key.
-DEDALUS_API_KEY=dsk-your-dedalus-api-key
+# ---------------------------
+# DEDALUS_API_KEY=dsk-your-dedalus-api-key
 
 # ---------------------------
 # Storage Mode

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,21 +30,21 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Copy dependency files first (better layer caching)
-COPY pyproject.toml ./
+COPY pyproject.toml uv.lock ./
 COPY manimations/pyproject.toml ./manimations/pyproject.toml
 
 # Create venv and install all deps via uv sync
 RUN uv venv /app/.venv && \
     uv sync --python /app/.venv/bin/python --no-dev --frozen 2>/dev/null || \
     uv pip install --python /app/.venv/bin/python \
-        "fastapi>=0.109.0" "uvicorn>=0.27.0" "anthropic>=0.18.0" \
+        "fastapi>=0.109.0" "uvicorn>=0.27.0" \
         "pydantic>=2.0.0" "python-dotenv>=0.21.1,<0.22.0" \
         "httpx>=0.25.0" "asyncio-throttle>=1.0.0" \
         "sqlalchemy>=2.0.0" "aiosqlite>=0.19.0" "asyncpg>=0.29.0" "greenlet>=3.0.0" \
         "arxiv>=2.0.0" "pymupdf4llm>=0.0.5" "pymupdf>=1.23.0" \
         "beautifulsoup4>=4.12.0" "lxml>=5.0.0" \
         "manim>=0.18.0" "manim-voiceover[gtts]>=0.3.0" \
-        "boto3>=1.34.0" "openai>=1.12.0" "setuptools>=65.0.0" \
+        "boto3>=1.34.0" "openai>=1.60.0" "setuptools>=65.0.0" \
         "dedalus-labs>=0.2.0" "python-multipart>=0.0.6"
 
 # ── Application ────────────────────────────────────────────

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     texlive-fonts-extra \
     cm-super \
     dvipng \
+    dvisvgm \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Python dependencies ────────────────────────────────────

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,19 +34,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock ./
 COPY manimations/pyproject.toml ./manimations/pyproject.toml
 
-# Create venv and install all deps via uv sync
+# Create venv and install the exact locked dependency set. This must fail the
+# build if uv.lock is missing or out of sync — a silent fallback to a
+# hand-maintained pip list previously shipped an incomplete/stale dependency
+# set (missing alembic/redis/modal, broken manim) that only surfaced at runtime.
 RUN uv venv /app/.venv && \
-    uv sync --python /app/.venv/bin/python --no-dev --frozen 2>/dev/null || \
-    uv pip install --python /app/.venv/bin/python \
-        "fastapi>=0.109.0" "uvicorn>=0.27.0" \
-        "pydantic>=2.0.0" "python-dotenv>=0.21.1,<0.22.0" \
-        "httpx>=0.25.0" "asyncio-throttle>=1.0.0" \
-        "sqlalchemy>=2.0.0" "aiosqlite>=0.19.0" "asyncpg>=0.29.0" "greenlet>=3.0.0" \
-        "arxiv>=2.0.0" "pymupdf4llm>=0.0.5" "pymupdf>=1.23.0" \
-        "beautifulsoup4>=4.12.0" "lxml>=5.0.0" \
-        "manim>=0.18.0" "manim-voiceover[gtts]>=0.3.0" \
-        "boto3>=1.34.0" "openai>=1.60.0" "setuptools>=65.0.0" \
-        "dedalus-labs>=0.2.0" "python-multipart>=0.0.6"
+    uv sync --python /app/.venv/bin/python --no-dev --frozen
 
 # ── Application ────────────────────────────────────────────
 FROM base AS runtime

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -1,4 +1,4 @@
-"""Base agent class with Dedalus-only LLM support."""
+"""Base agent class with provider-switchable LLM support (Azure OpenAI / Dedalus)."""
 
 import json
 import logging
@@ -20,31 +20,134 @@ except ImportError:
     pass  # python-dotenv not installed, use system env vars
 
 
-# Default model
-DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+# Default model per provider. For Azure this is the *deployment name* you
+# created in Azure AI Foundry (defaults to the model name, e.g. "gpt-5").
+DEFAULT_DEDALUS_MODEL = "claude-sonnet-4-5"
 
-# Provider is intentionally fixed to Dedalus for production consistency.
-_provider: str = "dedalus"
 
-# Shared Dedalus runner (reuse across agents to avoid re-init)
-_dedalus_runner = None
+def _azure_deployment() -> str:
+    return os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-5")
+
+
+# GPT-5 reasoning tokens count against max_completion_tokens. Agents size
+# max_tokens for the *visible* answer, so give the model extra room to think
+# or it can return an empty message after exhausting the cap on reasoning.
+_AZURE_REASONING_HEADROOM = 4096
 
 
 def _detect_provider() -> str:
-    """Detect provider and enforce Dedalus-only configuration."""
-    if not os.environ.get("DEDALUS_API_KEY"):
+    """Resolve the LLM provider from env: LLM_PROVIDER wins, else auto-detect."""
+    explicit = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    if explicit == "azure":
+        _require_azure_env()
+        return "azure"
+    if explicit == "dedalus":
+        _require_dedalus_env()
+        return "dedalus"
+    if explicit:
         raise RuntimeError(
-            "DEDALUS_API_KEY is required. This project is configured to use "
-            "Dedalus-only LLM routing."
+            f"Unknown LLM_PROVIDER={explicit!r}. Use 'azure' or 'dedalus'."
         )
-    return "dedalus"
+
+    if os.environ.get("AZURE_OPENAI_API_KEY") and os.environ.get("AZURE_OPENAI_ENDPOINT"):
+        return "azure"
+    if os.environ.get("DEDALUS_API_KEY"):
+        return "dedalus"
+    raise RuntimeError(
+        "No LLM provider configured. Set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT "
+        "(Azure OpenAI, GPT-5 family) or DEDALUS_API_KEY (Dedalus)."
+    )
+
+
+def _require_azure_env() -> None:
+    missing = [
+        k for k in ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")
+        if not os.environ.get(k)
+    ]
+    if missing:
+        raise RuntimeError(f"LLM_PROVIDER=azure but missing env vars: {', '.join(missing)}")
+
+
+def _require_dedalus_env() -> None:
+    if not os.environ.get("DEDALUS_API_KEY"):
+        raise RuntimeError("LLM_PROVIDER=dedalus but DEDALUS_API_KEY is not set.")
 
 
 def get_provider() -> str:
-    """Get the current provider name."""
-    # Always validate env when requested so misconfigurations fail fast.
-    _detect_provider()
-    return _provider
+    """Get the current provider name (validates env on every call)."""
+    return _detect_provider()
+
+
+# ---------------------------------------------------------------------------
+# Azure OpenAI (GPT-5 family) — billed against Azure / Microsoft credits
+# ---------------------------------------------------------------------------
+
+_azure_async_client = None
+_azure_sync_client = None
+
+
+def _azure_base_url() -> str:
+    endpoint = os.environ["AZURE_OPENAI_ENDPOINT"].rstrip("/")
+    return f"{endpoint}/openai/v1/"
+
+
+def _get_azure_client():
+    global _azure_async_client
+    if _azure_async_client is None:
+        from openai import AsyncOpenAI
+        _azure_async_client = AsyncOpenAI(
+            base_url=_azure_base_url(),
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            timeout=300.0,  # 5 min — large paper summarization needs headroom
+        )
+    return _azure_async_client
+
+
+def _get_azure_sync_client():
+    global _azure_sync_client
+    if _azure_sync_client is None:
+        from openai import OpenAI
+        _azure_sync_client = OpenAI(
+            base_url=_azure_base_url(),
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            timeout=300.0,
+        )
+    return _azure_sync_client
+
+
+def _azure_model(model: str | None) -> str:
+    """Map a requested model to an Azure deployment name.
+
+    Claude model names (the old Dedalus defaults) map to the configured
+    GPT-5 deployment; explicit gpt-* names pass through.
+    """
+    if not model or model.startswith("claude") or "/" in model:
+        return _azure_deployment()
+    return model
+
+
+def _azure_request_kwargs(
+    model: str, prompt: str, system_prompt: str, max_tokens: int
+) -> dict:
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+    kwargs: dict = {
+        "model": model,
+        "messages": messages,
+        "max_completion_tokens": max_tokens + _AZURE_REASONING_HEADROOM,
+    }
+    # minimal | low | medium | high — low keeps the pipeline fast/cheap
+    kwargs["reasoning_effort"] = os.environ.get("AZURE_OPENAI_REASONING_EFFORT", "low")
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Dedalus (legacy fallback)
+# ---------------------------------------------------------------------------
+
+_dedalus_runner = None
 
 
 def _get_dedalus_runner():
@@ -67,13 +170,17 @@ def _dedalus_model(model: str) -> str:
 
 
 def _get_client() -> None:
-    """Compatibility shim: there is no direct SDK client in Dedalus-only mode."""
+    """Compatibility shim: agents don't hold a direct SDK client."""
     return None
 
 
 def get_model_name(model: str | None = None) -> str:
-    """Get the model name (bare name, no provider prefix)."""
-    return model or DEFAULT_MODEL
+    """Get the model name for the active provider."""
+    if model:
+        return model
+    if get_provider() == "azure":
+        return _azure_deployment()
+    return DEFAULT_DEDALUS_MODEL
 
 
 # ---------------------------------------------------------------------------
@@ -82,18 +189,36 @@ def get_model_name(model: str | None = None) -> str:
 
 async def call_llm(
     prompt: str,
-    model: str = DEFAULT_MODEL,
+    model: str | None = None,
     system_prompt: str = "",
     max_tokens: int = 4096,
 ) -> str:
-    """Async LLM call routed through Dedalus."""
-    get_provider()
-    runner = _get_dedalus_runner()
-    dedalus_model = _dedalus_model(model)
+    """Async LLM call routed through the configured provider."""
+    provider = get_provider()
     input_words = len(prompt.split())
-    logger.info(f"[LLM] Calling {dedalus_model} ({input_words} input words, max_tokens={max_tokens})")
     t0 = time.monotonic()
+
+    if provider == "azure":
+        resolved = _azure_model(model)
+        logger.info(f"[LLM] Calling azure/{resolved} ({input_words} input words, max_tokens={max_tokens})")
+        try:
+            client = _get_azure_client()
+            resp = await client.chat.completions.create(
+                **_azure_request_kwargs(resolved, prompt, system_prompt, max_tokens)
+            )
+            output = resp.choices[0].message.content or ""
+            elapsed = time.monotonic() - t0
+            logger.info(f"[LLM] azure/{resolved} responded in {elapsed:.1f}s ({len(output.split())} output words)")
+            return output
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            logger.error(f"[LLM] azure/{resolved} FAILED after {elapsed:.1f}s: {type(e).__name__}: {e}")
+            raise
+
+    dedalus_model = _dedalus_model(model or DEFAULT_DEDALUS_MODEL)
+    logger.info(f"[LLM] Calling {dedalus_model} ({input_words} input words, max_tokens={max_tokens})")
     try:
+        runner = _get_dedalus_runner()
         result = await runner.run(
             input=prompt,
             model=dedalus_model,
@@ -102,8 +227,7 @@ async def call_llm(
         )
         elapsed = time.monotonic() - t0
         output = result.final_output or ""
-        output_words = len(output.split())
-        logger.info(f"[LLM] {dedalus_model} responded in {elapsed:.1f}s ({output_words} output words)")
+        logger.info(f"[LLM] {dedalus_model} responded in {elapsed:.1f}s ({len(output.split())} output words)")
         return output
     except Exception as e:
         elapsed = time.monotonic() - t0
@@ -113,18 +237,27 @@ async def call_llm(
 
 def call_llm_sync(
     prompt: str,
-    model: str = DEFAULT_MODEL,
+    model: str | None = None,
     system_prompt: str = "",
     max_tokens: int = 4096,
 ) -> str:
-    """Synchronous LLM call routed through Dedalus."""
+    """Synchronous LLM call routed through the configured provider."""
+    provider = get_provider()
+
+    if provider == "azure":
+        resolved = _azure_model(model)
+        client = _get_azure_sync_client()
+        resp = client.chat.completions.create(
+            **_azure_request_kwargs(resolved, prompt, system_prompt, max_tokens)
+        )
+        return resp.choices[0].message.content or ""
+
     import asyncio
 
-    get_provider()
     runner = _get_dedalus_runner()
     result = asyncio.run(runner.run(
         input=prompt,
-        model=_dedalus_model(model),
+        model=_dedalus_model(model or DEFAULT_DEDALUS_MODEL),
         instructions=system_prompt,
         max_tokens=max_tokens,
     ))
@@ -135,7 +268,8 @@ class BaseAgent:
     """
     Base class for all AI agents in the pipeline.
 
-    Uses Dedalus SDK only (DEDALUS_API_KEY).
+    Provider is selected via env: Azure OpenAI (AZURE_OPENAI_*) or
+    Dedalus (DEDALUS_API_KEY). See _detect_provider().
     """
 
     def __init__(
@@ -154,7 +288,10 @@ class BaseAgent:
         self.client = _get_client()
 
         # Log active provider
-        print(f"🔮 Dedalus SDK → anthropic/{self.model}")
+        if self._provider == "azure":
+            print(f"☁️  Azure OpenAI → {_azure_model(self.model)}")
+        else:
+            print(f"🔮 Dedalus SDK → anthropic/{self.model}")
 
     def _get_prompts_dir(self) -> Path:
         """Get the prompts directory path."""

--- a/backend/agents/context7_docs.py
+++ b/backend/agents/context7_docs.py
@@ -513,6 +513,11 @@ async def fetch_manim_docs_direct(
 # Main entry point with fallback chain
 # ---------------------------------------------------------------------------
 
+def _read_static_docs(path: Path) -> str:
+    """Blocking read of the static Manim reference (run via asyncio.to_thread)."""
+    return path.read_text() if path.exists() else ""
+
+
 async def get_manim_docs(
     topic: str = "animations mobjects Scene ThreeDScene MathTex",
     max_tokens: int = 5000,
@@ -565,8 +570,9 @@ async def get_manim_docs(
         static_path = (
             Path(__file__).parent.parent / "prompts" / "system" / "manim_reference.md"
         )
-        if static_path.exists():
-            docs = static_path.read_text()
+        # Read off the event loop — get_manim_docs is async and this fallback is
+        # reachable during request handling.
+        docs = await asyncio.to_thread(_read_static_docs, static_path)
 
     return docs
 

--- a/backend/agents/context7_docs.py
+++ b/backend/agents/context7_docs.py
@@ -536,7 +536,13 @@ async def get_manim_docs(
     """
     docs = ""
 
-    if use_dedalus and DEDALUS_API_KEY:
+    # Skip the Dedalus path entirely when the pipeline runs on another
+    # provider (e.g. Azure) — go straight to the Context7 REST API.
+    dedalus_active = bool(DEDALUS_API_KEY) and os.environ.get(
+        "LLM_PROVIDER", "dedalus" if DEDALUS_API_KEY else ""
+    ).strip().lower() == "dedalus"
+
+    if use_dedalus and dedalus_active:
         docs = await fetch_manim_docs_via_dedalus(topic, max_tokens)
 
     if not docs:

--- a/backend/agents/context7_docs.py
+++ b/backend/agents/context7_docs.py
@@ -536,17 +536,25 @@ async def get_manim_docs(
     """
     docs = ""
 
-    # Skip the Dedalus path entirely when the pipeline runs on another
-    # provider (e.g. Azure) — go straight to the Context7 REST API. Reuse the
-    # same resolver as call_llm so this can't diverge (base.py is Azure-first
-    # when both providers' creds are present and LLM_PROVIDER is unset).
-    try:
-        from .base import get_provider
-    except ImportError:
-        from agents.base import get_provider
-    dedalus_active = get_provider() == "dedalus"
+    # Use the Dedalus doc path only when explicitly requested AND the pipeline's
+    # resolved provider is Dedalus — reuse the same resolver as call_llm so this
+    # can't diverge (base.py is Azure-first when both providers' creds are present
+    # and LLM_PROVIDER is unset). Resolve the provider ONLY when use_dedalus is
+    # set: the direct Context7 REST path and static fallback don't need a provider
+    # and must keep working even when none is configured.
+    dedalus_active = False
+    if use_dedalus:
+        try:
+            from .base import get_provider
+        except ImportError:
+            from agents.base import get_provider
+        try:
+            dedalus_active = get_provider() == "dedalus"
+        except RuntimeError:
+            # No LLM provider configured — fall through to direct/static docs.
+            dedalus_active = False
 
-    if use_dedalus and dedalus_active:
+    if dedalus_active:
         docs = await fetch_manim_docs_via_dedalus(topic, max_tokens)
 
     if not docs:

--- a/backend/agents/context7_docs.py
+++ b/backend/agents/context7_docs.py
@@ -537,10 +537,14 @@ async def get_manim_docs(
     docs = ""
 
     # Skip the Dedalus path entirely when the pipeline runs on another
-    # provider (e.g. Azure) — go straight to the Context7 REST API.
-    dedalus_active = bool(DEDALUS_API_KEY) and os.environ.get(
-        "LLM_PROVIDER", "dedalus" if DEDALUS_API_KEY else ""
-    ).strip().lower() == "dedalus"
+    # provider (e.g. Azure) — go straight to the Context7 REST API. Reuse the
+    # same resolver as call_llm so this can't diverge (base.py is Azure-first
+    # when both providers' creds are present and LLM_PROVIDER is unset).
+    try:
+        from .base import get_provider
+    except ImportError:
+        from agents.base import get_provider
+    dedalus_active = get_provider() == "dedalus"
 
     if use_dedalus and dedalus_active:
         docs = await fetch_manim_docs_via_dedalus(topic, max_tokens)

--- a/backend/agents/voiceover_script_validator.py
+++ b/backend/agents/voiceover_script_validator.py
@@ -95,6 +95,14 @@ class VoiceoverScriptValidator:
             if stripped.lower().startswith(self.BANNED_STARTS):
                 issues.append(f"Narration {idx} starts with animation command style wording.")
 
+            # Word-count rule (hard fail — too short reads as filler, too long overruns the beat)
+            word_count = self._word_count(stripped)
+            if word_count < self.min_words or word_count > self.max_words:
+                issues.append(
+                    f"Narration {idx} is {word_count} words, outside the "
+                    f"{self.min_words}-{self.max_words} words range."
+                )
+
             alignment_rule_scores.append(self._rule_alignment_score(stripped, reference_terms))
             educational_rule_scores.append(self._rule_educational_score(stripped))
 

--- a/backend/agents/voiceover_script_validator.py
+++ b/backend/agents/voiceover_script_validator.py
@@ -89,19 +89,23 @@ class VoiceoverScriptValidator:
         reference_terms = self._build_reference_terms(candidate)
         for idx, line in enumerate(narrations, 1):
             stripped = line.strip()
-            if not stripped:
-                continue
-            # Banned animation-command starts (hard fail — bad narration quality)
-            if stripped.lower().startswith(self.BANNED_STARTS):
-                issues.append(f"Narration {idx} starts with animation command style wording.")
 
-            # Word-count rule (hard fail — too short reads as filler, too long overruns the beat)
+            # Word-count rule (hard fail — too short reads as filler, too long
+            # overruns the beat). Checked BEFORE skipping blanks so a blank or
+            # whitespace-only narration counts as zero words and fails the rule
+            # instead of silently passing validation.
             word_count = self._word_count(stripped)
             if word_count < self.min_words or word_count > self.max_words:
                 issues.append(
                     f"Narration {idx} is {word_count} words, outside the "
                     f"{self.min_words}-{self.max_words} words range."
                 )
+
+            if not stripped:
+                continue
+            # Banned animation-command starts (hard fail — bad narration quality)
+            if stripped.lower().startswith(self.BANNED_STARTS):
+                issues.append(f"Narration {idx} starts with animation command style wording.")
 
             alignment_rule_scores.append(self._rule_alignment_score(stripped, reference_terms))
             educational_rule_scores.append(self._rule_educational_score(stripped))

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -313,7 +313,8 @@ async def health_check(db: AsyncSession = Depends(get_db)):
             version = result.stdout.strip().split("\n")[0]
             manim_status = f"available ({version})"
         else:
-            manim_status = "error: command failed"
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            manim_status = f"error: {detail[-1][:200] if detail else 'command failed'}"
     except FileNotFoundError:
         manim_status = "not installed"
     except Exception as e:

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -313,7 +313,7 @@ async def health_check(db: AsyncSession = Depends(get_db)):
             version = result.stdout.strip().split("\n")[0]
             manim_status = f"available ({version})"
         else:
-            detail = (result.stderr or result.stdout).strip().splitlines()
+            detail = (result.stderr.strip() or result.stdout.strip()).splitlines()
             manim_status = f"error: {detail[-1][:200] if detail else 'command failed'}"
     except FileNotFoundError:
         manim_status = "not installed"

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,9 @@ app.add_middleware(
         "https://www.arxivisual.org",
         "http://localhost:3000",  # local frontend dev
     ],
-    allow_origin_regex=r"https://.*\.vercel\.app",  # Vercel preview deploys
+    # This project's Vercel preview deploys only — not every *.vercel.app site
+    # (which any Vercel user controls). Anchored end-to-end via fullmatch.
+    allow_origin_regex=r"https://ar-xivisual-[a-z0-9-]+\.vercel\.app",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -59,7 +59,12 @@ app = FastAPI(
 # Configure CORS for frontend development
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allow all origins for hackathon development
+    allow_origins=[
+        "https://arxivisual.org",
+        "https://www.arxivisual.org",
+        "http://localhost:3000",  # local frontend dev
+    ],
+    allow_origin_regex=r"https://.*\.vercel\.app",  # Vercel preview deploys
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "uvicorn>=0.27.0",
 
     # Core AI + validation
-    "anthropic>=0.18.0",
     "pydantic>=2.0.0",
     "python-dotenv>=0.21.1,<0.22.0",
 
@@ -38,8 +37,8 @@ dependencies = [
     # Cloud storage (S3-compatible — Cloudflare R2)
     "boto3>=1.34.0",
 
-    # LLM
-    "openai>=1.12.0",
+    # LLM — Azure OpenAI (GPT-5 family; needs reasoning_effort support)
+    "openai>=1.60.0",
 
     # Required by manim-voiceover (pkg_resources)
     "setuptools>=65.0.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,6 @@ fastapi>=0.109.0
 uvicorn>=0.27.0
 
 # Core AI + validation
-anthropic>=0.18.0
 pydantic>=2.0.0
 python-dotenv>=0.21.1,<0.22.0
 
@@ -36,10 +35,10 @@ manim-voiceover[gtts]>=0.3.0
 # Cloud storage (S3-compatible — Cloudflare R2)
 boto3>=1.34.0
 
-# LLM
-openai>=1.12.0
+# LLM — Azure OpenAI (GPT-5 family; needs reasoning_effort support)
+openai>=1.60.0
 
-# Dedalus SDK + MCP Gateway (Context7 live docs)
+# Dedalus SDK + MCP Gateway (legacy fallback + Context7 live docs)
 dedalus-labs>=0.2.0
 
 # Tests

--- a/backend/tests/test_context7_docs_routing.py
+++ b/backend/tests/test_context7_docs_routing.py
@@ -1,0 +1,56 @@
+"""Regression tests for provider routing in get_manim_docs.
+
+The Dedalus doc path must be selected only when explicitly requested AND the
+resolved LLM provider is Dedalus. The direct Context7 REST path (and the static
+fallback) must keep working even when no provider is configured — resolving the
+provider eagerly there previously raised RuntimeError and broke the independent
+docs path (CodeRabbit finding on PR #15).
+"""
+
+import asyncio
+
+import pytest
+
+from agents import context7_docs
+
+
+@pytest.fixture(autouse=True)
+def _no_provider(monkeypatch):
+    # No LLM provider configured -> base.get_provider() would raise RuntimeError.
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.delenv("DEDALUS_API_KEY", raising=False)
+
+
+def _stub_docs(monkeypatch):
+    calls = {"direct": 0, "dedalus": 0}
+
+    async def fake_direct(topic, max_tokens):
+        calls["direct"] += 1
+        return "DIRECT DOCS"
+
+    async def fake_dedalus(topic, max_tokens):
+        calls["dedalus"] += 1
+        return "DEDALUS DOCS"
+
+    monkeypatch.setattr(context7_docs, "fetch_manim_docs_direct", fake_direct)
+    monkeypatch.setattr(context7_docs, "fetch_manim_docs_via_dedalus", fake_dedalus)
+    context7_docs._docs_cache.clear()
+    return calls
+
+
+def test_direct_path_works_without_provider(monkeypatch):
+    calls = _stub_docs(monkeypatch)
+    docs = asyncio.run(context7_docs.get_manim_docs(topic="direct-no-provider", use_dedalus=False))
+    assert docs == "DIRECT DOCS"
+    assert calls["dedalus"] == 0  # provider never consulted / dedalus never called
+
+
+def test_use_dedalus_true_without_provider_falls_back(monkeypatch):
+    calls = _stub_docs(monkeypatch)
+    # use_dedalus=True but no provider configured: get_provider() raises, is caught,
+    # and we fall through to the direct path instead of blowing up.
+    docs = asyncio.run(context7_docs.get_manim_docs(topic="dedalus-no-provider", use_dedalus=True))
+    assert docs == "DIRECT DOCS"
+    assert calls["dedalus"] == 0

--- a/backend/tests/test_context7_docs_routing.py
+++ b/backend/tests/test_context7_docs_routing.py
@@ -54,3 +54,20 @@ def test_use_dedalus_true_without_provider_falls_back(monkeypatch):
     docs = asyncio.run(context7_docs.get_manim_docs(topic="dedalus-no-provider", use_dedalus=True))
     assert docs == "DIRECT DOCS"
     assert calls["dedalus"] == 0
+
+
+def test_static_fallback_used_when_live_sources_empty(monkeypatch):
+    calls = _stub_docs(monkeypatch)
+
+    async def empty_direct(topic, max_tokens):
+        calls["direct"] += 1
+        return ""
+
+    monkeypatch.setattr(context7_docs, "fetch_manim_docs_direct", empty_direct)
+    # Static read is exercised off the event loop via asyncio.to_thread; stub it
+    # so the test doesn't depend on the on-disk reference file.
+    monkeypatch.setattr(context7_docs, "_read_static_docs", lambda path: "STATIC DOCS")
+
+    docs = asyncio.run(context7_docs.get_manim_docs(topic="static-fallback", use_dedalus=False))
+    assert docs == "STATIC DOCS"
+    assert calls["direct"] == 1

--- a/backend/tests/test_voiceover_script_validator.py
+++ b/backend/tests/test_voiceover_script_validator.py
@@ -148,3 +148,28 @@ def test_validator_fails_word_count_rule():
     result = validator.validate(generated_code=generated, plan=_plan(), candidate=_candidate())
     assert result.is_valid is False
     assert any("outside" in issue.lower() and "words" in issue.lower() for issue in result.issues_found)
+
+
+def test_validator_flags_blank_narration_as_zero_words():
+    """A whitespace-only narration entry must fail the word-count rule instead
+    of being silently skipped (regression for CodeRabbit finding on PR #15)."""
+    validator = VoiceoverScriptValidator(use_llm_judge=False)
+    code = _valid_code().replace(
+        "Softmax-normalized weights control how strongly each value contributes to the output representation.",
+        "   ",
+    )
+    generated = GeneratedCode(
+        code=code,
+        scene_class_name="AttentionVoice",
+        dependencies=["manim", "manim_voiceover"],
+        voiceover_enabled=True,
+        narration_lines=[
+            "Queries compare against keys to compute relevance scores across all token positions.",
+            "   ",
+        ],
+        narration_beats=["# Beat 2", "# Beat 3"],
+    )
+
+    result = validator.validate(generated_code=generated, plan=_plan(), candidate=_candidate())
+    assert result.is_valid is False
+    assert any("0 words" in issue for issue in result.issues_found)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -91,25 +91,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.77.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/88/61/50aef0587acd9dd8bf1b8b7fd7fbb25ba4c6ec5387a6ffc195a697951fcc/anthropic-0.77.1.tar.gz", hash = "sha256:a19d78ff6fff9e05d211e3a936051cd5b9462f0eac043d2d45b2372f455d11cd", size = 504691, upload-time = "2026-02-03T17:44:22.667Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/54/e83babf9833547c5548b4e25230ef3d62492e45925b0d104a43e501918a0/anthropic-0.77.1-py3-none-any.whl", hash = "sha256:76fd6f2ab36033a5294d58182a5f712dab9573c3a54413a275ecdf29e727c1e0", size = 397856, upload-time = "2026-02-03T17:44:20.962Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -140,7 +121,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
-    { name = "anthropic" },
     { name = "arxiv" },
     { name = "asyncio-throttle" },
     { name = "asyncpg" },
@@ -173,7 +153,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
-    { name = "anthropic", specifier = ">=0.18.0" },
     { name = "arxiv", specifier = ">=2.0.0" },
     { name = "asyncio-throttle", specifier = ">=1.0.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
@@ -187,7 +166,7 @@ requires-dist = [
     { name = "manim", specifier = ">=0.18.0" },
     { name = "manim-voiceover", extras = ["gtts"], specifier = ">=0.3.0" },
     { name = "modal", specifier = ">=0.60.0" },
-    { name = "openai", specifier = ">=1.12.0" },
+    { name = "openai", specifier = ">=1.60.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymupdf", specifier = ">=1.23.0" },
     { name = "pymupdf4llm", specifier = ">=0.0.5" },
@@ -465,15 +444,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,8 +10,13 @@ import type { Paper, ProcessingStatus, Section } from "./types";
 // Toggle between mock and real API
 const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
-// Backend API base URL - defaults to localhost:8000 for development
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Backend API base URL — env var wins; production builds fall back to the
+// Azure backend, dev builds to localhost.
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.NODE_ENV === "production"
+    ? "https://arxivisual-api.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io"
+    : "http://localhost:8000");
 
 // === Types matching backend schemas ===
 

--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,14 @@ services:
     region: oregon
     healthCheckPath: /api/health
     envVars:
-      # LLM
+      # LLM — Azure OpenAI (GPT-5). Set values in the dashboard.
+      - key: AZURE_OPENAI_ENDPOINT
+        sync: false
+      - key: AZURE_OPENAI_API_KEY
+        sync: false
+      - key: AZURE_OPENAI_DEPLOYMENT
+        value: gpt-5
+      # Legacy fallback provider (optional)
       - key: DEDALUS_API_KEY
         sync: false  # Set manually in Render dashboard
       # TTS


### PR DESCRIPTION
## Summary

Migrates the LLM provider from Dedalus (key inactive) to **Azure OpenAI (GPT-5 family)**, with Dedalus retained as an env-selectable fallback. Also carries the deployment fixes discovered while bringing the backend up on Azure Container Apps.

**Note: production already runs this code.** The Container Apps backend image was built from this branch head, and the Vercel frontend now points at the Azure backend URL — merging brings `main` in line with what's deployed.

## Commits

- `903ab83` **feat: switch LLM provider to Azure OpenAI** — `agents/base.py` is now provider-switchable via env (`AZURE_OPENAI_*` primary, `DEDALUS_API_KEY` fallback); adds GPT-5 reasoning-token headroom to `max_completion_tokens`
- `7dcba44` **fix: enforce narration word-count rule in voiceover validator** (8/8 unit tests pass)
- `35968a6` **fix: ship `uv.lock` into the Docker image** — the silent fallback to a hand-pinned pip list was installing stale deps and breaking Manim in the container; also surfaces manim health-check errors instead of swallowing them
- `6278ad9` **feat: default production frontend to the Azure backend URL** (env var still wins)
- `4021db7` **fix: restrict CORS** to arxivisual.org, Vercel previews, and localhost dev (was wide open)
- `d406687` **fix: install `dvisvgm` in the Docker image** — required for `MathTex`/SVG rendering

## Test plan

- [x] `pytest backend/tests` — voiceover validator suite passes (8/8)
- [x] Deployed image health check: `/api/health` reports database connected, Manim v0.19.2 available, R2 storage connected
- [x] End-to-end verified in production: paper fetch + CORS preflight from https://www.arxivisual.org succeed against the Azure backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Azure OpenAI GPT-5 support as the primary AI provider, with automatic or explicit provider selection.
  - Added configurable deployment, endpoint, API key, and reasoning settings.
  - Improved production API routing and preview deployment support.

- **Bug Fixes**
  - Voiceover validation now flags blank or invalid narration lines.
  - Health checks provide specific Manim failure details.
  - Documentation retrieval now falls back gracefully when no provider is configured.

- **Security**
  - Restricted backend access to approved production, local development, and preview origins.

- **Documentation**
  - Updated setup guidance and configuration examples for Azure OpenAI and legacy fallback support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->