### PR TITLE
feat: Azure OpenAI TTS voiceovers + Langfuse tracing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,27 @@ AZURE_OPENAI_DEPLOYMENT=gpt-5
 # DEDALUS_API_KEY=dsk-your-dedalus-api-key
 
 # ---------------------------
+# Voiceover / TTS
+# "openai" (default) routes narration through Azure OpenAI's OpenAI-compatible
+#   endpoint at render time (reuses AZURE_OPENAI_* — no extra key needed).
+# "gtts" is the free Google TTS fallback.
+# ---------------------------
+# VOICEOVER_TTS_SERVICE=openai
+# VOICEOVER_VOICE_NAME=nova           # alloy | echo | fable | onyx | nova | shimmer
+# VOICEOVER_TTS_MODEL=gpt-4o-mini-tts # must match an Azure TTS deployment name
+# Override only if you have a real OpenAI key for TTS instead of Azure:
+# OPENAI_API_KEY=sk-...
+
+# ---------------------------
+# Langfuse — LLM observability (traces, token usage, cost)
+# Create a project at https://cloud.langfuse.com; both keys enable tracing.
+# ---------------------------
+# LANGFUSE_PUBLIC_KEY=pk-lf-...
+# LANGFUSE_SECRET_KEY=sk-lf-...
+# LANGFUSE_HOST=https://us.cloud.langfuse.com   # US region; EU: https://cloud.langfuse.com
+# LANGFUSE_TRACING_ENVIRONMENT=development       # set to "production" in prod to keep test traces separate
+
+# ---------------------------
 # Storage Mode
 # ---------------------------
 # "local" (default) — files stored in ./media/videos/

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -86,6 +86,29 @@ _azure_async_client = None
 _azure_sync_client = None
 
 
+def _langfuse_enabled() -> bool:
+    """Langfuse tracing is on when both project keys are present in the env."""
+    return bool(
+        os.environ.get("LANGFUSE_PUBLIC_KEY")
+        and os.environ.get("LANGFUSE_SECRET_KEY")
+    )
+
+
+def _openai_classes():
+    """Return (OpenAI, AsyncOpenAI) classes.
+
+    When Langfuse is configured, return its drop-in wrappers so every LLM call
+    is traced automatically (model, token usage, cost, latency). The wrapper
+    imports must happen AFTER env vars are loaded — hence the deferred import.
+    Falls back to the plain SDK when Langfuse isn't configured (local dev).
+    """
+    if _langfuse_enabled():
+        from langfuse.openai import OpenAI, AsyncOpenAI
+    else:
+        from openai import OpenAI, AsyncOpenAI
+    return OpenAI, AsyncOpenAI
+
+
 def _azure_base_url() -> str:
     endpoint = os.environ["AZURE_OPENAI_ENDPOINT"].rstrip("/")
     return f"{endpoint}/openai/v1/"
@@ -94,7 +117,7 @@ def _azure_base_url() -> str:
 def _get_azure_client():
     global _azure_async_client
     if _azure_async_client is None:
-        from openai import AsyncOpenAI
+        _, AsyncOpenAI = _openai_classes()
         _azure_async_client = AsyncOpenAI(
             base_url=_azure_base_url(),
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
@@ -106,7 +129,7 @@ def _get_azure_client():
 def _get_azure_sync_client():
     global _azure_sync_client
     if _azure_sync_client is None:
-        from openai import OpenAI
+        OpenAI, _ = _openai_classes()
         _azure_sync_client = OpenAI(
             base_url=_azure_base_url(),
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
@@ -187,11 +210,20 @@ def get_model_name(model: str | None = None) -> str:
 # Standalone LLM call helpers (usable outside BaseAgent, e.g. validators)
 # ---------------------------------------------------------------------------
 
+def _with_trace_name(kwargs: dict, name: str | None) -> dict:
+    """Attach a Langfuse generation name — only when tracing is on, since the
+    plain OpenAI client rejects the unknown ``name`` kwarg."""
+    if name and _langfuse_enabled():
+        kwargs["name"] = name
+    return kwargs
+
+
 async def call_llm(
     prompt: str,
     model: str | None = None,
     system_prompt: str = "",
     max_tokens: int = 4096,
+    name: str | None = None,
 ) -> str:
     """Async LLM call routed through the configured provider."""
     provider = get_provider()
@@ -204,7 +236,10 @@ async def call_llm(
         try:
             client = _get_azure_client()
             resp = await client.chat.completions.create(
-                **_azure_request_kwargs(resolved, prompt, system_prompt, max_tokens)
+                **_with_trace_name(
+                    _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens),
+                    name,
+                )
             )
             output = resp.choices[0].message.content or ""
             elapsed = time.monotonic() - t0
@@ -240,6 +275,7 @@ def call_llm_sync(
     model: str | None = None,
     system_prompt: str = "",
     max_tokens: int = 4096,
+    name: str | None = None,
 ) -> str:
     """Synchronous LLM call routed through the configured provider."""
     provider = get_provider()
@@ -248,7 +284,10 @@ def call_llm_sync(
         resolved = _azure_model(model)
         client = _get_azure_sync_client()
         resp = client.chat.completions.create(
-            **_azure_request_kwargs(resolved, prompt, system_prompt, max_tokens)
+            **_with_trace_name(
+                _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens),
+                name,
+            )
         )
         return resp.choices[0].message.content or ""
 
@@ -283,6 +322,8 @@ class BaseAgent:
         self.max_tokens = max_tokens
         self.system_prompt = self._load_system_prompt()
         self.prompt_template = self._load_prompt(prompt_file)
+        # Readable Langfuse generation name, e.g. "manim_generator"
+        self._trace_name = Path(prompt_file).stem
 
         # Keep self.client for any code that still references it directly
         self.client = _get_client()
@@ -399,6 +440,7 @@ class BaseAgent:
             model=self.model,
             system_prompt=system_prompt or self.system_prompt,
             max_tokens=max_tokens or self.max_tokens,
+            name=self._trace_name,
         )
 
     def _call_llm_sync(
@@ -413,6 +455,7 @@ class BaseAgent:
             model=self.model,
             system_prompt=system_prompt or self.system_prompt,
             max_tokens=max_tokens or self.max_tokens,
+            name=self._trace_name,
         )
 
     # ------------------------------------------------------------------

--- a/backend/agents/manim_generator.py
+++ b/backend/agents/manim_generator.py
@@ -8,6 +8,7 @@ Hackathon Track: Dedalus "Best use of tool calling"
 """
 
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -65,6 +66,17 @@ class ManimGenerator(BaseAgent):
     DEFAULT_EXAMPLE = "equation_walkthrough.py"
     DEFAULT_VOICEOVER_EXAMPLE = "voiceover_equation.py"
 
+    # TTS service wiring injected verbatim into generated scenes. The `openai`
+    # option targets Azure OpenAI's OpenAI-compatible endpoint at render time
+    # (see rendering/local_runner._tts_subprocess_env), so audio bills against
+    # Azure credits like the rest of the pipeline. gTTS is a free fallback.
+    OPENAI_TTS_MODEL = os.getenv("VOICEOVER_TTS_MODEL", "gpt-4o-mini-tts")
+    DEFAULT_OPENAI_VOICE = "nova"
+
+    TTS_IMPORTS = {
+        "gtts": "from manim_voiceover.services.gtts import GTTSService",
+        "openai": "from manim_voiceover.services.openai import OpenAIService",
+    }
     TTS_SETUP = {
         "gtts": "self.set_speech_service(GTTSService(transcription_model=None))",
     }
@@ -108,7 +120,18 @@ class ManimGenerator(BaseAgent):
 
     def _get_tts_setup_snippet(self, tts_service: str, voice_name: str) -> str:
         """Return concrete set_speech_service(...) snippet for prompt grounding."""
+        if tts_service == "openai":
+            voice = voice_name or self.DEFAULT_OPENAI_VOICE
+            return (
+                f'self.set_speech_service(OpenAIService('
+                f'voice="{voice}", model="{self.OPENAI_TTS_MODEL}", '
+                f'transcription_model=None))'
+            )
         return self.TTS_SETUP.get(tts_service, self.TTS_SETUP["gtts"])
+
+    def _get_tts_import(self, tts_service: str) -> str:
+        """Return the exact import line matching the selected TTS service."""
+        return self.TTS_IMPORTS.get(tts_service, self.TTS_IMPORTS["gtts"])
 
     def _generate_scene_class_name(self, concept_name: str) -> str:
         """Generate a valid Python class name from concept name."""
@@ -177,6 +200,7 @@ class ManimGenerator(BaseAgent):
         example_code = self._get_example_for_type(plan.visualization_type, voiceover_enabled)
         scene_class_name = self._generate_scene_class_name(plan.concept_name)
         tts_setup_snippet = self._get_tts_setup_snippet(tts_service, voice_name)
+        tts_import = self._get_tts_import(tts_service)
 
         return self._format_prompt(
             plan_json=plan.model_dump_json(indent=2),
@@ -190,6 +214,7 @@ class ManimGenerator(BaseAgent):
             voice_name=voice_name,
             narration_style=narration_style,
             tts_setup_snippet=tts_setup_snippet,
+            tts_import=tts_import,
         )
 
     async def _enrich_system_prompt_with_live_docs(

--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -18,6 +18,14 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+try:
+    from langfuse import observe
+except ImportError:  # langfuse optional — degrade to no-op decorator
+    def observe(*_args, **_kwargs):
+        def _decorator(fn):
+            return fn
+        return _decorator
+
 # Handle both package and direct imports
 try:
     from ..models.paper import StructuredPaper
@@ -79,9 +87,11 @@ RENDER_MODE = os.getenv("RENDER_MODE", "local")
 ENABLE_RENDER_TESTING = RENDER_MODE != "modal"
 
 # Voiceover configuration
+# TTS defaults to Azure OpenAI (gpt-4o-mini-tts, routed via the OpenAI-compatible
+# endpoint at render time); set VOICEOVER_TTS_SERVICE=gtts for the free fallback.
 ENABLE_VOICEOVER = True
-VOICEOVER_TTS_SERVICE = "gtts"
-VOICEOVER_VOICE_NAME = ""
+VOICEOVER_TTS_SERVICE = os.getenv("VOICEOVER_TTS_SERVICE", "openai")
+VOICEOVER_VOICE_NAME = os.getenv("VOICEOVER_VOICE_NAME", "nova")
 VOICEOVER_NARRATION_STYLE = "friendly_tutor"
 VOICEOVER_TARGET_DURATION_SECONDS = (30, 45)
 
@@ -113,6 +123,7 @@ def _extract_voiceover_metadata(code: str) -> tuple[list[str], list[str]]:
     return [n.strip() for n in narrations if n.strip()], beats
 
 
+@observe(name="generate-visualizations", capture_input=False)
 async def generate_visualizations(
     paper: StructuredPaper,
     max_visualizations: int = MAX_VISUALIZATIONS,
@@ -269,6 +280,7 @@ async def _analyze_all_sections(
     return candidates
 
 
+@observe(name="generate-single-visualization", capture_input=False)
 async def generate_single_visualization(
     candidate: VisualizationCandidate,
     paper: StructuredPaper,

--- a/backend/examples/voiceover_architecture.py
+++ b/backend/examples/voiceover_architecture.py
@@ -2,12 +2,12 @@
 
 from manim import *
 from manim_voiceover import VoiceoverScene
-from manim_voiceover.services.gtts import GTTSService
+from manim_voiceover.services.openai import OpenAIService
 
 
 class VoiceoverArchitectureExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(GTTSService(transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: frame architecture objective
         title = Text("Transformer Encoder Block", font_size=40)

--- a/backend/examples/voiceover_data_flow.py
+++ b/backend/examples/voiceover_data_flow.py
@@ -2,12 +2,12 @@
 
 from manim import *
 from manim_voiceover import VoiceoverScene
-from manim_voiceover.services.gtts import GTTSService
+from manim_voiceover.services.openai import OpenAIService
 
 
 class VoiceoverDataFlowExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(GTTSService(transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: framing
         title = Text("Attention Data Flow", font_size=42)

--- a/backend/examples/voiceover_equation.py
+++ b/backend/examples/voiceover_equation.py
@@ -2,12 +2,12 @@
 
 from manim import *
 from manim_voiceover import VoiceoverScene
-from manim_voiceover.services.gtts import GTTSService
+from manim_voiceover.services.openai import OpenAIService
 
 
 class VoiceoverEquationExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(GTTSService(transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: framing equation
         title = Text("Scaled Dot-Product Attention", font_size=38)

--- a/backend/jobs/worker.py
+++ b/backend/jobs/worker.py
@@ -6,7 +6,27 @@ Processes papers asynchronously with progress tracking.
 
 import asyncio
 import logging
+import os
 from datetime import datetime
+
+try:
+    from langfuse import observe, get_client, propagate_attributes
+    _LANGFUSE_AVAILABLE = True
+except ImportError:  # langfuse optional — degrade to no-op decorator
+    _LANGFUSE_AVAILABLE = False
+
+    def observe(*_args, **_kwargs):
+        def _decorator(fn):
+            return fn
+        return _decorator
+
+
+def _langfuse_on() -> bool:
+    return _LANGFUSE_AVAILABLE and bool(
+        os.environ.get("LANGFUSE_PUBLIC_KEY") and os.environ.get("LANGFUSE_SECRET_KEY")
+    )
+
+
 from db.connection import async_session_maker
 from db import queries
 from db.models import Section
@@ -59,7 +79,35 @@ class ProgressBar:
         logger.info(f"  [{self.name}] {bar} {percent_str} ({self.current}/{self.total}){eta_str}")
 
 
+@observe(name="process-paper")
 async def process_paper_job(job_id: str, arxiv_id: str):
+    """Traced entry point for the background paper pipeline.
+
+    Wraps the implementation so every LLM/render span for this job is grouped
+    under one Langfuse session (keyed by job_id) and traces are flushed before
+    the background task ends.
+    """
+    if not _langfuse_on():
+        await _process_paper_job_impl(job_id, arxiv_id)
+        return
+
+    with propagate_attributes(
+        session_id=job_id,
+        trace_name="process-paper",
+        tags=["pipeline"],
+        metadata={"arxiv_id": arxiv_id},
+    ):
+        try:
+            await _process_paper_job_impl(job_id, arxiv_id)
+        finally:
+            # Background task runs off-request; flush traces before it ends.
+            try:
+                get_client().flush()
+            except Exception:
+                logger.debug("Langfuse flush failed", exc_info=True)
+
+
+async def _process_paper_job_impl(job_id: str, arxiv_id: str):
     """
     Main job processing function. Called as a background task.
 

--- a/backend/prompts/manim_generator.md
+++ b/backend/prompts/manim_generator.md
@@ -49,10 +49,10 @@ The video must feel like a coherent teaching sequence, not a list of disconnecte
 ## Narration and Voiceover Requirements
 When voiceover is enabled (`{voiceover_enabled}` = true):
 1. Inherit from `VoiceoverScene`.
-2. Add these imports in the file:
+2. Add these imports in the file (use these EXACT lines, do not substitute a different service):
    - `from manim_voiceover import VoiceoverScene`
-   - service import matching `{tts_service}`
-3. In `construct`, configure TTS with this exact pattern:
+   - `{tts_import}`
+3. In `construct`, configure TTS with this EXACT line (copy it verbatim — do not change the service, model, or voice):
    - `{tts_setup_snippet}`
 4. For each content beat, wrap the core animation in:
    - `with self.voiceover(text="...") as tracker:`

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Rendering / visualization
     "manim>=0.18.0",
     "modal>=0.60.0",
-    "manim-voiceover[gtts]>=0.3.0",
+    "manim-voiceover[gtts,openai]>=0.3.0",
 
     # Cloud storage (S3-compatible — Cloudflare R2)
     "boto3>=1.34.0",
@@ -45,6 +45,9 @@ dependencies = [
 
     # Dedalus SDK + MCP Gateway (Context7 live docs)
     "dedalus-labs>=0.2.0",
+
+    # Observability — LLM tracing / cost tracking
+    "langfuse>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -62,6 +65,10 @@ packages = ["agents", "models", "prompts", "examples"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Only collect the real unit-test suite. Without this, plain `pytest` also
+# collects the argparse scripts under tools/ and backend root, some of which
+# fire real Azure OpenAI calls and network fetches on collection/execution.
+testpaths = ["tests"]
 
 [tool.uv.workspace]
 members = [

--- a/backend/rendering/local_runner.py
+++ b/backend/rendering/local_runner.py
@@ -16,6 +16,29 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def _tts_subprocess_env() -> dict[str, str]:
+    """Environment for the render subprocess.
+
+    manim-voiceover's OpenAIService talks to the module-level OpenAI client,
+    which reads ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL``. When those aren't
+    already set but Azure OpenAI is configured, point them at Azure's
+    OpenAI-compatible endpoint so voiceover audio bills against Azure credits.
+    A pre-existing ``OPENAI_API_KEY`` (e.g. a real OpenAI key) is respected.
+    """
+    env = dict(os.environ)
+    if not env.get("OPENAI_API_KEY"):
+        endpoint = env.get("AZURE_OPENAI_ENDPOINT", "").rstrip("/")
+        key = env.get("AZURE_OPENAI_API_KEY", "")
+        if endpoint and key:
+            env["OPENAI_API_KEY"] = key
+            env["OPENAI_BASE_URL"] = f"{endpoint}/openai/v1/"
+            # Both OPENAI_* and AZURE_OPENAI_* are now present; the module-level
+            # OpenAI client refuses to guess between them. Pin it to the plain
+            # OpenAI code path — our base_url already targets the Azure endpoint.
+            env["OPENAI_API_TYPE"] = "openai"
+    return env
+
+
 def get_manim_executable() -> str:
     """Get Manim executable path from environment or venv, with system fallback."""
     env_val = os.getenv("MANIM_EXECUTABLE")
@@ -89,6 +112,8 @@ def _run_manim_subprocess(
                 text=True,
                 timeout=300,
                 cwd=tmpdir,
+                env=_tts_subprocess_env(),
+                stdin=subprocess.DEVNULL,
             )
             if result.stdout:
                 logger.debug(f"{tag} Manim stdout:\n{result.stdout}")

--- a/backend/tests/test_tts_config.py
+++ b/backend/tests/test_tts_config.py
@@ -1,0 +1,82 @@
+"""Unit tests for the Azure OpenAI TTS wiring in the voiceover pipeline.
+
+These cover the prompt-grounding snippets the generator injects into scenes and
+the render-subprocess env that routes manim-voiceover's OpenAIService at Azure.
+No network calls — pure config logic.
+"""
+
+import importlib
+
+import pytest
+
+from agents.manim_generator import ManimGenerator
+
+
+@pytest.fixture
+def generator():
+    return ManimGenerator()
+
+
+def test_openai_snippet_uses_configured_voice_and_model(generator):
+    snippet = generator._get_tts_setup_snippet("openai", "shimmer")
+    assert "OpenAIService(" in snippet
+    assert 'voice="shimmer"' in snippet
+    assert 'model="gpt-4o-mini-tts"' in snippet
+    # Bookmark transcription must stay off — it would pull in whisper at render.
+    assert "transcription_model=None" in snippet
+
+
+def test_openai_snippet_defaults_voice_when_blank(generator):
+    snippet = generator._get_tts_setup_snippet("openai", "")
+    assert 'voice="nova"' in snippet
+
+
+def test_gtts_snippet_is_the_free_fallback(generator):
+    snippet = generator._get_tts_setup_snippet("gtts", "")
+    assert "GTTSService(" in snippet
+    assert "OpenAIService" not in snippet
+
+
+def test_unknown_service_falls_back_to_gtts(generator):
+    assert "GTTSService(" in generator._get_tts_setup_snippet("banana", "")
+
+
+def test_import_line_matches_service(generator):
+    assert generator._get_tts_import("openai") == (
+        "from manim_voiceover.services.openai import OpenAIService"
+    )
+    assert generator._get_tts_import("gtts") == (
+        "from manim_voiceover.services.gtts import GTTSService"
+    )
+
+
+def test_render_env_routes_openai_to_azure(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-secret")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    from rendering import local_runner
+    importlib.reload(local_runner)
+    env = local_runner._tts_subprocess_env()
+
+    assert env["OPENAI_API_KEY"] == "azure-secret"
+    assert env["OPENAI_BASE_URL"] == "https://example.openai.azure.com/openai/v1/"
+    # Disambiguates the module-level client so it doesn't refuse Azure+OpenAI env.
+    assert env["OPENAI_API_TYPE"] == "openai"
+
+
+def test_render_env_respects_existing_openai_key(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "real-openai-key")
+
+    from rendering import local_runner
+    importlib.reload(local_runner)
+    env = local_runner._tts_subprocess_env()
+
+    # A real OpenAI key wins — we don't clobber it with the Azure endpoint.
+    assert env["OPENAI_API_KEY"] == "real-openai-key"
+    assert "OPENAI_BASE_URL" not in env or env["OPENAI_BASE_URL"] != (
+        "https://example.openai.azure.com/openai/v1/"
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -130,9 +130,10 @@ dependencies = [
     { name = "fastapi" },
     { name = "greenlet" },
     { name = "httpx" },
+    { name = "langfuse" },
     { name = "lxml" },
     { name = "manim" },
-    { name = "manim-voiceover", extra = ["gtts"] },
+    { name = "manim-voiceover", extra = ["gtts", "openai"] },
     { name = "modal" },
     { name = "openai" },
     { name = "pydantic" },
@@ -162,9 +163,10 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "langfuse", specifier = ">=3.0.0" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "manim", specifier = ">=0.18.0" },
-    { name = "manim-voiceover", extras = ["gtts"], specifier = ">=0.3.0" },
+    { name = "manim-voiceover", extras = ["gtts", "openai"], specifier = ">=0.3.0" },
     { name = "modal", specifier = ">=0.60.0" },
     { name = "openai", specifier = ">=1.60.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -273,6 +275,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751, upload-time = "2026-01-11T09:58:22.788Z" },
     { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355, upload-time = "2026-01-11T09:58:26.125Z" },
     { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047, upload-time = "2026-01-11T09:58:31.867Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -532,6 +543,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +731,25 @@ wheels = [
 ]
 
 [[package]]
+name = "langfuse"
+version = "4.14.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/5c/f316b31abda2aab6ebadf69de99ea39df8d22ca743ac429284c0c1e12921/langfuse-4.14.5.tar.gz", hash = "sha256:75ccf86523ee87945bf9a853d4de65195376f9be5bda7178dd3d138b66fc670f", size = 391893, upload-time = "2026-08-24T13:01:08.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d4/914a654c3af7792f02394d93e0cbb052927b3e1e727416c62740cc49490d/langfuse-4.14.5-py3-none-any.whl", hash = "sha256:29e710b9b06adb30094e69af0034d10a47193bfb9c233296fe96b235cf1a377c", size = 695395, upload-time = "2026-08-24T13:01:09.62Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -791,6 +833,9 @@ wheels = [
 [package.optional-dependencies]
 gtts = [
     { name = "gtts" },
+]
+openai = [
+    { name = "openai" },
 ]
 
 [[package]]
@@ -1005,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.17.0"
+version = "1.109.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1017,9 +1062,90 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/a2/677f22c4b487effb8a09439fb6134034b5f0a39ca27df8b95fac23a93720/openai-2.17.0.tar.gz", hash = "sha256:47224b74bd20f30c6b0a6a329505243cb2f26d5cf84d9f8d0825ff8b35e9c999", size = 631445, upload-time = "2026-02-05T16:27:40.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/97/284535aa75e6e84ab388248b5a323fc296b1f70530130dee37f7f4fbe856/openai-2.17.0-py3-none-any.whl", hash = "sha256:4f393fd886ca35e113aac7ff239bcd578b81d8f104f5aedc7d3693eb2af1d338", size = 1069524, upload-time = "2026-02-05T16:27:38.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -1735,6 +1861,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
     { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
     { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/6e/0f88a072483e76b881e3fdcd6b6ffb4a5791002514fe541e72b1b73c859a/wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f", size = 81960, upload-time = "2026-07-28T06:04:49.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ff/b7e2776e7c294075eb712cc9ef573d1b818f393006d09787262b8fc871c4/wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f", size = 82435, upload-time = "2026-07-28T06:04:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/343bb5d0f1f9669bc252a6073f085b4abf862511bd5c9c9eaec754341f1d/wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5", size = 170350, upload-time = "2026-07-28T06:04:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f8/13b79a392930bd0dd6b86cbfbfe1c40944110456e1dc6d809e5c46ece904/wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0", size = 170022, upload-time = "2026-07-28T06:04:53.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/4f1b6918f5290db959d6e0c07f77385d87cede29c39c9cf8f145e9c82954/wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609", size = 161043, upload-time = "2026-07-28T06:04:54.936Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/45d3cf74414780bdff6d0380467e003f6eb0f028b6c9403db868dbc7209c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8", size = 168576, upload-time = "2026-07-28T06:04:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/73/2fa58dd97f191c997755e2c6d569a68f0c433db4e4b36099bdd7227b6cac/wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae", size = 159140, upload-time = "2026-07-28T06:04:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a8/08a56e2000a8816d449dcbad8c8b081697acbbd490821ceca0f9d8e8d20c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3", size = 169263, upload-time = "2026-07-28T06:04:59.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/354e1725e35a73b2af4fa70a3e024c7a5d1bf1802dfb862dcb668aae0253/wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f", size = 78241, upload-time = "2026-07-28T06:05:00.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/34c87fa2174848dfee820322aaa318bab08913998ccecc8d2f57b4ad4639/wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838", size = 81113, upload-time = "2026-07-28T06:05:01.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/fcc9a530579e008c9478bb565a6cdfbfd33536660f069c8b91a6607c5050/wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579", size = 80182, upload-time = "2026-07-28T06:05:03.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/50/3864848b95b28ef73e17551fc8dccbff2628a834f52cf26a57f9c419fb83/wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944", size = 83921, upload-time = "2026-07-28T06:05:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/3d1921a60c3e8c71c540ff136e6a47a1fbccf7f671e818394889f7871d9c/wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360", size = 84412, upload-time = "2026-07-28T06:05:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/4a796ff7adb26ada6d4b758c94d47a38320b085e7099afc088efbbcdb006/wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614", size = 207168, upload-time = "2026-07-28T06:05:07.256Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3e/d7777776806c579b761bac2f91721dda9f04c7a1b380213c5935cc750ae6/wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a", size = 214351, upload-time = "2026-07-28T06:05:08.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/2d64d394df7bf181955b3bb562bf33c4492fb4be113f53071106d43ad8b5/wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687", size = 199020, upload-time = "2026-07-28T06:05:10.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/fb31d3db7d9834d265fb1a27a2adf0ddf51557c67458c97b22439ad6ae3d/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570", size = 209969, upload-time = "2026-07-28T06:05:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/8724b5da582e62070dc9bf4d8bf1972f317297eefd7ba1f2b5c6393ccf6c/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41", size = 196324, upload-time = "2026-07-28T06:05:13.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/3d9ef411149543016ee6bcf3af707f787cebd946527452b94bf122e9b7b4/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4", size = 202610, upload-time = "2026-07-28T06:05:15.048Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9b/4fc042ceb757866dd4a5fc057b3b736f2b360d3703ce9f830d83dc9226e0/wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3", size = 79178, upload-time = "2026-07-28T06:05:16.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/b94878f8eed809ca042685276bcea9f24e8c2ca7c9653bb80bbb920a68a5/wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98", size = 82634, upload-time = "2026-07-28T06:05:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/663e1de5332a71685a729754312d327d4cada767c36e1c5a2db4c8de49e6/wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6", size = 81387, upload-time = "2026-07-28T06:05:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on top of #15 (`azure-openai-provider`) so the diff is scoped to just this work.

## Why
"I want voice to also work" — voiceovers were on free gTTS (robotic, and an extra network call per narration block). This switches narration to **Azure OpenAI `gpt-4o-mini-tts`**, billed against the same Azure credits as the rest of the pipeline. Also wires up **Langfuse** tracing (we have an account) so we can finally see token usage, cost, and latency per paper.

## Voiceover
- Default TTS `gtts → openai` (Azure), routed via the OpenAI-compatible endpoint **inside the render subprocess** (`rendering/local_runner._tts_subprocess_env`). Reuses `AZURE_OPENAI_*` — no new key. Sets `OPENAI_API_TYPE=openai` to disambiguate the module client, and adds `stdin=DEVNULL` (fixes a latent render-hang).
- Generator injects the exact `import` + `set_speech_service(...)` line into scenes; voiceover few-shot examples switched to `OpenAIService` so the model mirrors the right service.
- `VOICEOVER_TTS_SERVICE` / `VOICEOVER_VOICE_NAME` / `VOICEOVER_TTS_MODEL` are env-configurable; `gtts` stays as a fallback.

## Observability (Langfuse)
- Every LLM call traced via the `langfuse.openai` drop-in when `LANGFUSE_*` is set (model, tokens incl. reasoning, cost, latency); plain SDK otherwise — zero overhead when unconfigured.
- Span tree: `process-paper` (session = job_id, tagged, arxiv_id in metadata) → `generate-visualizations` → `generate-single-visualization` → per-agent generations. Flush on job end.

## Tooling
- `pytest testpaths = ["tests"]` so plain `pytest` can't collect the `tools/` scripts that fire real Azure calls.
- New `tests/test_tts_config.py` covering snippet/import selection and Azure env routing.

## Verification
- [x] Rendered a `VoiceoverScene` end-to-end through the real env path → MP4 with **h264 video + AAC audio** (Azure TTS narration muxed in).
- [x] Smoke trace confirmed in Langfuse: correct hierarchy, `model=gpt-5-mini-2025-08-07`, token usage, auto-computed cost, session grouping. Audited against Langfuse's current best-practices doc.
- [x] `pytest tests/` — 14 passed.

## Deploy note
Production activation needs an image rebuild (adds `langfuse`) + these container env vars: `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` (as secrets), `LANGFUSE_HOST=https://us.cloud.langfuse.com`, `LANGFUSE_TRACING_ENVIRONMENT=production`. TTS needs **no** new env — it auto-routes from the existing `AZURE_OPENAI_*`. Not done in this PR.