### PR TITLE
fix(security): gate POST /api/render (unauthenticated RCE)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -4,6 +4,7 @@ FastAPI routes for the ArXiviz API.
 Now using SQLite database and local Manim rendering.
 """
 
+import hmac
 import logging
 import os
 import uuid
@@ -52,7 +53,9 @@ def _authorize_render(secret: str | None) -> None:
     if os.getenv("ENVIRONMENT", "development").lower() != "production":
         return
     expected = os.getenv("RENDER_API_SECRET")
-    if expected and secret == expected:
+    # Timing-safe comparison; the explicit None guard keeps compare_digest from
+    # being handed a non-str. No configured secret in prod = fully disabled.
+    if expected and secret is not None and hmac.compare_digest(secret, expected):
         return
     raise HTTPException(status_code=404, detail="Not found")
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -4,9 +4,10 @@ FastAPI routes for the ArXiviz API.
 Now using SQLite database and local Manim rendering.
 """
 
+import logging
 import os
 import uuid
-from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
+from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, Header
 from fastapi.responses import FileResponse, RedirectResponse
 from datetime import datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +35,26 @@ from db import queries
 from rendering import process_visualization, get_video_path, get_video_url, extract_scene_name
 from jobs import process_paper_job
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api")
+
+
+def _authorize_render(secret: str | None) -> None:
+    """Guard the raw-code render endpoint.
+
+    ``POST /api/render`` executes caller-supplied Python via Manim, so it must
+    never be openly reachable in production. Outside production it stays open for
+    local development; in production it is disabled entirely unless RENDER_API_SECRET
+    is configured AND the caller presents it. We return 404 (not 403) so the
+    endpoint's existence isn't advertised.
+    """
+    if os.getenv("ENVIRONMENT", "development").lower() != "production":
+        return
+    expected = os.getenv("RENDER_API_SECRET")
+    if expected and secret == expected:
+        return
+    raise HTTPException(status_code=404, detail="Not found")
 
 
 # === Endpoints ===
@@ -242,13 +262,19 @@ async def get_video(video_id: str):
 
 
 @router.post("/render", response_model=RenderResponse)
-async def render_manim(request: RenderRequest):
+async def render_manim(
+    request: RenderRequest,
+    x_render_secret: str | None = Header(default=None),
+):
     """
     Test endpoint to render Manim code directly.
 
-    This is for testing/development purposes.
-    In production, rendering happens as part of the paper processing pipeline.
+    This is for testing/development purposes only — it executes caller-supplied
+    Python. It is disabled in production unless RENDER_API_SECRET is set and the
+    caller presents it via the X-Render-Secret header. In production, rendering
+    happens as part of the paper processing pipeline.
     """
+    _authorize_render(x_render_secret)
     try:
         # Generate a unique video ID
         video_id = f"test_{uuid.uuid4().hex[:8]}"
@@ -275,10 +301,11 @@ async def render_manim(request: RenderRequest):
             status_code=500,
             detail=f"Rendering failed: {str(e)}"
         )
-    except Exception as e:
+    except Exception:
+        logger.exception("Unexpected error while rendering Manim code")
         raise HTTPException(
             status_code=500,
-            detail=f"Unexpected error: {str(e)}"
+            detail="Internal error while rendering. See server logs.",
         )
 
 

--- a/backend/tests/test_render_auth.py
+++ b/backend/tests/test_render_auth.py
@@ -1,0 +1,52 @@
+"""Tests for the POST /api/render authorization guard.
+
+The endpoint executes caller-supplied Python, so it must be unreachable in
+production without an explicit shared secret, while staying open in dev.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import _authorize_render
+
+
+def test_dev_allows_render_without_secret(monkeypatch):
+    monkeypatch.delenv("ENVIRONMENT", raising=False)  # defaults to development
+    _authorize_render(None)  # should not raise
+
+
+def test_explicit_development_allows_render(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    _authorize_render(None)
+
+
+def test_production_blocks_render_without_secret(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("RENDER_API_SECRET", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        _authorize_render(None)
+    # 404, not 403 — don't advertise the endpoint's existence.
+    assert exc.value.status_code == 404
+
+
+def test_production_blocks_render_with_wrong_secret(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("RENDER_API_SECRET", "correct-horse")
+    with pytest.raises(HTTPException) as exc:
+        _authorize_render("wrong")
+    assert exc.value.status_code == 404
+
+
+def test_production_allows_render_with_matching_secret(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("RENDER_API_SECRET", "correct-horse")
+    _authorize_render("correct-horse")  # should not raise
+
+
+def test_production_without_secret_configured_stays_closed(monkeypatch):
+    # If no secret is configured in prod, the endpoint is fully disabled even
+    # if a caller sends some header value.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("RENDER_API_SECRET", raising=False)
+    with pytest.raises(HTTPException):
+        _authorize_render("anything")

--- a/backend/tests/test_render_auth.py
+++ b/backend/tests/test_render_auth.py
@@ -43,6 +43,16 @@ def test_production_allows_render_with_matching_secret(monkeypatch):
     _authorize_render("correct-horse")  # should not raise
 
 
+def test_production_rejects_near_miss_secret(monkeypatch):
+    # Exercises the timing-safe hmac.compare_digest path + the None guard.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("RENDER_API_SECRET", "correct-horse")
+    with pytest.raises(HTTPException):
+        _authorize_render("correct-hors")  # one char short
+    with pytest.raises(HTTPException):
+        _authorize_render(None)
+
+
 def test_production_without_secret_configured_stays_closed(monkeypatch):
     # If no secret is configured in prod, the endpoint is fully disabled even
     # if a caller sends some header value.


### PR DESCRIPTION
Stacked on #16. First of the verified-audit hardening fixes.

## Problem
`POST /api/render` (`backend/api/routes.py`) takes a raw `code` string and executes it via Manim — no auth, no gate. CORS does not help (it only restricts browsers; `curl` bypasses it). This is remote code execution on the container that holds R2 and Postgres credentials in env. Highest-severity item in the audit, verified by hand.

## Fix
- New `_authorize_render()` guard: in production the endpoint is disabled unless `RENDER_API_SECRET` is configured **and** the caller sends a matching `X-Render-Secret` header. Returns **404** (not 403) so the endpoint isn't advertised. Stays open in dev/test for local iteration.
- Catch-all handler now logs the full traceback and returns a generic message instead of echoing `str(e)` to the client (was another info leak).

## Tests
`tests/test_render_auth.py`: dev-open, prod-closed-without-secret, wrong-secret, matching-secret, and "no secret configured stays closed". Full suite: **20 passed**.

## Deploy note
To keep using the endpoint in production, set `RENDER_API_SECRET` as a container secret and send `X-Render-Secret`. Otherwise it's simply off in prod (the pipeline's own rendering is unaffected — it doesn't go through this route).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added authorization for raw rendering requests in production using a configured secret.
  * Unauthorized or misconfigured requests are concealed with a not-found response.
* **Bug Fixes**
  * Rendering failures now return a generic error without exposing internal details.
  * Added server-side logging to support troubleshooting.
* **Tests**
  * Added coverage for authorized, unauthorized, development, and misconfigured production scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->