### PR TITLE
fix: pipeline correctness (async judge, per-task DB sessions, stale feedback)

### DIFF
--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -358,6 +358,16 @@ async def generate_single_visualization(
                     target_duration_seconds=VOICEOVER_TARGET_DURATION_SECONDS,
                 )
 
+            # Clear the previous attempt's gate results now that this attempt's
+            # regeneration feedback has been built from them. Otherwise a later
+            # attempt that fails early (e.g. at stage 1) would carry forward a
+            # stale spatial/voice/render result and feed the model issues that
+            # no longer exist.
+            validation = None
+            spatial_result = None
+            voice_result = None
+            render_result = None
+
             # Stage 1: code validation
             logger.info("    [1/4] CodeValidator: Checking syntax & structure...")
             validation = validator.validate(code_result.code)
@@ -397,7 +407,13 @@ async def generate_single_visualization(
                 code_result.narration_beats = beats
                 code_result.voiceover_enabled = True
 
-                voice_result = voiceover_script_validator.validate(
+                # Run the (synchronous, LLM-backed) judge in a worker thread so
+                # it doesn't block the event loop. Without this, the sync judge
+                # call serializes all 5 gathered visualization tasks at this gate
+                # and stalls /api/status polling. Running off-thread also avoids
+                # the nested-asyncio.run failure on the Dedalus provider path.
+                voice_result = await asyncio.to_thread(
+                    voiceover_script_validator.validate,
                     generated_code=code_result,
                     plan=plan,
                     candidate=candidate,

--- a/backend/jobs/worker.py
+++ b/backend/jobs/worker.py
@@ -251,47 +251,43 @@ async def _process_paper_job_impl(job_id: str, arxiv_id: str):
             async def _render_one(viz: dict, index: int):
                 nonlocal completed_count
                 async with render_semaphore:
+                    status = "complete"
+                    video_url: str | None = None
+                    error: str | None = None
                     try:
                         logger.info(f"Starting render: {viz['id']}")
                         video_url = await process_visualization(
                             viz_id=viz["id"],
                             manim_code=viz["manim_code"],
-                            quality="low_quality"
+                            quality="low_quality",
                         )
                         logger.info(f"✓ Successfully rendered {viz['id']}")
-                        await queries.update_visualization_status(
-                            db, viz["id"],
-                            status="complete",
-                            video_url=video_url
-                        )
-                        progress_bar.update()
-
-                        # Update job progress incrementally (75% to 95%)
-                        async with progress_lock:
-                            completed_count += 1
-                            render_progress = 0.75 + (0.20 * (completed_count / len(viz_records)))
-                            await queries.update_job_status(
-                                db, job_id,
-                                progress=render_progress,
-                                sections_completed=completed_count
-                            )
                     except Exception as e:
-                        logger.error(f"✗ Failed to render {viz['id']}: {str(e)}")
-                        await queries.update_visualization_status(
-                            db, viz["id"],
-                            status="failed",
-                            error=str(e)
-                        )
-                        progress_bar.update()
+                        status = "failed"
+                        error = str(e)
+                        logger.error(f"✗ Failed to render {viz['id']}: {error}")
 
-                        # Still update progress even on failure
+                    # Each concurrent render commits through its OWN session.
+                    # A single AsyncSession is not safe to share across tasks
+                    # running under asyncio.gather — interleaved operations raise
+                    # InterfaceError / corrupt session state. The progress_lock
+                    # serializes the shared counter, progress bar, and job-row
+                    # write so they stay consistent.
+                    async with async_session_maker() as task_db:
+                        await queries.update_visualization_status(
+                            task_db, viz["id"],
+                            status=status,
+                            video_url=video_url,
+                            error=error,
+                        )
                         async with progress_lock:
                             completed_count += 1
+                            progress_bar.update()
                             render_progress = 0.75 + (0.20 * (completed_count / len(viz_records)))
                             await queries.update_job_status(
-                                db, job_id,
+                                task_db, job_id,
                                 progress=render_progress,
-                                sections_completed=completed_count
+                                sections_completed=completed_count,
                             )
 
             logger.info(f"Rendering {len(viz_records)} videos concurrently (max 3 parallel)...")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test configuration.
+
+Keeps the test suite offline: disables Langfuse tracing so decorated pipeline
+functions don't try to export spans to the network during unit tests. (A fuller
+socket-blocking fixture is tracked in the backlog under Testing & CI.)
+"""
+
+import os
+
+os.environ["LANGFUSE_TRACING_ENABLED"] = "false"

--- a/backend/tests/test_pipeline_retry_feedback.py
+++ b/backend/tests/test_pipeline_retry_feedback.py
@@ -1,0 +1,144 @@
+"""Regression test for stale retry feedback in generate_single_visualization.
+
+Bug: per-stage results (validation / spatial / voice / render) were initialized
+once before the retry loop and never reset per attempt. If a later attempt failed
+at an early gate, the regeneration prompt for the *next* attempt still carried a
+gate result from an earlier attempt — feeding the model issues that no longer
+applied. The fix resets all four each attempt after feedback is built.
+
+This test drives the real generate_single_visualization with fakes so that:
+  attempt 0: stage 1 passes, stage 2 (spatial) FAILS  -> spatial issue recorded
+  attempt 1: feedback carries the spatial issue; stage 1 FAILS (syntax)
+  attempt 2: feedback must carry ONLY the syntax issue, NOT the stale spatial one
+"""
+
+import asyncio
+
+from agents import pipeline
+from models.generation import (
+    GeneratedCode,
+    Scene,
+    ValidatorOutput,
+    VisualizationCandidate,
+    VisualizationPlan,
+    VisualizationType,
+)
+from models.spatial import SpatialValidatorOutput
+
+SPATIAL_MARKER = "SPATIAL ISSUES DETECTED"
+SYNTAX_MARKER = "SyntaxError: unexpected token"
+
+
+def _candidate() -> VisualizationCandidate:
+    return VisualizationCandidate(
+        section_id="section-1",
+        concept_name="Scaled Dot-Product Attention",
+        concept_description="Query-key similarity, softmax, value aggregation.",
+        visualization_type=VisualizationType.DATA_FLOW,
+        priority=5,
+        context="Attention(Q,K,V)=softmax(QK^T/sqrt(d_k))V",
+    )
+
+
+def _plan() -> VisualizationPlan:
+    return VisualizationPlan(
+        concept_name="Scaled Dot-Product Attention",
+        visualization_type=VisualizationType.DATA_FLOW,
+        duration_seconds=30,
+        scenes=[Scene(order=1, description="beat", duration_seconds=10, transitions="Write", elements=["Text"])],
+        narration_points=[],
+    )
+
+
+def _code(tag: str) -> GeneratedCode:
+    return GeneratedCode(
+        code=f"# {tag}\nfrom manim import *\n",
+        scene_class_name="Viz",
+        dependencies=["manim"],
+        voiceover_enabled=False,
+        narration_lines=[],
+        narration_beats=[],
+    )
+
+
+class _FakePaper:
+    def get_section_by_id(self, _sid):
+        return None
+
+    def get_context(self):
+        return "context"
+
+
+class _FakePlanner:
+    async def run(self, candidate, full_section_content, paper_context):
+        return _plan()
+
+
+class _FakeGenerator:
+    def __init__(self):
+        self.feedback_messages: list[str] = []
+
+    async def run(self, **_kwargs):
+        return _code("attempt-0")
+
+    async def run_with_feedback(self, plan, previous_code, error_message, **_kwargs):
+        self.feedback_messages.append(error_message)
+        return _code(f"attempt-{len(self.feedback_messages)}")
+
+
+class _FakeValidator:
+    """attempt 0 valid, attempt 1 invalid (syntax), rest valid."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def validate(self, code):
+        self.calls += 1
+        if self.calls == 2:
+            return ValidatorOutput(
+                is_valid=False,
+                code=code,
+                issues_found=[SYNTAX_MARKER],
+                needs_regeneration=True,
+            )
+        return ValidatorOutput(is_valid=True, code=code, issues_found=[], needs_regeneration=False)
+
+
+class _FakeSpatial:
+    """Always reports a spatial failure when reached (only attempt 0 reaches it)."""
+
+    def validate(self, code):
+        return SpatialValidatorOutput(
+            has_spatial_issues=True,
+            needs_regeneration=True,
+            suggestions=["Element off-screen at x=9"],
+        )
+
+
+def test_retry_feedback_drops_stale_gate_results(monkeypatch):
+    # Keep the loop in a simple 2-gate configuration: no voiceover, no render test.
+    monkeypatch.setattr(pipeline, "ENABLE_VOICEOVER", False)
+    monkeypatch.setattr(pipeline, "ENABLE_SPATIAL_VALIDATION", True)
+
+    generator = _FakeGenerator()
+
+    asyncio.run(
+        pipeline.generate_single_visualization(
+            candidate=_candidate(),
+            paper=_FakePaper(),
+            planner=_FakePlanner(),
+            generator=generator,
+            validator=_FakeValidator(),
+            spatial_validator=_FakeSpatial(),
+            voiceover_script_validator=None,
+            render_tester=None,
+        )
+    )
+
+    # feedback_messages[0] -> attempt 1 (built from attempt 0: spatial failure)
+    assert SPATIAL_MARKER in generator.feedback_messages[0]
+
+    # feedback_messages[1] -> attempt 2 (built from attempt 1: syntax failure only).
+    # The stale spatial result from attempt 0 must NOT leak in.
+    assert SYNTAX_MARKER in generator.feedback_messages[1]
+    assert SPATIAL_MARKER not in generator.feedback_messages[1]


### PR DESCRIPTION
Stacked on #17. The three verified-audit correctness fixes from the "ship this week" batch (adversarially confirmed against source earlier).

## A3 — Async voiceover judge (event-loop unblock)
The stage [3/4] voiceover-script judge made a **synchronous** LLM call from inside coroutines running under `asyncio.gather`, freezing the event loop: it serialized all 5 "concurrent" visualization tasks and stalled `/api/status` polling (up to 25 blocking calls/paper). Now wrapped in `asyncio.to_thread`, so it runs off-thread. Bonus: this also fixes the Dedalus-path crash (nested `asyncio.run` in a running loop). No signature change → validator unit tests untouched.

## A2 — Per-task DB sessions (concurrency corruption)
The 3 concurrent `_render_one` tasks shared one `AsyncSession` (SQLAlchemy documents this as unsafe → intermittent `InterfaceError: another operation is in progress`). Each task now commits through its own `async_session_maker()` session. `progress_bar.update()` moved inside the lock so the bar and `sections_completed` stay in sync; success/failure branches deduplicated.

## A4 — Stale retry feedback
`validation`/`spatial_result`/`voice_result`/`render_result` were initialized once before the retry loop and never reset, so an attempt that failed at an early gate carried a *previous* attempt's gate result into the next regeneration prompt — feeding the model issues that no longer applied. Now reset each attempt after feedback is built. **Regression test** drives the real retry loop and asserts a stale spatial issue doesn't leak into a later syntax-only feedback message.

## Tests
`tests/test_pipeline_retry_feedback.py` (new) + `tests/conftest.py` (disables Langfuse export to keep the suite offline). Full suite: **22 passed**.

Deferred to backlog: integration-level concurrency assertions for A2/A3 (Testing & CI · D3), and A5 "don't report completed when every render failed" (pairs with frontend partial-failure UX).