### PR TITLE
ci: add GitHub Actions pipeline (backend tests, frontend build, image build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+    env:
+      # Dummy values: BaseAgent resolves a provider at construction, and the
+      # suite must never reach a real API. tests/conftest.py additionally
+      # disables Langfuse export.
+      LLM_PROVIDER: azure
+      AZURE_OPENAI_ENDPOINT: https://example.openai.azure.com
+      AZURE_OPENAI_API_KEY: dummy-key-for-tests
+      AZURE_OPENAI_DEPLOYMENT: gpt-5-mini
+      ENVIRONMENT: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      # --frozen: the lockfile must be current. This is the same guarantee the
+      # Dockerfile relies on, so a stale uv.lock fails CI before it fails a build.
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  frontend:
+    name: Frontend typecheck, lint & build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      # Non-blocking for now: main carries 12 pre-existing lint errors (impure
+      # calls during render, setState-in-effect). Surfaced on every run so they
+      # stay visible; flip to a hard gate once the existing violations are fixed.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Build
+        run: npm run build
+
+  # The image carries texlive and takes several minutes, so gate it on the build
+  # inputs actually changing. It catches the class of failure that broke prod
+  # before: a dependency/lockfile change that passes tests but can't build.
+  changes:
+    name: Detect build-input changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'backend/Dockerfile'
+              - 'backend/pyproject.toml'
+              - 'backend/uv.lock'
+              - '.github/workflows/ci.yml'
+
+  docker:
+    name: Backend image builds
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docker == 'true' || github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # manimpango (via manim) builds against system pango/cairo headers, which
+      # a bare runner lacks. Mirrors the Dockerfile's system deps, minus texlive
+      # and ffmpeg — the unit suite never renders.
+      - name: Install system build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libcairo2-dev libpango1.0-dev
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
Backlog **D1** — the foundational testing/CI item. The repo had **no `.github/` at all**, so nothing guarded any of the merges made today.

## Jobs
| Job | What | Gate? |
|---|---|---|
| **backend** | `uv sync --extra dev --frozen` + `pytest` on Python **3.11 and 3.13** | ✅ blocking |
| **frontend** | `npm ci`, `tsc --noEmit`, `lint`, `next build` | ✅ blocking (except lint) |
| **docker** | Builds the backend image, path-filtered | ✅ blocking when triggered |

## Notes on the choices
- **`--frozen` is deliberate.** A stale `uv.lock` now fails CI *before* it fails a Docker build — the same guarantee the Dockerfile relies on since we removed its silent pip fallback.
- **Dummy Azure env vars** in the backend job: `BaseAgent` resolves a provider at construction, so the suite can't even import without them. `tests/conftest.py` already disables Langfuse export, so nothing reaches the network.
- **Lint is `continue-on-error`.** `main` carries **12 pre-existing violations** (9 impure-call-during-render, 3 setState-in-effect) unrelated to any recent change. A CI that fails red on day one gets ignored, so lint is surfaced-but-not-blocking; flip it to a gate once those are fixed (tracked in the roadmap's code-health section).
- **Docker job is path-filtered** (`Dockerfile` / `pyproject.toml` / `uv.lock`, plus always on `main`) because the texlive image takes minutes. It catches precisely the failure class that broke production before: a dependency change that passes tests but can't build.

## Verified locally before committing
- `uv sync --extra dev --frozen` → clean (lockfile current)
- `pytest tests/` with the exact CI env → **26 passed**
- `npx tsc --noEmit` after a fresh `npm ci` → **clean** (it fails on a stale `node_modules`, which is why the job runs `npm ci` first)
- `npm run build` → succeeds
- Workflow YAML parses; job graph and conditions confirmed