### PR TITLE
feat: add Explore gallery of processed papers

### DIFF
--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { MosaicBackground } from "@/components/ui/mosaic-background";
+import { ShardField } from "@/components/ui/glass-shard";
+import { GlassCard } from "@/components/ui/glass-card";
+import { CardSkeleton } from "@/components/LoadingState";
+import { listPapers } from "@/lib/api";
+import type { PaperSummary } from "@/lib/types";
+
+type ExploreState =
+  | { type: "loading" }
+  | { type: "empty" }
+  | { type: "ready"; papers: PaperSummary[] }
+  | { type: "error"; message: string };
+
+function formatAuthors(authors: string[]): string {
+  if (!authors || authors.length === 0) return "Unknown authors";
+  if (authors.length <= 3) return authors.join(", ");
+  return `${authors.slice(0, 3).join(", ")}, et al.`;
+}
+
+function formatDate(iso: string): string | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function ExplorePage() {
+  const [state, setState] = useState<ExploreState>({ type: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ type: "loading" });
+    try {
+      const papers = await listPapers();
+      if (papers.length === 0) {
+        setState({ type: "empty" });
+        return;
+      }
+      setState({ type: "ready", papers });
+    } catch (err) {
+      console.error("Error loading papers:", err);
+      setState({
+        type: "error",
+        message: err instanceof Error ? err.message : "Failed to load papers",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <main className="min-h-dvh relative overflow-hidden bg-black">
+      {/* Mosaic background + floating shards — same ambient treatment as home */}
+      <MosaicBackground />
+      <ShardField />
+
+      {/* Back to home — floating glass pill, top-left (matches reader) */}
+      <motion.div
+        initial={{ opacity: 0, x: -10 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.4 }}
+        className="fixed top-5 left-5 z-50"
+      >
+        <Link
+          href="/"
+          className="group inline-flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-xl px-4 py-2.5 text-sm text-white/50 border border-white/[0.08] transition-all hover:bg-black/80 hover:text-white/80 hover:border-white/[0.15] shadow-lg shadow-black/30"
+        >
+          <span className="transition-transform group-hover:-translate-x-0.5">&larr;</span>
+          <span className="hidden sm:inline">Back</span>
+        </Link>
+      </motion.div>
+
+      <div className="relative z-10 mx-auto w-full max-w-6xl px-6 pb-24 pt-24 sm:pt-28">
+        {/* Header */}
+        <motion.header
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mb-12 text-center"
+        >
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/[0.04] border border-white/[0.08]">
+            <span className="w-2 h-2 rounded-full bg-white/30" />
+            <span className="text-sm text-white/50">The Library</span>
+          </div>
+          <h1 className="mt-6 text-3xl sm:text-4xl lg:text-5xl font-medium text-white/90 leading-tight tracking-tight">
+            Explore Visualized Papers
+          </h1>
+          <p className="mt-4 text-white/40 max-w-xl mx-auto leading-relaxed font-light">
+            Browse papers that have already been turned into{" "}
+            <span className="text-white/60 font-medium">visual</span> scrollytelling
+            explanations. Pick one to dive in.
+          </p>
+        </motion.header>
+
+        {/* Content states */}
+        {state.type === "loading" && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <CardSkeleton key={i} />
+            ))}
+          </div>
+        )}
+
+        {state.type === "error" && (
+          <ExploreMessage
+            title="Couldn't load the library"
+            body={state.message}
+            action={
+              <button
+                onClick={load}
+                className="rounded-2xl bg-white/[0.06] px-8 py-4 text-sm font-medium text-white/80 border border-white/[0.10] transition hover:bg-white/[0.10]"
+              >
+                Try Again
+              </button>
+            }
+            accent="error"
+          />
+        )}
+
+        {state.type === "empty" && (
+          <ExploreMessage
+            title="No papers yet"
+            body="Nothing has been visualized so far. Be the first — paste an arXiv paper and watch it come to life."
+            action={
+              <Link
+                href="/"
+                className="rounded-2xl bg-white/[0.08] hover:bg-white/[0.12] px-8 py-4 text-sm font-medium text-white border border-white/[0.15] hover:border-white/[0.25] transition-all"
+              >
+                Visualize a paper
+              </Link>
+            }
+          />
+        )}
+
+        {state.type === "ready" && (
+          <>
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.4 }}
+              className="mb-6 text-sm text-white/30"
+            >
+              {state.papers.length}{" "}
+              {state.papers.length === 1 ? "paper" : "papers"} visualized
+            </motion.p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+              {state.papers.map((paper, i) => (
+                <PaperCard key={paper.paper_id} paper={paper} index={i} />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function PaperCard({ paper, index }: { paper: PaperSummary; index: number }) {
+  const date = formatDate(paper.processed_at);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: Math.min(index * 0.05, 0.4), ease: "easeOut" }}
+    >
+      <Link
+        href={`/abs/${encodeURIComponent(paper.paper_id)}`}
+        className="block h-full"
+      >
+        <GlassCard animate={false} className="h-full p-6 flex flex-col">
+          {/* Top row: viz badge + arxiv id */}
+          <div className="flex items-center justify-between gap-3">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] border border-white/[0.08] px-3 py-1 text-xs text-white/50">
+              <span className="text-white/40">&#9671;</span>
+              {paper.visualization_count}{" "}
+              {paper.visualization_count === 1 ? "visual" : "visuals"}
+            </span>
+            <span className="font-mono text-xs text-white/25">{paper.paper_id}</span>
+          </div>
+
+          {/* Title */}
+          <h2 className="mt-5 text-lg font-medium text-white/90 leading-snug tracking-tight line-clamp-3 transition-colors group-hover:text-white">
+            {paper.title}
+          </h2>
+
+          {/* Authors */}
+          <p className="mt-3 text-sm text-white/40 line-clamp-2">
+            {formatAuthors(paper.authors)}
+          </p>
+
+          {/* Footer */}
+          <div className="mt-auto pt-6 flex items-center justify-between text-xs">
+            {date ? (
+              <span className="text-white/25">{date}</span>
+            ) : (
+              <span />
+            )}
+            <span className="inline-flex items-center gap-1 text-white/40 transition-colors group-hover:text-white/70">
+              Read
+              <span className="transition-transform group-hover:translate-x-0.5">&rarr;</span>
+            </span>
+          </div>
+        </GlassCard>
+      </Link>
+    </motion.div>
+  );
+}
+
+function ExploreMessage({
+  title,
+  body,
+  action,
+  accent,
+}: {
+  title: string;
+  body: string;
+  action?: React.ReactNode;
+  accent?: "error";
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="mx-auto max-w-lg text-center py-16"
+    >
+      <div className="rounded-2xl bg-white/[0.04] border border-white/[0.08] p-8 backdrop-blur-sm">
+        <h2
+          className={`text-2xl font-medium ${
+            accent === "error" ? "text-[#f27066]" : "text-white/90"
+          }`}
+        >
+          {title}
+        </h2>
+        <p className="mt-4 text-white/40 leading-relaxed">{body}</p>
+        {action && <div className="mt-8 flex justify-center">{action}</div>}
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-vanish-input";
@@ -57,6 +58,23 @@ export default function Home() {
 
       {/* Floating glass shards */}
       <ShardField />
+
+      {/* Explore the library — floating glass pill, top-right */}
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+        className="fixed top-5 right-5 z-20"
+      >
+        <Link
+          href="/explore"
+          className="group inline-flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-xl px-4 py-2.5 text-sm text-white/50 border border-white/[0.08] transition-all hover:bg-black/80 hover:text-white/80 hover:border-white/[0.15] shadow-lg shadow-black/30"
+        >
+          <span className="text-white/40 select-none">&#9671;</span>
+          <span>Explore</span>
+          <span className="transition-transform group-hover:translate-x-0.5">&rarr;</span>
+        </Link>
+      </motion.div>
 
       <div className="relative z-10 mx-auto w-full max-w-6xl px-6">
         {/* ── First viewport: Logo (clear) + search bar below ── */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,7 +5,7 @@
  */
 
 import { DEMO_PAPER_IDS, getDemoPaper, MOCK_PAPER, MOCK_STATUS } from "./mock-data";
-import type { Paper, ProcessingStatus, Section } from "./types";
+import type { Paper, PaperSummary, ProcessingStatus, Section } from "./types";
 
 // Toggle between mock and real API
 const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
@@ -71,6 +71,19 @@ export interface PaperResponse {
   sections: SectionResponse[];
   visualizations: VisualizationResponse[];
   processed_at: string;
+}
+
+export interface PaperSummaryResponse {
+  paper_id: string;
+  title: string;
+  authors: string[];
+  visualization_count: number;
+  processed_at: string;
+}
+
+export interface PaperListResponse {
+  papers: PaperSummaryResponse[];
+  total: number;
 }
 
 export interface HealthResponse {
@@ -222,6 +235,45 @@ export async function getPaper(arxivId: string): Promise<Paper | null> {
     html_url: data.html_url,
     sections,
   };
+}
+
+/**
+ * List all processed papers as lightweight summaries for the Explore gallery.
+ * Calls GET /api/papers.
+ */
+export async function listPapers(): Promise<PaperSummary[]> {
+  if (USE_MOCK) {
+    await new Promise((r) => setTimeout(r, 400));
+    return Array.from(DEMO_PAPER_IDS)
+      .map((id) => getDemoPaper(id))
+      .filter((p): p is Paper => p !== null)
+      .map((p) => ({
+        paper_id: p.paper_id,
+        title: p.title,
+        authors: p.authors,
+        visualization_count:
+          p.sections.filter((s) => s.video_url).length || p.sections.length,
+        processed_at: new Date().toISOString(),
+      }));
+  }
+
+  const res = await fetch(`${API_BASE}/api/papers`);
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Failed to list papers: ${res.status} - ${errorText}`);
+  }
+
+  const data: PaperListResponse = await res.json();
+
+  // Map backend summaries (paper_id) to the frontend PaperSummary type.
+  return data.papers.map((p) => ({
+    paper_id: p.paper_id,
+    title: p.title,
+    authors: p.authors,
+    visualization_count: p.visualization_count,
+    processed_at: p.processed_at,
+  }));
 }
 
 /**

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -18,6 +18,14 @@ export type Paper = {
   sections: Section[];
 };
 
+export type PaperSummary = {
+  paper_id: string; // e.g. "1706.03762"
+  title: string;
+  authors: string[];
+  visualization_count: number;
+  processed_at: string; // ISO 8601 datetime string
+};
+
 export type Section = {
   id: string;
   title: string;


### PR DESCRIPTION
Backlog **B1** — the highest impact-per-effort feature on the [roadmap](https://claude.ai/code/artifact/82284ddc-4c3b-419a-a889-d8328525242d).

## Why
`GET /api/papers` has existed all along and **nothing consumed it**. Every processed paper was reachable only if you already knew its arXiv id, so the site opened as a blank prompt instead of a library — and all that spent LLM + render compute was invisible. This is a frontend-only change; **no backend work required**.

## What
- **`lib/api.ts`** — `listPapers()` calling `GET /api/papers`. Maps the backend's `paper_id` field deliberately (not `id` — that drift is a known frontend bug documented in the audit), so this doesn't inherit it.
- **`lib/types.ts`** — `PaperSummary` matching the backend schema.
- **`app/explore/page.tsx`** — responsive card grid (1/2/3 col) built from the site's existing primitives: glass cards on the mosaic/shard background, visualization-count badge, arXiv id, 3-line-clamped title, truncated authors, processed date, and a "Read →" affordance. Whole card links to `/abs/{paper_id}`. Handles loading (skeletons), empty ("no papers yet" + CTA), and error (message + retry).
- **`app/page.tsx`** — an unobtrusive top-right "Explore" pill.

## Verification (against the live production backend, not mocks)
- **25 real papers render** with correct titles, authors, arXiv ids, and visual counts
- **Card click → `/abs/2608.23565`** → reader loads the correct paper (ReWorld) with its real abstract
- `npx tsc --noEmit` → clean; `npm run build` → succeeds with `/explore` registered as a static route

The one console error observed (`getImageData` on a 0-width canvas) is **pre-existing** in `components/ui/mosaic-background.tsx`, untouched by this PR.

## Notes
The gallery's fetch-on-mount effect trips the same `react-hooks/set-state-in-effect` lint rule as the existing reader page — matching the repo's established idiom rather than adding an inconsistent `eslint-disable`. That rule family is already tracked for cleanup in the roadmap (and lint is non-blocking in the new CI for exactly this reason).