### PR TITLE
chore: gitignore .claude/ local agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ server/outputs/*
 
 # External MCP server clone
 manim-mcp-server/
+
+# Claude Code local state (agent worktrees, local launch config)
+.claude/


### PR DESCRIPTION
Claude Code writes agent worktrees and a local `launch.json` under `.claude/`. None of it belongs in version control — this keeps `git status` clean for anyone using it.