### PR TITLE
perf: persistent TTS audio cache + tunable render concurrency

### DIFF
--- a/backend/agents/manim_generator.py
+++ b/backend/agents/manim_generator.py
@@ -73,12 +73,15 @@ class ManimGenerator(BaseAgent):
     OPENAI_TTS_MODEL = os.getenv("VOICEOVER_TTS_MODEL", "gpt-4o-mini-tts")
     DEFAULT_OPENAI_VOICE = "nova"
 
+    # Persistent narration-audio cache. manim-voiceover's default cache lives
+    # under the render's TemporaryDirectory, so identical narration was
+    # re-synthesized (and re-billed) on every retry/re-render. A stable path on
+    # the container survives across renders within a replica's lifetime.
+    TTS_CACHE_DIR = os.getenv("VOICEOVER_CACHE_DIR", "/tmp/arxivisual-tts-cache")
+
     TTS_IMPORTS = {
         "gtts": "from manim_voiceover.services.gtts import GTTSService",
         "openai": "from manim_voiceover.services.openai import OpenAIService",
-    }
-    TTS_SETUP = {
-        "gtts": "self.set_speech_service(GTTSService(transcription_model=None))",
     }
 
     def __init__(self, model: str | None = None):
@@ -125,9 +128,12 @@ class ManimGenerator(BaseAgent):
             return (
                 f'self.set_speech_service(OpenAIService('
                 f'voice="{voice}", model="{self.OPENAI_TTS_MODEL}", '
-                f'transcription_model=None))'
+                f'transcription_model=None, cache_dir="{self.TTS_CACHE_DIR}"))'
             )
-        return self.TTS_SETUP.get(tts_service, self.TTS_SETUP["gtts"])
+        return (
+            f"self.set_speech_service(GTTSService("
+            f'transcription_model=None, cache_dir="{self.TTS_CACHE_DIR}"))'
+        )
 
     def _get_tts_import(self, tts_service: str) -> str:
         """Return the exact import line matching the selected TTS service."""

--- a/backend/examples/voiceover_architecture.py
+++ b/backend/examples/voiceover_architecture.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverArchitectureExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
 
         # Beat 1: frame architecture objective
         title = Text("Transformer Encoder Block", font_size=40)

--- a/backend/examples/voiceover_data_flow.py
+++ b/backend/examples/voiceover_data_flow.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverDataFlowExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
 
         # Beat 1: framing
         title = Text("Attention Data Flow", font_size=42)

--- a/backend/examples/voiceover_equation.py
+++ b/backend/examples/voiceover_equation.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverEquationExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
 
         # Beat 1: framing equation
         title = Text("Scaled Dot-Product Attention", font_size=38)

--- a/backend/jobs/worker.py
+++ b/backend/jobs/worker.py
@@ -282,7 +282,12 @@ async def _process_paper_job_impl(job_id: str, arxiv_id: str):
                 progress=0.75
             )
 
-            render_semaphore = asyncio.Semaphore(3)
+            # Concurrent Manim renders are CPU-bound (manim + latex + ffmpeg);
+            # production telemetry shows rendering is ~74% of pipeline wall-clock
+            # on the 2-vCPU container, so this is the knob to tune per host.
+            render_semaphore = asyncio.Semaphore(
+                max(1, int(os.getenv("RENDER_CONCURRENCY", "3")))
+            )
             progress_lock = asyncio.Lock()
             progress_bar = ProgressBar(len(viz_records), "Video Rendering")
             completed_count = 0

--- a/backend/tests/test_tts_config.py
+++ b/backend/tests/test_tts_config.py
@@ -24,6 +24,13 @@ def test_openai_snippet_uses_configured_voice_and_model(generator):
     assert 'model="gpt-4o-mini-tts"' in snippet
     # Bookmark transcription must stay off — it would pull in whisper at render.
     assert "transcription_model=None" in snippet
+    # Persistent audio cache — without it, retries re-synthesize (and re-bill)
+    # identical narration because the default cache dies with the render tmpdir.
+    assert 'cache_dir="/tmp/arxivisual-tts-cache"' in snippet
+
+
+def test_gtts_snippet_also_uses_persistent_cache(generator):
+    assert 'cache_dir="/tmp/arxivisual-tts-cache"' in generator._get_tts_setup_snippet("gtts", "")
 
 
 def test_openai_snippet_defaults_voice_when_blank(generator):


### PR DESCRIPTION
First slice of the speed work, guided by real production telemetry rather than guesses.

## The measured profile (Langfuse, production run `job_6e1a98ace1b6`)
| Phase | Time | Share |
|---|---|---|
| LLM generation (5 viz, truly parallel now) | 106s | 26% |
| **Rendering + upload (5 videos, Semaphore(3) on 2 vCPU)** | **~304s** | **74%** |

Generation is already fixed (the async-judge PR made all 5 visualizations start simultaneously — verified in the trace). **Rendering is the bottleneck.**

## Changes (zero quality risk)
1. **Persistent TTS audio cache.** manim-voiceover caches synthesized narration keyed by text+voice+model — but its default cache dir lives inside the render's `TemporaryDirectory`, destroyed after every render. Identical narration was re-synthesized and **re-billed per character** on every retry/re-render of the same paper (common, since there's no job dedupe). The injected `set_speech_service` snippet now pins `cache_dir="/tmp/arxivisual-tts-cache"` (`VOICEOVER_CACHE_DIR` to override), surviving across renders within a replica's lifetime.
2. **`RENDER_CONCURRENCY` env knob** for the render semaphore (default unchanged at 3). On a 2-vCPU container, 3 concurrent CPU-bound renders thrash; this makes the contention point tunable per host — worth an A/B at 2 vs 3 with the Langfuse timings.

## Not in this PR (bigger levers, tracked)
- **Modal render fan-out** — to be clear: Modal is currently **not in effect at all** (prod runs `RENDER_MODE=local`, no Modal token exists anywhere, the app was never deployed, and the Modal fn requests no GPU — Manim/Cairo is CPU-bound anyway). Fanning renders out to one Modal container each would collapse the 304s render phase to roughly the slowest single video, but requires a Modal account token (user action) and an updated Modal image (its pinned deps predate the Azure TTS switch).
- Overlapping generation with rendering (start each video as its code validates).
- Reasoning-effort A/B: 22.9k of 23.2k output tokens are reasoning tokens at `medium` — a huge cost/latency lever, but it changes model behavior, so it needs a golden-set comparison first.

32 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent, configurable cache for generated voiceovers.
  * Added an environment setting to control rendering concurrency, with safe defaults and limits.

* **Bug Fixes**
  * Improved voiceover retry behavior by preserving generated audio in the cache.

* **Tests**
  * Added coverage for voiceover caching across supported text-to-speech services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->