### PR TITLE
feat: vision-based visual QA for overlap defects (observe mode) + anti-overlap prompt rules

### DIFF
--- a/backend/agents/visual_qa.py
+++ b/backend/agents/visual_qa.py
@@ -1,0 +1,172 @@
+"""Visual QA judge — catches layout defects the static validators can't see.
+
+The spatial validator regex-parses explicit ``move_to``/``shift`` coordinates,
+but generated scenes mostly use relative layout (``next_to``/``arrange`` — which
+the prompt itself encourages), so real overlaps are invisible to it. This module
+judges the *rendered pixels* instead: sample a few frames from the finished
+video and ask a vision model whether elements overlap, collide, or fall off
+frame.
+
+Ships in OBSERVE mode: enable with ``ENABLE_VISUAL_QA=1`` and results are
+logged (and scored to Langfuse when configured) without changing pipeline
+behavior. Once thresholds are trusted, the verdict can gate a targeted repair.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+# Handle imports for both package and direct execution
+try:
+    from .base import _get_azure_client, _azure_model, get_provider
+except ImportError:  # pragma: no cover - direct execution path
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from agents.base import _get_azure_client, _azure_model, get_provider
+
+logger = logging.getLogger(__name__)
+
+# Observe-mode switch and judge model (gpt-5-mini and gpt-5.6-sol both verified
+# to catch real overlap/cutoff/collision defects on production frames).
+VISUAL_QA_ENABLED = os.getenv("ENABLE_VISUAL_QA", "0") == "1"
+VISUAL_QA_MODEL = os.getenv("VISUAL_QA_MODEL", "gpt-5-mini")
+VISUAL_QA_FRAMES = max(1, int(os.getenv("VISUAL_QA_FRAMES", "3")))
+
+JUDGE_PROMPT = """You are a visual QA judge for auto-generated Manim educational videos.
+Inspect these frames (sampled from one video) for LAYOUT DEFECTS only, not content quality:
+1. overlapping elements (text/shapes drawn on top of each other illegibly)
+2. elements cut off by the frame edges
+3. text colliding with arrows/shapes
+
+Return ONLY JSON:
+{"overlap": bool, "cutoff": bool, "collisions": bool, "severity": "none"|"minor"|"major", "issues": ["short specific descriptions"]}"""
+
+
+class VisualQAResult(BaseModel):
+    """Structured verdict from the vision judge."""
+
+    overlap: bool = False
+    cutoff: bool = False
+    collisions: bool = False
+    severity: str = Field("none", description='none | minor | major')
+    issues: list[str] = Field(default_factory=list)
+    judge_model: str = ""
+    frames_checked: int = 0
+
+    @property
+    def has_defects(self) -> bool:
+        return self.severity in ("minor", "major")
+
+
+def sample_frames(video_bytes: bytes, count: int = VISUAL_QA_FRAMES) -> list[bytes]:
+    """Extract ``count`` evenly spaced PNG frames from an MP4 via ffmpeg.
+
+    Runs in a temp dir; returns raw PNG bytes. Raises RuntimeError on ffmpeg
+    failure so callers can decide whether QA failure should be fatal (in
+    observe mode it never is).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = Path(tmpdir) / "video.mp4"
+        video_path.write_bytes(video_bytes)
+
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "csv=p=0", str(video_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        if probe.returncode != 0:
+            raise RuntimeError(f"ffprobe failed: {probe.stderr.strip()[:200]}")
+        duration = float(probe.stdout.strip())
+
+        frames: list[bytes] = []
+        for i in range(1, count + 1):
+            # Sample the middle of the video's i-th segment; skip t=0 (usually
+            # an empty first frame) and the very end.
+            ts = duration * i / (count + 1)
+            out_path = Path(tmpdir) / f"frame_{i}.png"
+            result = subprocess.run(
+                ["ffmpeg", "-y", "-loglevel", "error", "-ss", f"{ts:.3f}",
+                 "-i", str(video_path), "-frames:v", "1", str(out_path)],
+                capture_output=True, text=True, timeout=60,
+            )
+            if result.returncode != 0 or not out_path.exists():
+                raise RuntimeError(f"ffmpeg frame extract failed: {result.stderr.strip()[:200]}")
+            frames.append(out_path.read_bytes())
+        return frames
+
+
+def _parse_verdict(text: str) -> VisualQAResult:
+    """Parse the judge's JSON, tolerating markdown fences and prose padding."""
+    cleaned = text.strip()
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned, re.DOTALL)
+    if fence:
+        cleaned = fence.group(1)
+    else:
+        brace = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if brace:
+            cleaned = brace.group(0)
+    try:
+        data = json.loads(cleaned)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("[VisualQA] Unparseable judge output: %r", text[:200])
+        return VisualQAResult(severity="none", issues=["judge output unparseable"])
+    if data.get("severity") not in ("none", "minor", "major"):
+        data["severity"] = "minor" if any(
+            data.get(k) for k in ("overlap", "cutoff", "collisions")
+        ) else "none"
+    return VisualQAResult(
+        overlap=bool(data.get("overlap", False)),
+        cutoff=bool(data.get("cutoff", False)),
+        collisions=bool(data.get("collisions", False)),
+        severity=data["severity"],
+        issues=[str(i) for i in data.get("issues", [])][:10],
+    )
+
+
+async def judge_video(video_bytes: bytes, viz_id: str = "") -> Optional[VisualQAResult]:
+    """Judge a rendered video's frames for layout defects.
+
+    Returns None when QA can't run (non-Azure provider, ffmpeg failure, API
+    error) — observe mode never breaks the pipeline.
+    """
+    if get_provider() != "azure":
+        logger.info("[VisualQA] Skipped (non-Azure provider has no vision path)")
+        return None
+    try:
+        frames = sample_frames(video_bytes)
+    except Exception as exc:
+        logger.warning("[VisualQA] Frame sampling failed for %s: %s", viz_id, exc)
+        return None
+
+    content: list[dict] = [{"type": "text", "text": JUDGE_PROMPT}]
+    for frame in frames:
+        b64 = base64.b64encode(frame).decode()
+        content.append(
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+        )
+
+    try:
+        client = _get_azure_client()
+        resp = await client.chat.completions.create(
+            model=_azure_model(VISUAL_QA_MODEL),
+            messages=[{"role": "user", "content": content}],
+            max_completion_tokens=4096,
+        )
+        verdict = _parse_verdict(resp.choices[0].message.content or "")
+        verdict.judge_model = VISUAL_QA_MODEL
+        verdict.frames_checked = len(frames)
+        return verdict
+    except Exception as exc:
+        logger.warning("[VisualQA] Judge call failed for %s: %s", viz_id, exc)
+        return None

--- a/backend/prompts/manim_generator.md
+++ b/backend/prompts/manim_generator.md
@@ -33,12 +33,23 @@ The video must feel like a coherent teaching sequence, not a list of disconnecte
    - `# Beat 3: ...`
 5. Keep consistent color semantics across all beats.
 
-## Spatial Quality Requirements
-- Keep content in safe area: x in [-6, 6], y in [-3.5, 3.5].
+## Spatial Quality Requirements (CRITICAL — overlapping visuals are the #1 defect)
+- Keep content in safe area: x in [-6, 6], y in [-3.5, 3.5]. Anything wider gets clipped by the frame.
 - Prefer relative layout (`next_to`, `arrange`, `to_edge(..., buff=...)`) over hardcoded offsets.
-- Always include `buff` in `next_to` / `arrange` calls.
-- Avoid overlap by grouping and arranging related objects.
-- Clear visual clutter between major beats when needed.
+- Always include `buff` in `next_to` / `arrange` calls (minimum 0.3).
+- MANDATORY: end every beat by clearing what the next beat replaces —
+  `self.play(FadeOut(old_group), run_time=0.5)` — never draw a new diagram on
+  top of a previous one. If elements persist across beats, MOVE them aside
+  (`.animate.to_edge(...)` or `.animate.scale(0.6).to_corner(...)`) first.
+- Never place more than ~7 labeled elements on screen at once; group related
+  mobjects into a `VGroup(...).arrange(..., buff=0.3)` instead of positioning
+  each independently.
+- Labels must never sit on top of arrows or other shapes: position labels with
+  `next_to(target, direction, buff=0.25)` on the side AWAY from incoming arrows.
+- When many arrows converge (e.g. fan-in diagrams), keep their label text OUTSIDE
+  the arrow region or omit per-arrow labels entirely.
+- Scale to fit: if a group would exceed the safe area, `group.scale_to_fit_width(12)`
+  (or height 7) BEFORE positioning it.
 
 ## LaTeX and MathTex Safety (CRITICAL)
 - Keep MathTex valid with BasicTeX-safe syntax.

--- a/backend/rendering/__init__.py
+++ b/backend/rendering/__init__.py
@@ -82,6 +82,10 @@ async def process_visualization(viz_id: str, manim_code: str, quality: str = "lo
     video_bytes = await render_manim(manim_code, scene_name, quality)
     logger.info(f"[Processing Visualization] Rendering complete ({len(video_bytes):,} bytes)")
 
+    # Visual QA (observe mode): judge sampled frames for overlap/cutoff defects.
+    # Logs + Langfuse score only — never blocks the pipeline or fails the render.
+    await _observe_visual_qa(viz_id, video_bytes)
+
     # Save to storage
     logger.info(f"[Processing Visualization] Saving to storage...")
     video_url = await save_video(video_bytes, f"{viz_id}.mp4")
@@ -89,3 +93,36 @@ async def process_visualization(viz_id: str, manim_code: str, quality: str = "lo
     logger.info(f"[Processing Visualization] Video URL: {video_url}")
 
     return video_url
+
+
+async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
+    """Run the vision layout judge when ENABLE_VISUAL_QA=1; log-only."""
+    if os.getenv("ENABLE_VISUAL_QA", "0") != "1":
+        return
+    try:
+        from agents.visual_qa import judge_video
+
+        verdict = await judge_video(video_bytes, viz_id=viz_id)
+        if verdict is None:
+            return
+        if verdict.has_defects:
+            logger.warning(
+                "[VisualQA] %s severity=%s overlap=%s cutoff=%s collisions=%s issues=%s",
+                viz_id, verdict.severity, verdict.overlap, verdict.cutoff,
+                verdict.collisions, "; ".join(verdict.issues[:5]),
+            )
+        else:
+            logger.info("[VisualQA] %s clean (%s frames)", viz_id, verdict.frames_checked)
+        # Score the current Langfuse span so defect rates become dashboardable.
+        try:
+            from langfuse import get_client
+
+            get_client().score_current_trace(
+                name="visual_qa_defect",
+                value=1.0 if verdict.has_defects else 0.0,
+                comment=f"{viz_id}: {verdict.severity}; " + "; ".join(verdict.issues[:3]),
+            )
+        except Exception:
+            pass  # Langfuse unavailable/unconfigured — logging above suffices
+    except Exception as exc:
+        logger.warning("[VisualQA] Observe-mode QA failed for %s: %s", viz_id, exc)

--- a/backend/tests/test_visual_qa.py
+++ b/backend/tests/test_visual_qa.py
@@ -1,0 +1,82 @@
+"""Unit tests for the visual QA judge (no network, no ffmpeg)."""
+
+import asyncio
+
+import pytest
+
+from agents import visual_qa
+from agents.visual_qa import VisualQAResult, _parse_verdict
+
+
+def test_parse_clean_json():
+    v = _parse_verdict(
+        '{"overlap": true, "cutoff": false, "collisions": true, '
+        '"severity": "major", "issues": ["labels overlap arrows"]}'
+    )
+    assert v.overlap is True
+    assert v.cutoff is False
+    assert v.collisions is True
+    assert v.severity == "major"
+    assert v.has_defects
+    assert v.issues == ["labels overlap arrows"]
+
+
+def test_parse_fenced_json():
+    v = _parse_verdict(
+        'Here is my assessment:\n```json\n{"overlap": false, "cutoff": false, '
+        '"collisions": false, "severity": "none", "issues": []}\n```'
+    )
+    assert v.severity == "none"
+    assert not v.has_defects
+
+
+def test_parse_json_embedded_in_prose():
+    v = _parse_verdict(
+        'The frame looks mostly fine. {"overlap": false, "cutoff": true, '
+        '"collisions": false, "severity": "minor", "issues": ["left box clipped"]}'
+    )
+    assert v.cutoff is True
+    assert v.severity == "minor"
+
+
+def test_parse_garbage_degrades_to_clean_verdict():
+    # Unparseable judge output must not raise and must not block anything.
+    v = _parse_verdict("I could not analyse the image, sorry!")
+    assert isinstance(v, VisualQAResult)
+    assert v.severity == "none"
+    assert not v.has_defects
+
+
+def test_parse_invalid_severity_is_derived_from_flags():
+    v = _parse_verdict(
+        '{"overlap": true, "cutoff": false, "collisions": false, '
+        '"severity": "catastrophic", "issues": ["x"]}'
+    )
+    assert v.severity == "minor"  # derived: defect flags set, unknown severity
+
+
+def test_issue_list_is_capped():
+    issues = [f"issue {i}" for i in range(25)]
+    v = _parse_verdict(
+        '{"overlap": true, "cutoff": false, "collisions": false, '
+        f'"severity": "major", "issues": {issues!r}}}'.replace("'", '"')
+    )
+    assert len(v.issues) == 10
+
+
+def test_judge_video_skips_non_azure_provider(monkeypatch):
+    monkeypatch.setattr(visual_qa, "get_provider", lambda: "dedalus")
+    result = asyncio.run(visual_qa.judge_video(b"not-a-video"))
+    assert result is None
+
+
+def test_judge_video_survives_ffmpeg_failure(monkeypatch):
+    # Azure provider but frame sampling explodes -> None, never raises.
+    monkeypatch.setattr(visual_qa, "get_provider", lambda: "azure")
+
+    def boom(video_bytes, count=3):
+        raise RuntimeError("ffprobe failed")
+
+    monkeypatch.setattr(visual_qa, "sample_frames", boom)
+    result = asyncio.run(visual_qa.judge_video(b"not-a-video"))
+    assert result is None

--- a/backend/tools/visual_qa_eval.py
+++ b/backend/tools/visual_qa_eval.py
@@ -1,0 +1,78 @@
+"""Evaluate the visual QA judge against already-rendered videos.
+
+Fetches a processed paper's videos (from the live API / R2) and runs the vision
+layout judge on each, printing a per-video verdict table. Use this to calibrate
+the judge on real output before turning the gate on in the pipeline.
+
+Usage (from backend/):
+    uv run python tools/visual_qa_eval.py --arxiv-id 1706.03762
+    uv run python tools/visual_qa_eval.py --arxiv-id 2603.20927 \
+        --api https://arxivisual-api.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agents.visual_qa import judge_video  # noqa: E402
+
+DEFAULT_API = "https://arxivisual-api.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io"
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arxiv-id", required=True)
+    parser.add_argument("--api", default=DEFAULT_API)
+    args = parser.parse_args()
+
+    async with httpx.AsyncClient(timeout=120) as http:
+        resp = await http.get(f"{args.api}/api/paper/{args.arxiv_id}")
+        if resp.status_code != 200:
+            print(f"paper {args.arxiv_id} not found ({resp.status_code})")
+            return 1
+        paper = resp.json()
+
+        videos = [
+            (v["id"], v["video_url"])
+            for v in paper.get("visualizations", [])
+            if v.get("video_url") and v.get("status") == "complete"
+        ]
+        if not videos:
+            print("no completed videos for this paper")
+            return 1
+
+        print(f"{paper['title'][:70]}")
+        print(f"judging {len(videos)} video(s)...\n")
+        print(f"{'viz':<20}{'severity':<10}{'ovl':<5}{'cut':<5}{'col':<5}issues")
+
+        defects = 0
+        for viz_id, url in videos:
+            video = await http.get(url)
+            if video.status_code != 200:
+                print(f"{viz_id:<20}download failed ({video.status_code})")
+                continue
+            verdict = await judge_video(video.content, viz_id=viz_id)
+            if verdict is None:
+                print(f"{viz_id:<20}judge unavailable")
+                continue
+            defects += 1 if verdict.has_defects else 0
+            flag = lambda b: "Y" if b else "-"
+            print(
+                f"{viz_id:<20}{verdict.severity:<10}"
+                f"{flag(verdict.overlap):<5}{flag(verdict.cutoff):<5}{flag(verdict.collisions):<5}"
+                f"{'; '.join(verdict.issues[:2])[:80]}"
+            )
+
+        print(f"\n{defects}/{len(videos)} videos have layout defects")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
The overlap experiment branch, as requested — **testable without touching pipeline behavior, and instantly revertable at every level**.

## 🔒 Safety / rollback ladder (nothing here can take prod down)
| Layer | State | To turn off |
|---|---|---|
| 1. The QA hook is **flag-gated** | `ENABLE_VISUAL_QA` **defaults OFF** — merging changes nothing at runtime | it's already off; enabling is a container env var, disabling = unset it (no code deploy) |
| 2. Even when ON, it's **observe-only** | logs + a Langfuse score, wrapped in try/except | it structurally cannot fail a render, change a job status, or block the pipeline |
| 3. The **one** behavior-affecting change (prompt rules) is its **own commit** | `a81b359` — text-only guidance to the generator | `git revert a81b359` (one file) |
| 4. Nuclear | — | revert the PR, or roll the container back to the previous ACR image tag |

## Why the spatial validator can't catch overlap
`agents/spatial_validator.py` regex-parses only explicit `move_to`/`shift` coordinates. Generated scenes mostly use relative layout (`next_to`/`arrange`) — **which the prompt itself encourages** — so real overlaps are invisible to it. Judging code text can't work; judging rendered pixels can.

## What this adds (2 commits)
**Commit 1 — inert machinery (`5a7cde2`):**
- `agents/visual_qa.py` — samples N frames from the finished MP4 (ffmpeg, already in the image), asks a vision model for `{overlap, cutoff, collisions, severity, issues[]}`. Model env-configurable (`VISUAL_QA_MODEL`, default `gpt-5-mini`).
- Observe-mode hook in `rendering/process_visualization` behind `ENABLE_VISUAL_QA=1`; scores `visual_qa_defect` (0/1) to Langfuse so defect rate becomes a dashboard number.
- `tools/visual_qa_eval.py` — judge any processed paper's existing videos (the test harness).

**Commit 2 — prompt hardening (`a81b359`):** mandatory `FadeOut` between beats, `arrange` with min buff, ≤7 labeled elements, labels never on arrows, `scale_to_fit` before positioning.

## Verified live (real Azure calls, real production videos)
- Judge on a frame with known defects: **caught every one** identified by eye (W-label pile-up, arrow spearing "Output", softmax collision, both edge cutoffs). `gpt-5.6-sol` was faster, cheaper, equally accurate vs `gpt-5-mini` (5.8s/221out vs 7.7s/531out) — a standby `gpt-5.6-sol` deployment already exists on the Azure resource.
- **Baseline on prod output** (`--arxiv-id 1706.03762`): **3/3 videos have major layout defects**.
- Cost: ~600 input tokens/frame → well under a cent per video.

## Test plan for the experiment
1. Merge (nothing changes — flag off).
2. Set `ENABLE_VISUAL_QA=1` (+ optionally `VISUAL_QA_MODEL=gpt-5.6-sol`) on the container; process a few papers; watch `visual_qa_defect` in Langfuse.
3. Compare defect rate before/after the prompt hardening (baseline: 3/3).
4. If the judge stays trustworthy → close the loop: feed `issues[]` back as targeted repair, or gate `status=complete` on severity.

8 new unit tests (parse robustness, non-Azure skip, ffmpeg-failure safety) — **39 total pass** on the branch.