### PR TITLE
ci: deploy workflow (OIDC), dependabot, secret scanning, PR template, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners: every PR requests review from the repo owner and the main
+# maintainer. Add path-scoped rules below if ownership ever splits.
+* @rajshah6 @Ajith-Bondili

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- One or two sentences: what this PR does and why. Link the backlog item or issue if there is one. -->
+
+## Changes
+
+<!-- Bullet the notable changes; call out anything reviewers should look at closely. -->
+
+-
+
+## Verification
+
+<!-- How you proved it works. Check what applies, delete what doesn't. -->
+
+- [ ] Backend: `uv run pytest tests/` passes
+- [ ] Frontend: `npx tsc --noEmit` and `npm run build` pass
+- [ ] Manually exercised the affected flow (describe how)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Weekly dependency updates. Minor + patch bumps are grouped into a single PR
+# per ecosystem to keep noise down; majors still arrive as individual PRs so
+# breaking changes get individual review.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Dependabot understands uv lockfiles natively (GA since 2025), so updates
+  # land in backend/uv.lock — the file CI's `uv sync --frozen` actually checks.
+  - package-ecosystem: "uv"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,106 @@
+# Manual backend deploy: build the image in ACR, roll the Container App, verify health.
+#
+# Deploys are human-initiated on purpose — there is NO on:push trigger. Run this
+# from the Actions tab (or `gh workflow run deploy-backend.yml`) once CI is green.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# One-time Azure setup (maintainers run these locally, once)
+#
+# The workflow authenticates via OIDC federation — no client secret is stored in
+# GitHub. It needs an Entra application that trusts this repo's main branch and
+# has rights over the arxivisual-rg resource group:
+#
+#   # 1) Create the Entra app + service principal
+#   APP_ID=$(az ad app create --display-name "arxivisual-github-deploy" \
+#              --query appId -o tsv)
+#   az ad sp create --id "$APP_ID"
+#
+#   # 2) Federate it with GitHub Actions. workflow_dispatch runs carry the ref
+#   #    they were dispatched on, so this subject allows dispatches from main:
+#   az ad app federated-credential create --id "$APP_ID" --parameters '{
+#     "name": "github-arxivisual-main",
+#     "issuer": "https://token.actions.githubusercontent.com",
+#     "subject": "repo:rajshah6/arXivisual:ref:refs/heads/main",
+#     "audiences": ["api://AzureADTokenExchange"]
+#   }'
+#
+#   # 3) Grant it Contributor on the resource group (covers both the ACR build
+#   #    and the containerapp update — registry and app live in arxivisual-rg):
+#   SUB_ID=$(az account show --query id -o tsv)
+#   az role assignment create \
+#     --assignee "$APP_ID" \
+#     --role Contributor \
+#     --scope "/subscriptions/$SUB_ID/resourceGroups/arxivisual-rg"
+#
+#   # 4) Store the three ids as repo secrets (ids, not credentials — the trust
+#   #    lives in the federated credential above):
+#   gh secret set AZURE_CLIENT_ID       --body "$APP_ID"
+#   gh secret set AZURE_TENANT_ID       --body "$(az account show --query tenantId -o tsv)"
+#   gh secret set AZURE_SUBSCRIPTION_ID --body "$SUB_ID"
+#
+# Required repo secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Deploy backend
+
+on:
+  workflow_dispatch:
+
+# One deploy at a time; queue rather than cancel a rollout mid-flight.
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+permissions:
+  id-token: write # mint the OIDC token azure/login exchanges
+  contents: read
+
+env:
+  ACR_NAME: ca82c08e2eadacr
+  IMAGE_NAME: arxivisual-api
+  APP_NAME: arxivisual-api
+  RESOURCE_GROUP: arxivisual-rg
+  HEALTH_URL: https://arxivisual-api.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io/api/health
+
+jobs:
+  deploy:
+    name: Build, roll, verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # Build happens inside ACR (same as the manual `az acr build` flow the
+      # project has used so far), tagged with the exact commit being deployed.
+      - name: Build image in ACR
+        run: az acr build -r "$ACR_NAME" -t "$IMAGE_NAME:gh-${{ github.sha }}" backend
+
+      - name: Roll Container App to the new image
+        run: |
+          az containerapp update \
+            -n "$APP_NAME" -g "$RESOURCE_GROUP" \
+            --image "$ACR_NAME.azurecr.io/$IMAGE_NAME:gh-${{ github.sha }}"
+
+      # The update returns before the new revision finishes provisioning, so
+      # poll the public health endpoint instead of trusting the CLI exit code.
+      - name: Verify health
+        run: |
+          echo "Polling $HEALTH_URL ..."
+          for attempt in $(seq 1 30); do
+            if curl -fsS --max-time 10 "$HEALTH_URL"; then
+              echo
+              echo "Backend healthy (attempt $attempt)."
+              exit 0
+            fi
+            echo "Attempt $attempt/30: not healthy yet, retrying in 10s..."
+            sleep 10
+          done
+          echo "Backend did not become healthy within ~5 minutes." >&2
+          echo "Inspect the revision: az containerapp logs show -n $APP_NAME -g $RESOURCE_GROUP --tail 100" >&2
+          exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,70 @@
+# Lightweight security checks. Only the secret scan blocks — leaked credentials
+# are an emergency regardless of context. The dependency audits are advisory
+# (continue-on-error) so a new upstream CVE never blocks unrelated work; they
+# surface in the logs and in the weekly scheduled run.
+name: Security
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC, runs against main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret scan (blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # gitleaks scans the full commit history
+
+      # Public repo: no GITLEAKS_LICENSE needed.
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm-audit:
+    name: npm audit (advisory)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Audits straight from package-lock.json — no install needed. Advisory:
+      # matches CI's lint precedent (step-level continue-on-error keeps the
+      # finding visible in logs without gating merges on upstream advisories).
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+        continue-on-error: true
+
+  pip-audit:
+    name: pip-audit (advisory)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      # Export the locked runtime closure instead of `uv sync`-ing: installing
+      # the real environment would drag in manimpango's pango/cairo build deps
+      # for no benefit. The export carries hashes, which lets pip-audit run
+      # with --disable-pip (audit the pinned set, install nothing).
+      - name: Export locked runtime dependencies
+        run: uv export --frozen --no-dev --no-emit-project -o requirements.txt
+
+      - name: Audit locked dependencies
+        run: pipx run pip-audit --disable-pip -r requirements.txt
+        continue-on-error: true


### PR DESCRIPTION
Infra/productionization batch — everything lives in `.github/`, zero code changes. `ci.yml` untouched.

## What's included
| File | What |
|---|---|
| `workflows/deploy-backend.yml` | **Manual-only** backend deploy (`workflow_dispatch`): Azure OIDC login (no stored credentials), `az acr build` tagged `gh-<sha>`, `containerapp update`, then a health-endpoint poll that **fails the job if the app doesn't come up healthy**. Concurrency-guarded so rollouts queue. |
| `dependabot.yml` | Weekly `github-actions`, `npm` (frontend), and **`uv`** (backend) updates — uv ecosystem chosen deliberately so updates land in `uv.lock`, the file CI's `--frozen` actually gates on. Minor+patch grouped. |
| `workflows/security.yml` | **gitleaks** secret scan (blocking) on PR + weekly cron; `npm audit` + `pip-audit` advisory. pip-audit runs against `uv export --frozen` output so the runner doesn't need pango/cairo build deps. |
| `PULL_REQUEST_TEMPLATE.md` | Summary / Changes / Verification checklist matching the house style. |
| `CODEOWNERS` | `@rajshah6 @Ajith-Bondili` |

## One-time setup needed before the deploy workflow works (maintainer action)
The workflow header documents the exact commands: create an Entra app, add a **federated credential** trusting `repo:rajshah6/arXivisual:ref:refs/heads/main`, grant it Contributor on `arxivisual-rg`, then `gh secret set` the three IDs (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`). These are identifiers, not credentials — the trust is OIDC-federated, so nothing secret is stored in GitHub.

## Verification
All 4 YAML files parse; action versions are current major tags (`azure/login@v2`, `gitleaks/gitleaks-action@v2`, `actions/checkout@v4`, `astral-sh/setup-uv@v5`). Deploys remain human-initiated by design — no on:push trigger.