### PR TITLE
feat(security): rate-limit and dedupe the public processing endpoint

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -8,7 +8,7 @@ import hmac
 import logging
 import os
 import uuid
-from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, Header
+from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, Header, Request
 from fastapi.responses import FileResponse, RedirectResponse
 from datetime import datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,6 +35,7 @@ from db.connection import get_db
 from db import queries
 from rendering import process_visualization, get_video_path, get_video_url, extract_scene_name
 from jobs import process_paper_job
+from .throttle import client_ip, global_limiter, per_ip_limiter, recent_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,7 @@ def _authorize_render(secret: str | None) -> None:
 @router.post("/process", response_model=ProcessResponse)
 async def start_processing(
     request: ProcessRequest,
+    http_request: Request,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db)
 ):
@@ -72,16 +74,57 @@ async def start_processing(
     Start processing an arXiv paper.
 
     Returns immediately with a job_id. Poll /api/status/{job_id} for progress.
+    Duplicate submissions for a paper already in flight return the existing
+    job instead of starting (and paying for) a second pipeline.
     """
+    arxiv_id = request.arxiv_id
+
+    # Dedupe: an in-flight job for this paper is returned as-is. The in-memory
+    # map covers the seconds before the worker links job.paper_id; the DB query
+    # covers everything after (including submissions from other clients).
+    existing_id = recent_jobs.get(arxiv_id)
+    if existing_id is None:
+        existing = await queries.get_active_job_for_paper(db, arxiv_id)
+        existing_id = existing.id if existing else None
+    if existing_id is not None:
+        job = await queries.get_job(db, existing_id)
+        if job and job.status in ("queued", "processing"):
+            return ProcessResponse(
+                job_id=existing_id,
+                arxiv_id=arxiv_id,
+                status=JobStatus(job.status),
+                message="This paper is already being processed. Poll /api/status/{job_id} for updates.",
+            )
+        recent_jobs.clear(arxiv_id)
+
+    # Cost fuse: each accepted job spends real LLM + render money.
+    ip = client_ip(http_request)
+    allowed, retry_after = per_ip_limiter.allow(ip)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit reached for starting new papers. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+    allowed, retry_after = global_limiter.allow("global")
+    if not allowed:
+        logger.warning("Global processing rate limit hit (client %s)", ip)
+        raise HTTPException(
+            status_code=429,
+            detail="The service is at capacity for new papers right now. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     # Create job in database
-    job_id = await queries.create_job(db, request.arxiv_id)
+    job_id = await queries.create_job(db, arxiv_id)
+    recent_jobs.put(arxiv_id, job_id)
 
     # Start background processing
-    background_tasks.add_task(process_paper_job, job_id, request.arxiv_id)
+    background_tasks.add_task(process_paper_job, job_id, arxiv_id)
 
     return ProcessResponse(
         job_id=job_id,
-        arxiv_id=request.arxiv_id,
+        arxiv_id=arxiv_id,
         status=JobStatus.queued,
         message="Processing started. Poll /api/status/{job_id} for updates."
     )

--- a/backend/api/throttle.py
+++ b/backend/api/throttle.py
@@ -1,0 +1,121 @@
+"""Cost protection for the public processing endpoint.
+
+Every ``POST /api/process`` run costs real money (LLM generation + rendering,
+roughly $0.10/paper) and minutes of the container's 2 vCPUs — and the endpoint
+is public with real traffic. Two guards:
+
+- Sliding-window rate limits: per-client-IP and a global cap across all clients.
+- A short-TTL recent-jobs map used for duplicate-submit detection during the
+  window before the worker links ``job.paper_id`` (it's NULL at creation to
+  avoid an FK violation, so a DB lookup alone misses immediate double-clicks).
+
+State is in-memory and per-replica. With Container Apps at 1-2 replicas that
+bounds cost within a small factor of the configured limits, which is the goal —
+this is a cost fuse, not billing-grade accounting. A shared store (Redis) is the
+upgrade path if replicas grow.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import deque
+
+from fastapi import Request
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return max(0, int(os.getenv(name, str(default))))
+    except ValueError:
+        return default
+
+
+class SlidingWindowLimiter:
+    """Thread-safe sliding-window counter. ``max_events == 0`` disables it."""
+
+    def __init__(self, max_events: int, window_seconds: float):
+        self.max_events = max_events
+        self.window_seconds = window_seconds
+        self._events: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key: str, now: float | None = None) -> tuple[bool, int]:
+        """Record-and-check. Returns (allowed, retry_after_seconds)."""
+        if self.max_events == 0:
+            return True, 0
+        now = time.monotonic() if now is None else now
+        cutoff = now - self.window_seconds
+        with self._lock:
+            q = self._events.setdefault(key, deque())
+            while q and q[0] <= cutoff:
+                q.popleft()
+            if len(q) >= self.max_events:
+                retry_after = int(q[0] + self.window_seconds - now) + 1
+                return False, max(1, retry_after)
+            q.append(now)
+            # Opportunistic cleanup so the map doesn't grow unboundedly.
+            if len(self._events) > 10_000:
+                dead = [k for k, v in self._events.items() if not v or v[-1] <= cutoff]
+                for k in dead:
+                    del self._events[k]
+            return True, 0
+
+
+class RecentJobs:
+    """arxiv_id -> job_id remembered for a short TTL, for duplicate submits."""
+
+    def __init__(self, ttl_seconds: float = 600):
+        self.ttl_seconds = ttl_seconds
+        self._jobs: dict[str, tuple[str, float]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, arxiv_id: str, now: float | None = None) -> str | None:
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            entry = self._jobs.get(arxiv_id)
+            if not entry:
+                return None
+            job_id, ts = entry
+            if now - ts > self.ttl_seconds:
+                del self._jobs[arxiv_id]
+                return None
+            return job_id
+
+    def put(self, arxiv_id: str, job_id: str, now: float | None = None) -> None:
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            self._jobs[arxiv_id] = (job_id, now)
+            if len(self._jobs) > 10_000:
+                cutoff = now - self.ttl_seconds
+                for k in [k for k, (_, ts) in self._jobs.items() if ts <= cutoff]:
+                    del self._jobs[k]
+
+    def clear(self, arxiv_id: str) -> None:
+        with self._lock:
+            self._jobs.pop(arxiv_id, None)
+
+
+def client_ip(request: Request) -> str:
+    """Client IP, honoring the ingress proxy's X-Forwarded-For (first hop)."""
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        first = forwarded.split(",")[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else "unknown"
+
+
+# Defaults: a person exploring the site can start 5 papers an hour; the whole
+# world combined is capped at 30/hour (~$3/hour worst-case LLM+render spend).
+# Set either env to 0 to disable that limiter.
+per_ip_limiter = SlidingWindowLimiter(
+    max_events=_int_env("RATE_LIMIT_PROCESS_PER_IP", 5),
+    window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
+)
+global_limiter = SlidingWindowLimiter(
+    max_events=_int_env("RATE_LIMIT_PROCESS_GLOBAL", 30),
+    window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
+)
+recent_jobs = RecentJobs(ttl_seconds=_int_env("PROCESS_DEDUPE_TTL_SECONDS", 600))

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -40,6 +40,27 @@ async def get_job(db: AsyncSession, job_id: str) -> Optional[ProcessingJob]:
     return result.scalar_one_or_none()
 
 
+async def get_active_job_for_paper(
+    db: AsyncSession, arxiv_id: str
+) -> Optional[ProcessingJob]:
+    """Find an in-flight job for a paper, newest first.
+
+    Note: jobs are created with paper_id=None (FK) and linked by the worker a
+    few seconds in, so this misses just-created jobs — callers pair it with the
+    in-memory recent-jobs map in api.throttle for the immediate-duplicate window.
+    """
+    result = await db.execute(
+        select(ProcessingJob)
+        .where(
+            ProcessingJob.paper_id == arxiv_id,
+            ProcessingJob.status.in_(("queued", "processing")),
+        )
+        .order_by(ProcessingJob.created_at.desc())
+        .limit(1)
+    )
+    return result.scalars().first()
+
+
 async def update_job_status(
     db: AsyncSession,
     job_id: str,

--- a/backend/tests/test_throttle.py
+++ b/backend/tests/test_throttle.py
@@ -1,0 +1,61 @@
+"""Unit tests for the /api/process cost-protection primitives."""
+
+from api.throttle import RecentJobs, SlidingWindowLimiter
+
+
+class TestSlidingWindowLimiter:
+    def test_allows_up_to_max_then_denies(self):
+        lim = SlidingWindowLimiter(max_events=3, window_seconds=60)
+        now = 1000.0
+        assert lim.allow("ip1", now)[0] is True
+        assert lim.allow("ip1", now + 1)[0] is True
+        assert lim.allow("ip1", now + 2)[0] is True
+        allowed, retry_after = lim.allow("ip1", now + 3)
+        assert allowed is False
+        # Oldest event at t=1000 expires at t=1060 -> ~57s (+1 rounding) left.
+        assert 57 <= retry_after <= 59
+
+    def test_window_expiry_frees_capacity(self):
+        lim = SlidingWindowLimiter(max_events=1, window_seconds=10)
+        assert lim.allow("k", 0.0)[0] is True
+        assert lim.allow("k", 5.0)[0] is False
+        assert lim.allow("k", 10.5)[0] is True  # first event aged out
+
+    def test_keys_are_independent(self):
+        lim = SlidingWindowLimiter(max_events=1, window_seconds=60)
+        assert lim.allow("a", 0.0)[0] is True
+        assert lim.allow("b", 0.0)[0] is True  # different key unaffected
+        assert lim.allow("a", 1.0)[0] is False
+
+    def test_zero_max_disables_limiter(self):
+        lim = SlidingWindowLimiter(max_events=0, window_seconds=60)
+        for i in range(100):
+            assert lim.allow("k", float(i))[0] is True
+
+    def test_retry_after_is_at_least_one_second(self):
+        lim = SlidingWindowLimiter(max_events=1, window_seconds=0.5)
+        assert lim.allow("k", 0.0)[0] is True
+        allowed, retry_after = lim.allow("k", 0.4)
+        assert allowed is False
+        assert retry_after >= 1
+
+
+class TestRecentJobs:
+    def test_put_get_roundtrip(self):
+        rj = RecentJobs(ttl_seconds=600)
+        rj.put("1706.03762", "job_abc", now=0.0)
+        assert rj.get("1706.03762", now=100.0) == "job_abc"
+
+    def test_ttl_expiry(self):
+        rj = RecentJobs(ttl_seconds=600)
+        rj.put("1706.03762", "job_abc", now=0.0)
+        assert rj.get("1706.03762", now=601.0) is None
+
+    def test_clear_removes_entry(self):
+        rj = RecentJobs(ttl_seconds=600)
+        rj.put("1706.03762", "job_abc", now=0.0)
+        rj.clear("1706.03762")
+        assert rj.get("1706.03762", now=1.0) is None
+
+    def test_unknown_paper_returns_none(self):
+        assert RecentJobs().get("nope") is None


### PR DESCRIPTION
Productionization/security batch. `POST /api/process` is public, unauthenticated, has **real traffic** (~8 jobs/90min observed), and every call spends ~$0.10 of LLM + minutes of the container's 2 vCPUs. Until now: no throttle, no duplicate protection — two tabs meant two full pipelines for the same paper, and nothing bounded worst-case spend.

## Changes
- **Sliding-window rate limits** (`api/throttle.py`): per client IP (default **5/hour**, `X-Forwarded-For`-aware behind the Container Apps ingress) and a **global cap** across all clients (default **30/hour** ≈ $3/hour worst-case spend fuse). Both env-tunable (`RATE_LIMIT_PROCESS_PER_IP`, `RATE_LIMIT_PROCESS_GLOBAL`, `RATE_LIMIT_PROCESS_WINDOW_SECONDS`); `0` disables. Rejections are `429` with a correct `Retry-After`.
- **Job dedupe**: submitting a paper already in flight returns the existing job instead of starting a second pipeline. Two layers because `create_job` writes `paper_id=NULL` (FK) and the worker links it seconds later: a DB query (`get_active_job_for_paper`) for linked jobs + a short-TTL in-memory map for the immediate-duplicate window. Pairs with the frontend's pending-button state in #27.

## Honest limitation
State is in-memory per replica (the app runs 1–2 replicas). That bounds cost within a small factor of the limits — the goal — but it isn't billing-grade accounting. Redis is the documented upgrade path if replicas grow.

## Verification
- 9 new unit tests (window expiry, per-key independence, retry-after bounds, disable-at-zero, dedupe TTL) — **40 total pass**
- Full route import check passes