### PR TITLE
fix: TTS cache TypeError (would crash all new voiceover renders) + review findings

### DIFF
--- a/backend/agents/manim_generator.py
+++ b/backend/agents/manim_generator.py
@@ -73,12 +73,10 @@ class ManimGenerator(BaseAgent):
     OPENAI_TTS_MODEL = os.getenv("VOICEOVER_TTS_MODEL", "gpt-4o-mini-tts")
     DEFAULT_OPENAI_VOICE = "nova"
 
-    # Persistent narration-audio cache. manim-voiceover's default cache lives
-    # under the render's TemporaryDirectory, so identical narration was
-    # re-synthesized (and re-billed) on every retry/re-render. A stable path on
-    # the container survives across renders within a replica's lifetime.
-    TTS_CACHE_DIR = os.getenv("VOICEOVER_CACHE_DIR", "/tmp/arxivisual-tts-cache")
-
+    # NOTE: narration-audio cache persistence is handled by the render runner
+    # (rendering/local_runner symlinks manim-voiceover's default cache dir to a
+    # stable per-scene path). Passing cache_dir="..." here would hand the
+    # library a str where it expects a Path and crash the first cache lookup.
     TTS_IMPORTS = {
         "gtts": "from manim_voiceover.services.gtts import GTTSService",
         "openai": "from manim_voiceover.services.openai import OpenAIService",
@@ -128,11 +126,11 @@ class ManimGenerator(BaseAgent):
             return (
                 f'self.set_speech_service(OpenAIService('
                 f'voice="{voice}", model="{self.OPENAI_TTS_MODEL}", '
-                f'transcription_model=None, cache_dir="{self.TTS_CACHE_DIR}"))'
+                f'transcription_model=None))'
             )
         return (
             f"self.set_speech_service(GTTSService("
-            f'transcription_model=None, cache_dir="{self.TTS_CACHE_DIR}"))'
+            f'transcription_model=None))'
         )
 
     def _get_tts_import(self, tts_service: str) -> str:

--- a/backend/agents/visual_qa.py
+++ b/backend/agents/visual_qa.py
@@ -14,6 +14,7 @@ behavior. Once thresholds are trusted, the verdict can gate a targeted repair.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -121,15 +122,19 @@ def _parse_verdict(text: str) -> VisualQAResult:
     except (json.JSONDecodeError, TypeError):
         logger.warning("[VisualQA] Unparseable judge output: %r", text[:200])
         return VisualQAResult(severity="none", issues=["judge output unparseable"])
-    if data.get("severity") not in ("none", "minor", "major"):
-        data["severity"] = "minor" if any(
-            data.get(k) for k in ("overlap", "cutoff", "collisions")
-        ) else "none"
+    any_flag = any(data.get(k) for k in ("overlap", "cutoff", "collisions"))
+    severity = data.get("severity")
+    if severity not in ("none", "minor", "major"):
+        severity = "minor" if any_flag else "none"
+    elif severity == "none" and any_flag:
+        # A judge that sets defect flags but says "none" is contradicting
+        # itself — trust the flags so the defect isn't scored as clean.
+        severity = "minor"
     return VisualQAResult(
         overlap=bool(data.get("overlap", False)),
         cutoff=bool(data.get("cutoff", False)),
         collisions=bool(data.get("collisions", False)),
-        severity=data["severity"],
+        severity=severity,
         issues=[str(i) for i in data.get("issues", [])][:10],
     )
 
@@ -144,7 +149,9 @@ async def judge_video(video_bytes: bytes, viz_id: str = "") -> Optional[VisualQA
         logger.info("[VisualQA] Skipped (non-Azure provider has no vision path)")
         return None
     try:
-        frames = sample_frames(video_bytes)
+        # sample_frames is blocking subprocess + file I/O — keep it off the
+        # event loop (the caller may be the FastAPI serving loop).
+        frames = await asyncio.to_thread(sample_frames, video_bytes)
     except Exception as exc:
         logger.warning("[VisualQA] Frame sampling failed for %s: %s", viz_id, exc)
         return None

--- a/backend/examples/voiceover_architecture.py
+++ b/backend/examples/voiceover_architecture.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverArchitectureExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: frame architecture objective
         title = Text("Transformer Encoder Block", font_size=40)

--- a/backend/examples/voiceover_data_flow.py
+++ b/backend/examples/voiceover_data_flow.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverDataFlowExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: framing
         title = Text("Attention Data Flow", font_size=42)

--- a/backend/examples/voiceover_equation.py
+++ b/backend/examples/voiceover_equation.py
@@ -7,7 +7,7 @@ from manim_voiceover.services.openai import OpenAIService
 
 class VoiceoverEquationExample(VoiceoverScene):
     def construct(self):
-        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None, cache_dir="/tmp/arxivisual-tts-cache"))
+        self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", transcription_model=None))
 
         # Beat 1: framing equation
         title = Text("Scaled Dot-Product Attention", font_size=38)

--- a/backend/jobs/worker.py
+++ b/backend/jobs/worker.py
@@ -44,6 +44,22 @@ from models.paper import (
 logger = logging.getLogger(__name__)
 
 
+def parse_render_concurrency(default: int = 3) -> int:
+    """Parse RENDER_CONCURRENCY safely.
+
+    An empty or non-numeric value must not fail jobs at render setup — fall
+    back to the documented default and log the misconfiguration instead.
+    """
+    raw = os.getenv("RENDER_CONCURRENCY", str(default))
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid RENDER_CONCURRENCY=%r — using default %d", raw, default
+        )
+        return default
+
+
 def resolve_terminal_job_status(
     succeeded_count: int, total_count: int
 ) -> tuple[str, str, str | None]:
@@ -285,9 +301,8 @@ async def _process_paper_job_impl(job_id: str, arxiv_id: str):
             # Concurrent Manim renders are CPU-bound (manim + latex + ffmpeg);
             # production telemetry shows rendering is ~74% of pipeline wall-clock
             # on the 2-vCPU container, so this is the knob to tune per host.
-            render_semaphore = asyncio.Semaphore(
-                max(1, int(os.getenv("RENDER_CONCURRENCY", "3")))
-            )
+            render_concurrency = parse_render_concurrency()
+            render_semaphore = asyncio.Semaphore(render_concurrency)
             progress_lock = asyncio.Lock()
             progress_bar = ProgressBar(len(viz_records), "Video Rendering")
             completed_count = 0
@@ -339,7 +354,10 @@ async def _process_paper_job_impl(job_id: str, arxiv_id: str):
                                 sections_completed=succeeded_count,
                             )
 
-            logger.info(f"Rendering {len(viz_records)} videos concurrently (max 3 parallel)...")
+            logger.info(
+                f"Rendering {len(viz_records)} videos concurrently "
+                f"(max {render_concurrency} parallel)..."
+            )
             await asyncio.gather(*[
                 _render_one(viz, i) for i, viz in enumerate(viz_records)
             ])

--- a/backend/prompts/manim_generator.md
+++ b/backend/prompts/manim_generator.md
@@ -45,7 +45,7 @@ The video must feel like a coherent teaching sequence, not a list of disconnecte
   mobjects into a `VGroup(...).arrange(..., buff=0.3)` instead of positioning
   each independently.
 - Labels must never sit on top of arrows or other shapes: position labels with
-  `next_to(target, direction, buff=0.25)` on the side AWAY from incoming arrows.
+  `next_to(target, direction, buff=0.3)` on the side AWAY from incoming arrows.
 - When many arrows converge (e.g. fan-in diagrams), keep their label text OUTSIDE
   the arrow region or omit per-arrow labels entirely.
 - Scale to fit: if a group would exceed the safe area, `group.scale_to_fit_width(12)`

--- a/backend/rendering/__init__.py
+++ b/backend/rendering/__init__.py
@@ -82,23 +82,44 @@ async def process_visualization(viz_id: str, manim_code: str, quality: str = "lo
     video_bytes = await render_manim(manim_code, scene_name, quality)
     logger.info(f"[Processing Visualization] Rendering complete ({len(video_bytes):,} bytes)")
 
-    # Visual QA (observe mode): judge sampled frames for overlap/cutoff defects.
-    # Logs + Langfuse score only — never blocks the pipeline or fails the render.
-    await _observe_visual_qa(viz_id, video_bytes)
-
-    # Save to storage
+    # Save to storage FIRST — visual QA must never delay video delivery.
     logger.info(f"[Processing Visualization] Saving to storage...")
     video_url = await save_video(video_bytes, f"{viz_id}.mp4")
     logger.info(f"[Processing Visualization] Video saved successfully")
     logger.info(f"[Processing Visualization] Video URL: {video_url}")
 
+    # Visual QA (observe mode): judge sampled frames for overlap/cutoff defects.
+    # Dispatched as supervised background work — logs + Langfuse score only,
+    # never blocks the render path or fails the visualization.
+    _dispatch_visual_qa(viz_id, video_bytes)
+
     return video_url
 
 
-async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
-    """Run the vision layout judge when ENABLE_VISUAL_QA=1; log-only."""
+# Keep strong references so background QA tasks aren't garbage-collected early.
+_visual_qa_tasks: set = set()
+
+
+def _dispatch_visual_qa(viz_id: str, video_bytes: bytes) -> None:
+    """Fire-and-supervise the observe-mode visual QA task."""
     if os.getenv("ENABLE_VISUAL_QA", "0") != "1":
         return
+    import asyncio
+
+    task = asyncio.get_running_loop().create_task(_observe_visual_qa(viz_id, video_bytes))
+    _visual_qa_tasks.add(task)
+
+    def _done(t: "asyncio.Task") -> None:
+        _visual_qa_tasks.discard(t)
+        exc = t.exception() if not t.cancelled() else None
+        if exc is not None:
+            logger.warning("[VisualQA] Background QA task failed for %s: %s", viz_id, exc)
+
+    task.add_done_callback(_done)
+
+
+async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
+    """Run the vision layout judge; log + score only."""
     try:
         from agents.visual_qa import judge_video
 
@@ -113,7 +134,7 @@ async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
             )
         else:
             logger.info("[VisualQA] %s clean (%s frames)", viz_id, verdict.frames_checked)
-        # Score the current Langfuse span so defect rates become dashboardable.
+        # Score the current Langfuse trace so defect rates become dashboardable.
         try:
             from langfuse import get_client
 
@@ -122,7 +143,8 @@ async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
                 value=1.0 if verdict.has_defects else 0.0,
                 comment=f"{viz_id}: {verdict.severity}; " + "; ".join(verdict.issues[:3]),
             )
-        except Exception:
-            pass  # Langfuse unavailable/unconfigured — logging above suffices
+        except Exception as exc:
+            # Distinguish broken telemetry from intentional unconfiguration.
+            logger.warning("[VisualQA] Langfuse scoring failed for %s: %s", viz_id, exc)
     except Exception as exc:
         logger.warning("[VisualQA] Observe-mode QA failed for %s: %s", viz_id, exc)

--- a/backend/rendering/local_runner.py
+++ b/backend/rendering/local_runner.py
@@ -66,6 +66,30 @@ def extract_scene_name(code: str) -> str:
     return "MainScene"  # Fallback
 
 
+def _link_persistent_voiceover_cache(media_dir: Path, scene_name: str) -> None:
+    """Persist manim-voiceover's narration cache across renders.
+
+    The library's default cache is ``Path(media_dir) / "voiceovers"`` — inside
+    the render's TemporaryDirectory, so identical narration was re-synthesized
+    (and re-billed per character) on every retry/re-render. Symlinking that
+    location to a stable per-scene path keeps the library on its default
+    Path-typed codepath (an explicit ``cache_dir=str`` crashes its cache
+    lookup) and gives each scene its own cache index, so concurrent renders
+    never share — or race on — the same cache.json.
+
+    Best effort: any failure just means the render uses the throwaway default.
+    """
+    try:
+        cache_root = Path(os.getenv("VOICEOVER_CACHE_DIR", "/tmp/arxivisual-tts-cache"))
+        safe_scene = re.sub(r"[^A-Za-z0-9_-]", "_", scene_name) or "scene"
+        target = cache_root / safe_scene
+        target.mkdir(parents=True, exist_ok=True)
+        media_dir.mkdir(parents=True, exist_ok=True)
+        (media_dir / "voiceovers").symlink_to(target, target_is_directory=True)
+    except Exception as exc:
+        logger.warning("[Renderer] Voiceover cache link failed (%s) — using throwaway cache", exc)
+
+
 def _run_manim_subprocess(
     code: str,
     scene_name: str,
@@ -84,6 +108,7 @@ def _run_manim_subprocess(
         code_path.write_text(code)
 
         output_dir = tmpdir_path / "media"
+        _link_persistent_voiceover_cache(output_dir, scene_name)
         quality_flags = {
             "low_quality": "-ql",
             "medium_quality": "-qm",

--- a/backend/tests/test_tts_config.py
+++ b/backend/tests/test_tts_config.py
@@ -24,13 +24,14 @@ def test_openai_snippet_uses_configured_voice_and_model(generator):
     assert 'model="gpt-4o-mini-tts"' in snippet
     # Bookmark transcription must stay off — it would pull in whisper at render.
     assert "transcription_model=None" in snippet
-    # Persistent audio cache — without it, retries re-synthesize (and re-bill)
-    # identical narration because the default cache dies with the render tmpdir.
-    assert 'cache_dir="/tmp/arxivisual-tts-cache"' in snippet
+    # cache_dir must NOT appear: SpeechService keeps an explicit cache_dir as a
+    # raw str and its cache lookup does Path division on it -> TypeError on the
+    # first narration. Persistence is the runner's job (voiceover-cache symlink).
+    assert "cache_dir" not in snippet
 
 
-def test_gtts_snippet_also_uses_persistent_cache(generator):
-    assert 'cache_dir="/tmp/arxivisual-tts-cache"' in generator._get_tts_setup_snippet("gtts", "")
+def test_gtts_snippet_has_no_cache_dir_either(generator):
+    assert "cache_dir" not in generator._get_tts_setup_snippet("gtts", "")
 
 
 def test_openai_snippet_defaults_voice_when_blank(generator):

--- a/backend/tests/test_visual_qa.py
+++ b/backend/tests/test_visual_qa.py
@@ -47,6 +47,17 @@ def test_parse_garbage_degrades_to_clean_verdict():
     assert not v.has_defects
 
 
+def test_contradictory_none_severity_is_upgraded_to_minor():
+    # Judge sets defect flags but claims severity "none" — trust the flags so
+    # the defect isn't scored as clean (CodeRabbit regression, PR #28).
+    v = _parse_verdict(
+        '{"overlap": true, "cutoff": false, "collisions": false, '
+        '"severity": "none", "issues": ["title overlaps box"]}'
+    )
+    assert v.severity == "minor"
+    assert v.has_defects
+
+
 def test_parse_invalid_severity_is_derived_from_flags():
     v = _parse_verdict(
         '{"overlap": true, "cutoff": false, "collisions": false, '

--- a/backend/tests/test_voiceover_cache_link.py
+++ b/backend/tests/test_voiceover_cache_link.py
@@ -1,0 +1,70 @@
+"""Tests for the runner-side persistent voiceover cache and concurrency parse."""
+
+from pathlib import Path
+
+from jobs.worker import parse_render_concurrency
+from rendering.local_runner import _link_persistent_voiceover_cache
+
+
+class TestVoiceoverCacheLink:
+    def test_symlinks_default_cache_to_persistent_per_scene_dir(self, tmp_path, monkeypatch):
+        cache_root = tmp_path / "persist"
+        monkeypatch.setenv("VOICEOVER_CACHE_DIR", str(cache_root))
+        media = tmp_path / "render" / "media"
+
+        _link_persistent_voiceover_cache(media, "AttentionScene")
+
+        link = media / "voiceovers"
+        assert link.is_symlink()
+        assert link.resolve() == (cache_root / "AttentionScene").resolve()
+        # Writes through manim-voiceover's default Path(media)/"voiceovers"
+        # land in the persistent target and survive the tmpdir's deletion.
+        (link / "cache.json").write_text("{}")
+        assert (cache_root / "AttentionScene" / "cache.json").read_text() == "{}"
+
+    def test_scene_name_is_sanitized_for_filesystem(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VOICEOVER_CACHE_DIR", str(tmp_path / "persist"))
+        media = tmp_path / "media"
+        _link_persistent_voiceover_cache(media, "Weird/Scene:Name!")
+        target = (media / "voiceovers").resolve()
+        assert target.name == "Weird_Scene_Name_"
+
+    def test_distinct_scenes_get_distinct_caches(self, tmp_path, monkeypatch):
+        # Per-scene isolation is what prevents concurrent renders from racing
+        # on a shared cache.json index.
+        monkeypatch.setenv("VOICEOVER_CACHE_DIR", str(tmp_path / "persist"))
+        media_a, media_b = tmp_path / "a" / "media", tmp_path / "b" / "media"
+        _link_persistent_voiceover_cache(media_a, "SceneA")
+        _link_persistent_voiceover_cache(media_b, "SceneB")
+        assert (media_a / "voiceovers").resolve() != (media_b / "voiceovers").resolve()
+
+    def test_failure_is_non_fatal(self, tmp_path, monkeypatch):
+        # Point the cache root at a path that cannot be created (a file).
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        monkeypatch.setenv("VOICEOVER_CACHE_DIR", str(blocker))
+        media = tmp_path / "media"
+        _link_persistent_voiceover_cache(media, "Scene")  # must not raise
+        assert not (media / "voiceovers").exists() or not (media / "voiceovers").is_symlink()
+
+
+class TestParseRenderConcurrency:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv("RENDER_CONCURRENCY", raising=False)
+        assert parse_render_concurrency() == 3
+
+    def test_valid_value(self, monkeypatch):
+        monkeypatch.setenv("RENDER_CONCURRENCY", "2")
+        assert parse_render_concurrency() == 2
+
+    def test_non_numeric_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("RENDER_CONCURRENCY", "many")
+        assert parse_render_concurrency() == 3
+
+    def test_empty_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("RENDER_CONCURRENCY", "")
+        assert parse_render_concurrency() == 3
+
+    def test_floor_of_one(self, monkeypatch):
+        monkeypatch.setenv("RENDER_CONCURRENCY", "0")
+        assert parse_render_concurrency() == 1

--- a/backend/tools/visual_qa_eval.py
+++ b/backend/tools/visual_qa_eval.py
@@ -33,7 +33,11 @@ async def main() -> int:
     args = parser.parse_args()
 
     async with httpx.AsyncClient(timeout=120) as http:
-        resp = await http.get(f"{args.api}/api/paper/{args.arxiv_id}")
+        try:
+            resp = await http.get(f"{args.api}/api/paper/{args.arxiv_id}")
+        except httpx.RequestError as exc:
+            print(f"could not reach {args.api}: {exc}")
+            return 1
         if resp.status_code != 200:
             print(f"paper {args.arxiv_id} not found ({resp.status_code})")
             return 1
@@ -53,15 +57,25 @@ async def main() -> int:
         print(f"{'viz':<20}{'severity':<10}{'ovl':<5}{'cut':<5}{'col':<5}issues")
 
         defects = 0
+        completed = 0
+        failed = 0
         for viz_id, url in videos:
-            video = await http.get(url)
+            try:
+                video = await http.get(url)
+            except httpx.RequestError as exc:
+                failed += 1
+                print(f"{viz_id:<20}download error: {exc}")
+                continue
             if video.status_code != 200:
+                failed += 1
                 print(f"{viz_id:<20}download failed ({video.status_code})")
                 continue
             verdict = await judge_video(video.content, viz_id=viz_id)
             if verdict is None:
+                failed += 1
                 print(f"{viz_id:<20}judge unavailable")
                 continue
+            completed += 1
             defects += 1 if verdict.has_defects else 0
             flag = lambda b: "Y" if b else "-"
             print(
@@ -70,8 +84,9 @@ async def main() -> int:
                 f"{'; '.join(verdict.issues[:2])[:80]}"
             )
 
-        print(f"\n{defects}/{len(videos)} videos have layout defects")
-        return 0
+        print(f"\n{defects}/{completed} judged videos have layout defects"
+              + (f" ({failed} could not be evaluated)" if failed else ""))
+        return 0 if failed == 0 else 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The critical one
CodeRabbit's post-merge review of #24 flagged that `SpeechService.__init__` stores an explicitly-passed `cache_dir` **as a raw string**, while its cache lookup does `cache_dir / CACHE_JSON` — pathlib division on a str. **Verified empirically: `TypeError: unsupported operand type(s) for /: 'str' and 'str'` on the first narration.** Every *newly generated* scene would have crashed at render time in production. The in-flight deploy was cancelled before the bug shipped; prod never ran it.

## The fix — persistence belongs to the runner, not the generated code
`local_runner` now symlinks manim-voiceover's **default** cache location (`Path(media_dir)/"voiceovers"` — already Path-typed) to a stable per-scene dir under `VOICEOVER_CACHE_DIR`. The snippet and few-shot examples revert to plain `transcription_model=None`.

Why this shape is strictly better:
- **No LLM involvement** — deterministic, works regardless of what the model emits
- **Kills the second CodeRabbit finding too**: per-scene cache targets mean concurrent renders never share (or race on) the same unlocked `cache.json` index
- **Fail-open**: a symlink failure logs a warning and falls back to the throwaway default

**Verified live** (real Azure TTS through `render_manim_local`, twice):
| Run | Time | What happened |
|---|---|---|
| 1 | 5.2s | narration synthesized + cached |
| 2 | **1.4s** | **cache hit** — no TTS call, no re-billing |

mp3 + cache.json persisted across both renders' tmpdirs.

## Also addressed (all 7 findings from #24 + #28 reviews)
- `parse_render_concurrency()`: invalid `RENDER_CONCURRENCY` → default 3 + warning, instead of failing the job at render setup; the log line reports the real value
- Visual QA: contradictory verdicts (defect flags + severity `"none"`) upgrade to `"minor"` (regression-tested); frame sampling off the event loop via `asyncio.to_thread`
- Render path: video **saves before** QA; QA dispatched as a supervised background task — enabling the flag can no longer delay video delivery
- Langfuse scoring failures logged (telemetry breakage distinguishable from unconfiguration)
- Prompt: label buff unified at 0.3; eval tool handles transport errors + exits nonzero on incomplete evaluations

## Tests
10 new (symlink cache incl. failure-safety + sanitization + per-scene isolation, concurrency parsing, severity contradiction) — **59 total pass**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent, scene-specific voiceover caching for local renders.
  * Visual quality checks now run in the background after videos are saved.
* **Bug Fixes**
  * Improved visual verdict handling when defect flags conflict with severity.
  * Invalid rendering-concurrency settings now fall back safely instead of preventing job setup.
  * Evaluation tools now report failed video checks accurately and return an appropriate failure status.
* **Documentation**
  * Updated animation guidance for improved label spacing.
* **Tests**
  * Added coverage for caching, concurrency settings, and visual-quality verdict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->