### PR TITLE
fix: don't let zombie jobs block re-processing via dedupe

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -79,6 +79,16 @@ async def start_processing(
     """
     arxiv_id = request.arxiv_id
 
+    # Opportunistic hygiene: jobs stranded at queued/processing by an
+    # interrupted worker would otherwise satisfy the dedupe check forever and
+    # block re-processing. Reap them before looking for an active job.
+    try:
+        reaped = await queries.reap_stale_jobs(db)
+        if reaped:
+            logger.info("Reaped %d stale job(s) before submission", reaped)
+    except Exception:
+        logger.exception("Stale-job reaping failed; continuing with submission")
+
     # Dedupe: an in-flight job for this paper is returned as-is. The in-memory
     # map covers the seconds before the worker links job.paper_id; the DB query
     # covers everything after (including submissions from other clients).

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -5,7 +5,7 @@ CRUD operations for papers, sections, visualizations, and processing jobs.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,24 +41,58 @@ async def get_job(db: AsyncSession, job_id: str) -> Optional[ProcessingJob]:
 
 
 async def get_active_job_for_paper(
-    db: AsyncSession, arxiv_id: str
+    db: AsyncSession, arxiv_id: str, max_age_hours: float = 2.0
 ) -> Optional[ProcessingJob]:
-    """Find an in-flight job for a paper, newest first.
+    """Find a genuinely in-flight job for a paper, newest first.
+
+    Jobs older than ``max_age_hours`` are ignored: a worker interrupted mid-run
+    (e.g. by a redeploy) strands its job at "processing" forever, and treating
+    such a zombie as active would block the paper from ever being re-processed
+    via dedupe. No real pipeline run approaches this age (p95 is ~7 minutes).
 
     Note: jobs are created with paper_id=None (FK) and linked by the worker a
     few seconds in, so this misses just-created jobs — callers pair it with the
     in-memory recent-jobs map in api.throttle for the immediate-duplicate window.
     """
+    cutoff = datetime.utcnow() - timedelta(hours=max_age_hours)
     result = await db.execute(
         select(ProcessingJob)
         .where(
             ProcessingJob.paper_id == arxiv_id,
             ProcessingJob.status.in_(("queued", "processing")),
+            ProcessingJob.created_at >= cutoff,
         )
         .order_by(ProcessingJob.created_at.desc())
         .limit(1)
     )
     return result.scalars().first()
+
+
+async def reap_stale_jobs(db: AsyncSession, max_age_hours: float = 2.0) -> int:
+    """Mark long-stranded queued/processing jobs as failed.
+
+    A worker killed mid-run (redeploy, crash, OOM) never updates its job row,
+    leaving it at "processing" forever — misleading pollers and, before the
+    dedupe staleness cutoff, blocking re-processing. Called opportunistically
+    on job submission; returns the number of jobs reaped.
+    """
+    cutoff = datetime.utcnow() - timedelta(hours=max_age_hours)
+    result = await db.execute(
+        select(ProcessingJob).where(
+            ProcessingJob.status.in_(("queued", "processing")),
+            ProcessingJob.created_at < cutoff,
+        )
+    )
+    stale = list(result.scalars().all())
+    for job in stale:
+        job.status = "failed"
+        job.error = (
+            "Job was interrupted (worker restarted mid-run) and never resumed. "
+            "Submit the paper again to re-process it."
+        )
+    if stale:
+        await db.commit()
+    return len(stale)
 
 
 async def update_job_status(

--- a/backend/tests/test_stale_job_dedupe.py
+++ b/backend/tests/test_stale_job_dedupe.py
@@ -1,0 +1,77 @@
+"""Tests for zombie-job handling in dedupe (in-memory SQLite, no network).
+
+Found in production: a job stranded at "processing" for 6 days (worker killed
+by a redeploy) satisfied the dedupe check, permanently blocking re-processing
+of its paper. Active-job lookup must ignore stale jobs, and submission reaps
+them so the jobs table tells the truth.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from db import queries
+from db.models import Base, ProcessingJob
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _add_job(db, job_id: str, paper_id: str, status: str, age_hours: float):
+    job = ProcessingJob(
+        id=job_id,
+        paper_id=paper_id,
+        status=status,
+        progress=0.5,
+        created_at=datetime.utcnow() - timedelta(hours=age_hours),
+    )
+    db.add(job)
+    await db.commit()
+    return job
+
+
+async def test_fresh_processing_job_is_active(db):
+    await _add_job(db, "job_fresh", "1706.03762", "processing", age_hours=0.1)
+    found = await queries.get_active_job_for_paper(db, "1706.03762")
+    assert found is not None and found.id == "job_fresh"
+
+
+async def test_zombie_job_is_not_treated_as_active(db):
+    # The production case: 6-day-old job stuck at "processing".
+    await _add_job(db, "job_zombie", "1706.03762", "processing", age_hours=144)
+    found = await queries.get_active_job_for_paper(db, "1706.03762")
+    assert found is None
+
+
+async def test_completed_jobs_are_never_active(db):
+    await _add_job(db, "job_done", "1706.03762", "completed", age_hours=0.1)
+    assert await queries.get_active_job_for_paper(db, "1706.03762") is None
+
+
+async def test_reap_marks_stale_jobs_failed_with_actionable_error(db):
+    await _add_job(db, "job_zombie", "1706.03762", "processing", age_hours=144)
+    await _add_job(db, "job_fresh", "2608.23554", "processing", age_hours=0.1)
+
+    reaped = await queries.reap_stale_jobs(db)
+    assert reaped == 1
+
+    zombie = await queries.get_job(db, "job_zombie")
+    assert zombie.status == "failed"
+    assert "interrupted" in zombie.error
+    fresh = await queries.get_job(db, "job_fresh")
+    assert fresh.status == "processing"  # untouched
+
+
+async def test_reap_noop_when_nothing_stale(db):
+    await _add_job(db, "job_fresh", "1706.03762", "processing", age_hours=0.1)
+    assert await queries.reap_stale_jobs(db) == 0


### PR DESCRIPTION
Found **live in production minutes after #30's dedupe shipped**: submitting `1706.03762` returned `job_31bda0e15150` — a job created **Aug 19**, stranded at `processing/0.5` when a redeploy killed its worker. The dedupe faithfully returned the corpse, so the paper could never be re-processed. (This is the dedupe interacting with the pre-existing zombie-job gap the roadmap's watchdog item describes.)

## Fix
- `get_active_job_for_paper` ignores queued/processing jobs older than `max_age_hours` (default **2h** — real pipeline runs finish in ~7 min).
- New `reap_stale_jobs()` marks stranded jobs **failed** with an actionable error ("worker restarted mid-run — submit again"), called opportunistically and fail-open on every submission. The jobs table stops lying to status pollers too.

## Verification
- 5 new DB-backed tests (in-memory SQLite) including the exact production case (144h-old processing job: not active, gets reaped; fresh job untouched)
- **64 total pass**

The fuller startup-reaper + heartbeat remains a roadmap item; this closes the user-facing hole.