### PR TITLE
feat: durable paper pipeline on Temporal (flag-gated, fail-open)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -129,8 +129,55 @@ async def start_processing(
     job_id = await queries.create_job(db, arxiv_id)
     recent_jobs.put(arxiv_id, job_id)
 
-    # Start background processing
-    background_tasks.add_task(process_paper_job, job_id, arxiv_id)
+    # Durable path (USE_TEMPORAL=1): start a Temporal workflow. Execution
+    # happens on the worker app and survives restarts/redeploys; the workflow
+    # ID makes duplicate submissions structurally impossible at the
+    # orchestrator. Fail-open: any Temporal error falls back to the legacy
+    # in-process BackgroundTasks path so paper processing never breaks on
+    # orchestrator trouble.
+    started_durably = False
+    from .temporal_client import temporal_enabled
+
+    if temporal_enabled():
+        try:
+            from .temporal_client import get_temporal_client
+            from temporal_app.workflows import TASK_QUEUE, PaperPipelineWorkflow
+            from temporal_app.activities import PipelineInput
+            from temporalio.exceptions import WorkflowAlreadyStartedError
+
+            temporal = await get_temporal_client()
+            try:
+                await temporal.start_workflow(
+                    PaperPipelineWorkflow.run,
+                    PipelineInput(job_id=job_id, arxiv_id=arxiv_id),
+                    id=f"paper-{arxiv_id}",
+                    task_queue=TASK_QUEUE,
+                )
+                started_durably = True
+            except WorkflowAlreadyStartedError:
+                # A workflow for this paper is already running (race past the
+                # cheap dedupe). Retire the row we just created and point the
+                # caller at the active job.
+                await queries.update_job_status(
+                    db, job_id, status="failed",
+                    error="Duplicate submission; another run was already in flight.",
+                )
+                recent_jobs.clear(arxiv_id)
+                active = await queries.get_active_job_for_paper(db, arxiv_id)
+                return ProcessResponse(
+                    job_id=active.id if active else job_id,
+                    arxiv_id=arxiv_id,
+                    status=JobStatus(active.status) if active else JobStatus.queued,
+                    message="This paper is already being processed. Poll /api/status/{job_id} for updates.",
+                )
+        except Exception:
+            logger.exception(
+                "Temporal unavailable — falling back to in-process pipeline"
+            )
+
+    if not started_durably:
+        # Legacy path: in-process background task (does not survive restarts).
+        background_tasks.add_task(process_paper_job, job_id, arxiv_id)
 
     return ProcessResponse(
         job_id=job_id,

--- a/backend/api/temporal_client.py
+++ b/backend/api/temporal_client.py
@@ -1,0 +1,28 @@
+"""Lazy, cached Temporal client for the API process.
+
+The API only ever *starts* workflows — all execution happens on the worker
+Container App. Kept in its own module so importing routes never touches
+Temporal when USE_TEMPORAL is off.
+"""
+
+from __future__ import annotations
+
+import os
+
+from temporalio.client import Client
+
+_client: Client | None = None
+
+
+def temporal_enabled() -> bool:
+    return os.getenv("USE_TEMPORAL", "0") == "1"
+
+
+async def get_temporal_client() -> Client:
+    global _client
+    if _client is None:
+        _client = await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+        )
+    return _client

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,47 +7,38 @@ dependencies = [
     # API framework
     "fastapi>=0.109.0",
     "uvicorn>=0.27.0",
-
     # Core AI + validation
     "pydantic>=2.0.0",
     "python-dotenv>=0.21.1,<0.22.0",
-
     # Async / transport
     "httpx>=0.25.0",
     "asyncio-throttle>=1.0.0",
-
     # Database / jobs
     "sqlalchemy>=2.0.0",
     "aiosqlite>=0.19.0",  # For local SQLite development
     "asyncpg>=0.29.0",     # For PostgreSQL (Neon, Supabase, Railway, etc.)
     "greenlet>=3.0.0",
-
     # Ingestion (Team 1)
     "arxiv>=2.0.0",
     "pymupdf4llm>=0.0.5",
     "pymupdf>=1.23.0",
     "beautifulsoup4>=4.12.0",
     "lxml>=5.0.0",
-
     # Rendering / visualization
     "manim>=0.18.0",
     "modal>=0.60.0",
     "manim-voiceover[gtts,openai]>=0.3.0",
-
     # Cloud storage (S3-compatible — Cloudflare R2)
     "boto3>=1.34.0",
-
     # LLM — Azure OpenAI (GPT-5 family; needs reasoning_effort support)
     "openai>=1.60.0",
-
     # Required by manim-voiceover (pkg_resources)
     "setuptools>=65.0.0",
-
     # Dedalus SDK + MCP Gateway (Context7 live docs)
     "dedalus-labs>=0.2.0",
-
     # Observability — LLM tracing / cost tracking
     "langfuse>=3.0.0",
+    "temporalio>=1.32.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/temporal_app/__init__.py
+++ b/backend/temporal_app/__init__.py
@@ -1,0 +1,2 @@
+"""Temporal orchestration package (kept import-light: the workflow sandbox
+re-imports this package, so its __init__ must never pull in the app graph)."""

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -1,0 +1,226 @@
+"""Temporal activities for the paper pipeline.
+
+Each activity is a thin, self-contained wrapper over the same building blocks
+the legacy BackgroundTasks path uses (`_ingest_and_store_paper`,
+`generate_visualizations`, `process_visualization`, `queries`). Activities open
+their own DB session (an AsyncSession is not safe to share across concurrent
+tasks) and keep writing job/viz status to the DB exactly as the legacy path
+does — the frontend's polling contract is unchanged.
+
+Why these boundaries: each activity is a durable checkpoint. If the worker dies
+mid-render (a redeploy — the exact failure that used to strand jobs at
+"processing" forever), the workflow resumes AFTER the last completed activity:
+the ~$0.07 LLM generation result is already checkpointed in workflow history,
+so only the interrupted render re-runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineInput:
+    job_id: str
+    arxiv_id: str
+
+
+@dataclass
+class RenderInput:
+    job_id: str
+    viz_id: str
+    manim_code: str
+
+
+@dataclass
+class RenderResult:
+    viz_id: str
+    succeeded: bool
+
+
+@dataclass
+class ProgressUpdate:
+    job_id: str
+    completed: int
+    total: int
+
+
+@activity.defn
+async def ingest_paper(params: PipelineInput) -> None:
+    """Fetch + parse the paper into the DB (skips if already present)."""
+    from db.connection import async_session_maker
+    from db import queries
+    from jobs.worker import _ingest_and_store_paper
+
+    async with async_session_maker() as db:
+        await queries.update_job_status(
+            db, params.job_id,
+            status="processing",
+            current_step="Fetching paper from arXiv",
+            progress=0.10,
+        )
+        if await queries.paper_exists(db, params.arxiv_id):
+            job = await queries.get_job(db, params.job_id)
+            if job:
+                job.paper_id = params.arxiv_id
+                await db.commit()
+            await queries.update_job_status(
+                db, params.job_id,
+                current_step="Paper already processed",
+                progress=0.30,
+            )
+            return
+        await _ingest_and_store_paper(db, params.job_id, params.arxiv_id)
+
+
+@activity.defn
+async def generate_visualizations_for_paper(params: PipelineInput) -> list[RenderInput]:
+    """Run the agent pipeline; upsert viz records; return render inputs.
+
+    The returned list is checkpointed in workflow history (~8KB of Manim code
+    per viz, well under Temporal's payload limits) — this is what makes
+    resume-without-re-paying-generation possible.
+    """
+    from db.connection import async_session_maker
+    from db import queries
+    from agents.pipeline import generate_visualizations
+    from jobs.worker import _build_structured_paper_from_db
+
+    try:
+        from langfuse import propagate_attributes
+    except ImportError:  # pragma: no cover
+        from contextlib import nullcontext
+
+        def propagate_attributes(**_kw):  # type: ignore
+            return nullcontext()
+
+    async with async_session_maker() as db:
+        await queries.update_job_status(
+            db, params.job_id,
+            current_step="Analyzing concepts for visualization",
+            progress=0.50,
+        )
+        db_paper = await queries.get_paper(db, params.arxiv_id)
+        db_sections = sorted(db_paper.sections, key=lambda s: s.order_index)
+        structured_paper = _build_structured_paper_from_db(db_paper, db_sections)
+
+    with propagate_attributes(
+        session_id=params.job_id,
+        trace_name="process-paper",
+        tags=["pipeline", "temporal"],
+        metadata={"arxiv_id": params.arxiv_id},
+    ):
+        generated = await generate_visualizations(structured_paper)
+
+    render_inputs: list[RenderInput] = []
+    paper_suffix = params.arxiv_id.replace(".", "")[:8]
+    async with async_session_maker() as db:
+        for i, viz in enumerate(generated):
+            viz_id = f"viz_{paper_suffix}_{i + 1}"
+            await queries.upsert_visualization(
+                db,
+                viz_id=viz_id,
+                paper_id=params.arxiv_id,
+                section_id=viz.section_id,
+                concept=viz.concept,
+                storyboard={"raw": viz.storyboard},
+                manim_code=viz.manim_code,
+                status="pending",
+            )
+            render_inputs.append(
+                RenderInput(job_id=params.job_id, viz_id=viz_id, manim_code=viz.manim_code)
+            )
+        if render_inputs:
+            await queries.update_job_status(
+                db, params.job_id,
+                current_step="Rendering videos",
+                progress=0.75,
+                sections_total=len(render_inputs),
+                sections_completed=0,
+            )
+    return render_inputs
+
+
+@activity.defn
+async def render_visualization(params: RenderInput) -> RenderResult:
+    """Render one video and record its status. Never raises for a render
+    failure — the outcome travels back to the workflow, which owns aggregation.
+    (Raising is reserved for infrastructure faults, which Temporal retries.)"""
+    from db.connection import async_session_maker
+    from db import queries
+    from rendering import process_visualization
+
+    succeeded = True
+    video_url: str | None = None
+    error: str | None = None
+    try:
+        video_url = await process_visualization(
+            viz_id=params.viz_id,
+            manim_code=params.manim_code,
+            quality="low_quality",
+        )
+    except Exception as exc:
+        succeeded = False
+        error = str(exc)
+        logger.error("Render failed for %s: %s", params.viz_id, error)
+
+    async with async_session_maker() as db:
+        await queries.update_visualization_status(
+            db, params.viz_id,
+            status="complete" if succeeded else "failed",
+            video_url=video_url,
+            error=error,
+        )
+    return RenderResult(viz_id=params.viz_id, succeeded=succeeded)
+
+
+@activity.defn
+async def update_render_progress(params: ProgressUpdate) -> None:
+    """Progress writes are driven by the workflow (which owns the counters),
+    so concurrent render activities never share mutable state."""
+    from db.connection import async_session_maker
+    from db import queries
+
+    async with async_session_maker() as db:
+        await queries.update_job_status(
+            db, params.job_id,
+            progress=0.75 + 0.20 * (params.completed / max(1, params.total)),
+            sections_completed=params.completed,
+        )
+
+
+@activity.defn
+async def finalize_job(params: ProgressUpdate) -> None:
+    """Write the honest terminal status (completed/failed + failure counts)."""
+    from db.connection import async_session_maker
+    from db import queries
+    from jobs.worker import resolve_terminal_job_status
+
+    status, step, error = resolve_terminal_job_status(params.completed, params.total)
+    async with async_session_maker() as db:
+        await queries.update_job_status(
+            db, params.job_id,
+            status=status,
+            current_step=step,
+            progress=1.0,
+            error=error,
+        )
+
+
+@activity.defn
+async def mark_job_failed(params: PipelineInput) -> None:
+    """Terminal failure marker for unrecoverable workflow errors."""
+    from db.connection import async_session_maker
+    from db import queries
+
+    async with async_session_maker() as db:
+        await queries.update_job_status(
+            db, params.job_id,
+            status="failed",
+            error="Pipeline failed after retries. See worker logs for details.",
+        )

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -1,0 +1,86 @@
+"""Temporal worker entrypoint.
+
+Runs two workers on one event loop:
+- ``paper-pipeline``: the workflow plus the light activities (ingest, generate,
+  progress, finalize). Generation is LLM-bound, not CPU-bound, so modest
+  concurrency is fine.
+- ``paper-render``: the CPU-heavy render activity only, capped at
+  RENDER_CONCURRENCY (same knob as the legacy path). Temporal server queues any
+  surplus renders — backpressure without shared semaphores.
+
+Deployed as its own Container App (same image as the API, different command),
+which also moves rendering OFF the API container — /api/status polling no
+longer competes with ffmpeg for CPU.
+
+Run: python -m temporal_app.worker  (from /app inside the container)
+Env: TEMPORAL_ADDRESS (host:port), TEMPORAL_NAMESPACE (default "default").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from temporal_app.activities import (
+    finalize_job,
+    generate_visualizations_for_paper,
+    ingest_paper,
+    mark_job_failed,
+    render_visualization,
+    update_render_progress,
+)
+from temporal_app.workflows import RENDER_TASK_QUEUE, TASK_QUEUE, PaperPipelineWorkflow
+from jobs.worker import parse_render_concurrency
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    address = os.getenv("TEMPORAL_ADDRESS", "localhost:7233")
+    namespace = os.getenv("TEMPORAL_NAMESPACE", "default")
+    render_concurrency = parse_render_concurrency()
+
+    logger.info("Connecting to Temporal at %s (namespace=%s)", address, namespace)
+    client = await Client.connect(address, namespace=namespace)
+    logger.info("Connected. Render concurrency: %d", render_concurrency)
+
+    pipeline_worker = Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[PaperPipelineWorkflow],
+        activities=[
+            ingest_paper,
+            generate_visualizations_for_paper,
+            update_render_progress,
+            finalize_job,
+            mark_job_failed,
+        ],
+    )
+    render_worker = Worker(
+        client,
+        task_queue=RENDER_TASK_QUEUE,
+        activities=[render_visualization],
+        max_concurrent_activities=render_concurrency,
+    )
+
+    logger.info(
+        "Workers running: %s (pipeline), %s (render, max %d concurrent)",
+        TASK_QUEUE, RENDER_TASK_QUEUE, render_concurrency,
+    )
+    await asyncio.gather(pipeline_worker.run(), render_worker.run())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -1,0 +1,127 @@
+"""The paper pipeline as a durable Temporal workflow.
+
+Why each Temporal feature is here (they all map to failures this project has
+actually had, not to technology enthusiasm):
+
+- Durable execution: a worker killed mid-run (redeploys did this twice) no
+  longer strands the job at "processing" forever — the workflow resumes after
+  the last completed activity, and the checkpointed generation result means the
+  LLM spend is never paid twice.
+- Workflow ID = ``paper-{arxiv_id}``: duplicate submissions become structurally
+  impossible at the orchestrator (the API's in-memory/DB dedupe remains as a
+  cheap first line, but this is the guarantee).
+- Per-activity retry policies: transient render failures (LaTeX/CPU
+  contention) retry once automatically; generation never auto-retries, because
+  a retry doubles real LLM spend and deserves a deliberate decision.
+- Orchestration state (completion counters) lives in the workflow, not in
+  shared mutable state between concurrent tasks — progress writes are issued
+  by the workflow as render results arrive.
+
+This module must stay sandbox-clean: no I/O, no heavy imports — activities
+carry all side effects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from temporal_app.activities import (
+        PipelineInput,
+        ProgressUpdate,
+        RenderInput,
+        RenderResult,
+        finalize_job,
+        generate_visualizations_for_paper,
+        ingest_paper,
+        mark_job_failed,
+        render_visualization,
+        update_render_progress,
+    )
+
+TASK_QUEUE = "paper-pipeline"
+RENDER_TASK_QUEUE = "paper-render"
+
+# Transient infra faults (network, DB hiccup) get one automatic retry.
+_INFRA_RETRY = RetryPolicy(maximum_attempts=2)
+# Generation is real money (~$0.07/paper of LLM spend) — never auto-retry.
+_NO_RETRY = RetryPolicy(maximum_attempts=1)
+
+
+@workflow.defn
+class PaperPipelineWorkflow:
+    """ingest → generate → parallel renders → honest finalize."""
+
+    @workflow.run
+    async def run(self, params: PipelineInput) -> str:
+        try:
+            await workflow.execute_activity(
+                ingest_paper,
+                params,
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=_INFRA_RETRY,
+            )
+
+            render_inputs: list[RenderInput] = await workflow.execute_activity(
+                generate_visualizations_for_paper,
+                params,
+                start_to_close_timeout=timedelta(minutes=25),
+                retry_policy=_NO_RETRY,
+            )
+
+            total = len(render_inputs)
+            if total == 0:
+                await self._finalize(params.job_id, succeeded=0, total=0)
+                return "no-visualizations"
+
+            # Start all renders; the render worker's concurrency cap does the
+            # throttling (Temporal queues the surplus — no semaphore needed).
+            render_tasks = [
+                workflow.execute_activity(
+                    render_visualization,
+                    ri,
+                    task_queue=RENDER_TASK_QUEUE,
+                    start_to_close_timeout=timedelta(minutes=15),
+                    retry_policy=_INFRA_RETRY,
+                )
+                for ri in render_inputs
+            ]
+
+            succeeded = 0
+            completed = 0
+            for task in asyncio.as_completed(render_tasks):
+                result: RenderResult = await task
+                completed += 1
+                if result.succeeded:
+                    succeeded += 1
+                await workflow.execute_activity(
+                    update_render_progress,
+                    ProgressUpdate(job_id=params.job_id, completed=completed, total=total),
+                    start_to_close_timeout=timedelta(minutes=1),
+                    retry_policy=_INFRA_RETRY,
+                )
+
+            await self._finalize(params.job_id, succeeded=succeeded, total=total)
+            return f"rendered {succeeded}/{total}"
+        except Exception:
+            # Mark the job failed so pollers see the truth, then let Temporal
+            # record the workflow failure with full history for debugging.
+            await workflow.execute_activity(
+                mark_job_failed,
+                params,
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=_INFRA_RETRY,
+            )
+            raise
+
+    async def _finalize(self, job_id: str, succeeded: int, total: int) -> None:
+        await workflow.execute_activity(
+            finalize_job,
+            ProgressUpdate(job_id=job_id, completed=succeeded, total=total),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=_INFRA_RETRY,
+        )

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -1,0 +1,152 @@
+"""Tests for the Temporal paper pipeline.
+
+Fast tests validate the module contracts (sandbox-safe imports, dataclasses).
+The integration tests run the REAL workflow against a local Temporal dev server
+(temporalio downloads it on first use) with mocked activities — proving
+orchestration order, success/failure aggregation, and workflow-ID dedupe.
+Integration tests are gated behind TEMPORAL_TESTS=1 to keep CI hermetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+from temporal_app.activities import PipelineInput, ProgressUpdate, RenderInput, RenderResult
+from temporal_app.workflows import RENDER_TASK_QUEUE, TASK_QUEUE, PaperPipelineWorkflow
+
+requires_temporal = pytest.mark.skipif(
+    os.getenv("TEMPORAL_TESTS") != "1",
+    reason="set TEMPORAL_TESTS=1 to run Temporal integration tests (downloads a local dev server)",
+)
+
+
+def test_workflow_module_is_sandbox_safe():
+    # Importing the workflow module must not drag in heavy/IO modules directly
+    # (they are gated behind imports_passed_through); reaching this line at all
+    # after the top-level imports proves definition-time sandbox safety.
+    assert PaperPipelineWorkflow is not None
+    assert TASK_QUEUE == "paper-pipeline"
+    assert RENDER_TASK_QUEUE == "paper-render"
+
+
+def test_dataclass_contracts():
+    p = PipelineInput(job_id="job_x", arxiv_id="1706.03762")
+    r = RenderInput(job_id="job_x", viz_id="viz_1", manim_code="code")
+    assert p.arxiv_id == "1706.03762" and r.viz_id == "viz_1"
+
+
+@requires_temporal
+class TestWorkflowOrchestration:
+    @pytest.fixture()
+    def calls(self):
+        return {"ingest": 0, "generate": 0, "render": [], "progress": [], "finalize": [], "failed": 0}
+
+    def _mock_activities(self, calls, viz_count=3, fail_viz_ids=frozenset()):
+        from temporalio import activity
+
+        @activity.defn(name="ingest_paper")
+        async def ingest(params: PipelineInput) -> None:
+            calls["ingest"] += 1
+
+        @activity.defn(name="generate_visualizations_for_paper")
+        async def generate(params: PipelineInput) -> list[RenderInput]:
+            calls["generate"] += 1
+            return [
+                RenderInput(job_id=params.job_id, viz_id=f"viz_{i}", manim_code=f"code{i}")
+                for i in range(1, viz_count + 1)
+            ]
+
+        @activity.defn(name="render_visualization")
+        async def render(params: RenderInput) -> RenderResult:
+            calls["render"].append(params.viz_id)
+            return RenderResult(viz_id=params.viz_id, succeeded=params.viz_id not in fail_viz_ids)
+
+        @activity.defn(name="update_render_progress")
+        async def progress(params: ProgressUpdate) -> None:
+            calls["progress"].append((params.completed, params.total))
+
+        @activity.defn(name="finalize_job")
+        async def finalize(params: ProgressUpdate) -> None:
+            calls["finalize"].append((params.completed, params.total))
+
+        @activity.defn(name="mark_job_failed")
+        async def failed(params: PipelineInput) -> None:
+            calls["failed"] += 1
+
+        return [ingest, generate, progress, finalize, failed], [render]
+
+    async def _run(self, calls, viz_count=3, fail_viz_ids=frozenset()):
+        from temporalio.testing import WorkflowEnvironment
+        from temporalio.worker import Worker
+
+        pipeline_acts, render_acts = self._mock_activities(calls, viz_count, fail_viz_ids)
+        async with await WorkflowEnvironment.start_local() as env:
+            async with Worker(
+                env.client, task_queue=TASK_QUEUE,
+                workflows=[PaperPipelineWorkflow], activities=pipeline_acts,
+            ), Worker(
+                env.client, task_queue=RENDER_TASK_QUEUE, activities=render_acts,
+            ):
+                wf_id = f"paper-test-{uuid.uuid4().hex[:8]}"
+                result = await env.client.execute_workflow(
+                    PaperPipelineWorkflow.run,
+                    PipelineInput(job_id="job_t", arxiv_id="1706.03762"),
+                    id=wf_id,
+                    task_queue=TASK_QUEUE,
+                )
+                return result
+
+    def test_happy_path_orders_and_aggregates(self, calls):
+        result = asyncio.run(self._run(calls, viz_count=3))
+        assert result == "rendered 3/3"
+        assert calls["ingest"] == 1 and calls["generate"] == 1
+        assert sorted(calls["render"]) == ["viz_1", "viz_2", "viz_3"]
+        # Progress is monotonically driven by the workflow as results arrive.
+        assert [c for c, _ in calls["progress"]] == [1, 2, 3]
+        assert calls["finalize"] == [(3, 3)]
+        assert calls["failed"] == 0
+
+    def test_partial_failure_reaches_finalize_with_honest_counts(self, calls):
+        result = asyncio.run(self._run(calls, viz_count=3, fail_viz_ids=frozenset({"viz_2"})))
+        assert result == "rendered 2/3"
+        assert calls["finalize"] == [(2, 3)]
+
+    def test_zero_visualizations_finalizes_as_empty(self, calls):
+        result = asyncio.run(self._run(calls, viz_count=0))
+        assert result == "no-visualizations"
+        assert calls["finalize"] == [(0, 0)]
+        assert calls["render"] == []
+
+    def test_duplicate_workflow_id_is_rejected(self, calls):
+        from temporalio.exceptions import WorkflowAlreadyStartedError
+        from temporalio.testing import WorkflowEnvironment
+        from temporalio.worker import Worker
+
+        async def run():
+            pipeline_acts, render_acts = self._mock_activities(calls, viz_count=1)
+            async with await WorkflowEnvironment.start_local() as env:
+                async with Worker(
+                    env.client, task_queue=TASK_QUEUE,
+                    workflows=[PaperPipelineWorkflow], activities=pipeline_acts,
+                ), Worker(env.client, task_queue=RENDER_TASK_QUEUE, activities=render_acts):
+                    handle = await env.client.start_workflow(
+                        PaperPipelineWorkflow.run,
+                        PipelineInput(job_id="job_a", arxiv_id="9999.00001"),
+                        id="paper-9999.00001",
+                        task_queue=TASK_QUEUE,
+                    )
+                    # Structural dedupe: same workflow ID while running -> rejected.
+                    with pytest.raises(WorkflowAlreadyStartedError):
+                        await env.client.start_workflow(
+                            PaperPipelineWorkflow.run,
+                            PipelineInput(job_id="job_b", arxiv_id="9999.00001"),
+                            id="paper-9999.00001",
+                            task_queue=TASK_QUEUE,
+                        )
+                    await handle.result()
+
+        asyncio.run(run())

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -176,6 +176,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "setuptools" },
     { name = "sqlalchemy" },
+    { name = "temporalio" },
     { name = "uvicorn" },
 ]
 
@@ -211,6 +212,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=0.21.1,<0.22.0" },
     { name = "setuptools", specifier = ">=65.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "temporalio", specifier = ">=1.32.0" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
 provides-extras = ["dev"]
@@ -1345,6 +1347,18 @@ wheels = [
 ]
 
 [[package]]
+name = "nexus-rpc"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2231,6 +2245,27 @@ wheels = [
 ]
 
 [[package]]
+name = "temporalio"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nexus-rpc" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/d8/18cf5bbbcc4b4c884d7723c9b54bf8d1d2556d9fbef3e99599dd3db12034/temporalio-1.32.0.tar.gz", hash = "sha256:2cfa50ec7ebdab66902b80c3a09da3258883d68540811ebfbf44f7f293a4d7d0", size = 2997642, upload-time = "2026-08-24T21:24:37.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/0b/adad9dcd8b96c760cd04dcc75f0a0f136aabdb78c4b180219589749469a4/temporalio-1.32.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:47c128732e5d49235c9daeeb084d55093cee5ebc200ccc3afaeb4468f08d809e", size = 13796063, upload-time = "2026-08-24T21:24:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/84/6cc96518a2aff3ce9fb132479811bb29db563fbcdc947c279df8f089721a/temporalio-1.32.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e78a209dc5ef3303bc6a3033fe11ffd813b778e4b176ec18d20386d65952daa9", size = 13467827, upload-time = "2026-08-24T21:24:19.731Z" },
+    { url = "https://files.pythonhosted.org/packages/92/d0/720e5e9bb51ae1af6b9fea4d5c56d6ac6e94fbf4c8b86a6b0b318b6aef1e/temporalio-1.32.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a86be3a6d237ea6cc2d632015a5df4cead2aa3143b9601721428b53b87df81e2", size = 13854003, upload-time = "2026-08-24T21:24:22.743Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6b/8c8973ad314efc8c124e9a0f602ae96533c7e624b3cde7fcc9704aa46dd2/temporalio-1.32.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd44a60ba54901560011a32f085353c0f5e7dac6b8d7a7e0c7c4ba508c6bf5d", size = 14193177, upload-time = "2026-08-24T21:24:25.849Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ad/7496f8424a6ccc9b6ce6c629f9375744e8a439e9a692bd27b4f77b99977a/temporalio-1.32.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6a7100b1f1bf781f8f1800f89bb787b3dd7ce883e78603442d0c7a40e1143a86", size = 13920043, upload-time = "2026-08-24T21:24:28.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/16/73fa24d69e70035323217e87d33cb3df6415e1906db07b2112c9a6b09e33/temporalio-1.32.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:311abb9f0650f4ad9f24944ef16d8ed47954ddc3075c1e8c73dcd968d70ccdce", size = 14309243, upload-time = "2026-08-24T21:24:31.727Z" },
+    { url = "https://files.pythonhosted.org/packages/07/72/4a49f38f294f9cc1ba15c0b5272adfa7d2a0da38e924ed7f0b1ea2e5bbc9/temporalio-1.32.0-cp310-abi3-win_amd64.whl", hash = "sha256:158386bcd9a6dce1ab63d732fc967c5a5830e15c3012ffaa4b8772bdac099e0f", size = 15196754, upload-time = "2026-08-24T21:24:34.931Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2282,6 +2317,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.35.1.20260825"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/5f/e6daccd9249d8cb21b59cf5638c3be4d86575212f351b8aad33369f5e743/types_protobuf-7.35.1.20260825.tar.gz", hash = "sha256:37997789e1255571db9991fd80d1663cfb50a974820ff3eaa8e51139a9a6d65e", size = 69624, upload-time = "2026-08-25T02:48:32.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/2d/029d9846615bfeb872c3bd2ddaa030caf1e26ddc2aaeb24ca01cc1821761/types_protobuf-7.35.1.20260825-py3-none-any.whl", hash = "sha256:5be41ee0ffcd2bf36e8b66cb90e58631f7bcf7cd31083b75de780f1218c96173", size = 86412, upload-time = "2026-08-25T02:48:30.975Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds Temporal as the durable orchestrator for the paper pipeline — **flag-gated (`USE_TEMPORAL`, default OFF), fail-open, and merging changes nothing at runtime.**

## Why each Temporal feature is here (all map to failures we actually had)
| Feature | The scar it heals |
|---|---|
| **Durable execution** | Two redeploys stranded jobs at "processing" forever (the zombie bug). A killed worker now *resumes* after the last completed activity. |
| **Checkpointed activity results** | A restart mid-render used to lose the ~$0.07 LLM generation spend. The generated code is in workflow history — only the interrupted render re-runs. |
| **Workflow ID = `paper-{arxiv_id}`** | Duplicate submissions become structurally impossible at the orchestrator (the cheap API dedupe stays as first line). |
| **Per-activity retry policies** | Transient render/infra faults retry once automatically; **generation never auto-retries** (a retry doubles real LLM spend). |
| **Task-queue concurrency caps** | Render throttling via `max_concurrent_activities` on a dedicated `paper-render` queue — Temporal queues the surplus; no shared semaphores. |

## Design
- `temporal_app/` — import-light package (the workflow sandbox re-imports it): `activities.py` (thin wrappers over the **same stage functions the legacy path uses** — DB status writes identical, frontend polling contract unchanged), `workflows.py` (sandbox-clean orchestration; progress counters live in the workflow, not shared state), `worker.py` (two workers; deploys as its **own Container App**, which also moves CPU-heavy renders off the API container).
- `api/routes.py` — when `USE_TEMPORAL=1`: start the workflow; on `WorkflowAlreadyStarted`, retire the fresh job row and return the active job; on **any Temporal error, fall back to the legacy BackgroundTasks path** (processing never breaks on orchestrator trouble).

## Verification
- **4 real orchestration tests** against a local Temporal dev server (mocked activities): execution order, partial-failure aggregation (`2/3` reaches finalize), zero-viz path, duplicate-ID rejection. Gated behind `TEMPORAL_TESTS=1` so CI stays hermetic; all pass locally.
- 2 fast contract tests run in CI. Full suite: **66 passed**.

## Infra (created via CLI; the upcoming Terraform step codifies it)
Internal-only Container App `arxivisual-temporal` (auto-setup 1.23.1.1, TCP 7233 — never internet-reachable), persisting to the existing Postgres (`temporal` + `temporal_visibility` DBs). Azure wrinkles solved along the way: `SQL_TLS_ENABLED` (server-side TLS envs differ from the schema tool's), `BTREE_GIN` allow-listing, and `SQL_MAX_CONNS` capped for the B1ms connection budget.

## Rollout plan (after merge)
1. Deploy API image; create the `arxivisual-worker` app (same image, command `python -m temporal_app.worker`).
2. Flip `USE_TEMPORAL=1` on the API; run a real paper end-to-end.
3. **The money demo**: restart the worker replica mid-render and watch the workflow resume without re-paying generation.
4. If anything misbehaves: unset the flag — instant revert to the legacy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable background processing for paper workflows, including progress tracking and visualization rendering.
  * Added parallel rendering with retry handling and partial-failure reporting.
  * Added duplicate-job protection to prevent concurrent processing of the same paper.
  * Added fallback processing when durable workflow services are unavailable.
* **Bug Fixes**
  * Improved job status updates and final success or failure reporting across processing stages.
* **Tests**
  * Added coverage for orchestration, progress aggregation, empty results, partial failures, and duplicate jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->