### PR TITLE
fix: reach Temporal via HTTP/2 ingress with TLS

### DIFF
--- a/backend/api/temporal_client.py
+++ b/backend/api/temporal_client.py
@@ -24,5 +24,8 @@ async def get_temporal_client() -> Client:
         _client = await Client.connect(
             os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
             namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+            # Container Apps fronts gRPC with HTTP/2 ingress behind TLS (:443);
+            # raw TCP ingress proved unroutable on this environment.
+            tls=os.getenv("TEMPORAL_TLS", "0") == "1",
         )
     return _client

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -52,8 +52,13 @@ async def main() -> None:
     namespace = os.getenv("TEMPORAL_NAMESPACE", "default")
     render_concurrency = parse_render_concurrency()
 
-    logger.info("Connecting to Temporal at %s (namespace=%s)", address, namespace)
-    client = await Client.connect(address, namespace=namespace)
+    use_tls = os.getenv("TEMPORAL_TLS", "0") == "1"
+    logger.info(
+        "Connecting to Temporal at %s (namespace=%s, tls=%s)", address, namespace, use_tls
+    )
+    # Container Apps fronts gRPC with HTTP/2 ingress behind TLS (:443);
+    # raw TCP ingress proved unroutable on this environment.
+    client = await Client.connect(address, namespace=namespace, tls=use_tls)
     logger.info("Connected. Render concurrency: %d", render_concurrency)
 
     pipeline_worker = Worker(


### PR DESCRIPTION
Follow-up to #49. Raw **TCP ingress proved unroutable** on the Container Apps environment — a raw socket probe from inside the environment times out even with `exposedPort` set and the server verifiably serving (live matching-engine logs). gRPC is HTTP/2, so this switches to ACA's standard gRPC pattern: **http2 ingress**, envoy terminating TLS on :443 and forwarding h2c to the Temporal frontend. `TEMPORAL_TLS=1` enables client TLS on both the API client and worker; default stays plaintext for local dev. Ingress already flipped on the server app (config-only). 66 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS connections for Temporal services.
  * TLS can be enabled through the `TEMPORAL_TLS` setting.
  * Connection logs now display the active TLS configuration and ingress details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->