### PR TITLE
feat(infra): Terraform codification of all Azure infrastructure

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+# Gitleaks configuration — extends the default ruleset.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Container image tags pinned to git commit SHAs (gh-<sha>) are public identifiers, not secrets; gitleaks' generic-api-key rule trips on their entropy."
+regexes = [
+  '''azurecr\.io/arxivisual-api:gh-[0-9a-f]{40}''',
+]

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,12 @@
+# Local Terraform working files
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Real variable values must never be committed (use terraform.tfvars.example
+# as the template). The dependency lock file IS committed on purpose.
+terraform.tfvars
+*.auto.tfvars
+
+# Local backend override used only for offline plan dry-runs
+backend_override.tf

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.12.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:unl+E0lyguiwVrP5lhbhn8yziGUs+0tuMVb28+qml90=",
+    "zh:2ba5c73930feaf804f8ed0358125706851993a2b959b531eb1019d718a302c42",
+    "zh:41e8188d87fad3db77769597a2d8c394b6bbd760a439c2dd5cf9365ed5f4576a",
+    "zh:4ba8d91c674fc866127b03a4ef4b1cd7836de61d3abddfd0d4b2245ec7d33bca",
+    "zh:63ffa2987b448b964ee335128420e65bf274dc0159568316fcb985b9d4958e63",
+    "zh:6801067f24557117c49cbeb76cc995351a0bfc8a44de47276d5c615284f43fe8",
+    "zh:6ac8b5b262fa3d79f8aa104e903f258ec83b0155f6988cba0f3b028edad323d0",
+    "zh:71402acfa1ad35788a5d1669bdd59040434a45aea990d062dcc41f17163c8e1b",
+    "zh:8e0f6b5f8de9dc6cf59ce338fb78c9fc0cd36b0fd424702620214fa1ea93f2e0",
+    "zh:94b266d1a096e41759d2c564dac1fda9c4a023806b5f3e3bc90e114378b2f423",
+    "zh:a650532fd8a06ce0cea1ae89ac20007d06b1246660e9d07ef7352db653c8a5eb",
+    "zh:bbe9018472ad804d60c471157eef6c959b272a741bb7476df9bd6650da6af7a3",
+    "zh:d2edcc0b716848c20c13ee88529be55c9a82f08a368bfd201945791edc4e15a2",
+    "zh:f193175c87376a70d387cf69ab458684b9ea76b0954b00480446cdf278c3076d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:caKVAk5GOECNATz8XPruo39n2y6OcntxPblPgl+6QaY=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:39b11a075e4baa4f6ed5c72a8427013d50f43eecc1a7603b73bccf80f952f758",
+    "zh:41484c196c943b39411f561e70a308bd2a71da18155bfec7381ba0bd61361d34",
+    "zh:42068e5da223494beea5f7fcb9057c308cbfa92f96e53c50083e2639216479d8",
+    "zh:464d7da44682443a4b64bfdaf3d0eb53011c6e1471f244f6354c4d5bca18edce",
+    "zh:49f597ea3fac39931ff91e55afd5b5cc91e449920a03716f82509d588aaab708",
+    "zh:6092c376accfc50b555b7a0cd56b76c09abc3d65ac9dd5069063d6f9f1e76d3b",
+    "zh:65326a9f3ac0783c16e05c16422d191f0a926b8d021fd5303c1fdf8dc42f16e9",
+    "zh:784214ed809347d74562bb38194c0cef57831eaa621ba3b7cdd3fe7a7a76d844",
+    "zh:b4233f9bc791adc7d6643507fa5b47360a21125763a072d953586151cacb65f9",
+    "zh:c4ecdd995ff99b7e362e087c45f080816bcf097da5be257c87b912210e45dd3e",
+    "zh:f0122771f71cb98248e70cdd6c2ccd3bffb34e79d19897fa28b785c86b2312ed",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:XhToZua4gtih1Kv8RdStcfND83G4Tmb6GZFT4jEUhDU=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}

--- a/infra/PLAN_SNAPSHOT.txt
+++ b/infra/PLAN_SNAPSHOT.txt
@@ -1,0 +1,27 @@
+  # azapi_resource.billing_monthly_reset_budget will be imported
+  # azuread_application.github_deploy will be imported
+  # azuread_application_federated_identity_credential.github_main will be imported
+  # azuread_service_principal.github_deploy will be imported
+  # azurerm_cognitive_account.openai will be imported
+  # azurerm_cognitive_deployment.gpt_4o_mini_tts will be imported
+  # azurerm_cognitive_deployment.gpt_5_6_sol will be imported
+  # azurerm_cognitive_deployment.gpt_5_mini will be imported
+  # azurerm_consumption_budget_subscription.monthly will be imported
+  # azurerm_container_app.api will be imported
+  # azurerm_container_app.temporal will be updated in-place
+  # azurerm_container_app.worker will be updated in-place
+  # azurerm_container_app_environment.main will be imported
+  # azurerm_container_registry.main will be imported
+  # azurerm_log_analytics_workspace.main will be updated in-place
+  # azurerm_postgresql_flexible_server.main will be updated in-place
+  # azurerm_postgresql_flexible_server_configuration.azure_extensions will be imported
+  # azurerm_postgresql_flexible_server_database.arxiviz will be imported
+  # azurerm_postgresql_flexible_server_database.temporal will be imported
+  # azurerm_postgresql_flexible_server_database.temporal_visibility will be imported
+  # azurerm_postgresql_flexible_server_firewall_rule.allow_azure_services will be imported
+  # azurerm_resource_group.main will be imported
+  # azurerm_role_assignment.api_acr_pull will be imported
+  # azurerm_role_assignment.github_deploy_contributor will be imported
+  # azurerm_storage_account.tfstate will be imported
+  # azurerm_storage_container.tfstate will be imported
+Plan: 26 to import, 0 to add, 4 to change, 0 to destroy.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,131 @@
+# arXivisual Infrastructure (Terraform)
+
+Terraform codification of the **live, production** arXivisual Azure
+infrastructure. Everything here was created by hand (az CLI / portal / GitHub
+Actions) and is being adopted into Terraform via `import` blocks so that the
+infra is reproducible and reviewable.
+
+> **WARNING: `terraform apply` touches production.** The Container Apps serve
+> arxivisual.org right now. Always run `terraform plan` first, read every diff,
+> and only apply when the plan matches the "Known first-apply diffs" list below
+> (plus whatever change you intended).
+
+## What this manages
+
+| File | Resources |
+|---|---|
+| `main.tf` | Resource group `arxivisual-rg` (eastus2) |
+| `registry.tf` | ACR `ca82c08e2eadacr` (Basic, admin enabled) + AcrPull role for the API app's system identity |
+| `openai.tf` | Azure OpenAI account `arxivisual-openai` + deployments `gpt-5-mini` (2025-08-07, GlobalStandard 250), `gpt-4o-mini-tts` (2025-12-15, GlobalStandard 50), `gpt-5.6-sol` (2026-07-09, GlobalStandard 250) |
+| `database.tf` | Postgres flexible server `arxivisual-db` (**westus3**, B1ms, PG16, 32GB); databases `arxiviz`, `temporal`, `temporal_visibility`; `azure.extensions=BTREE_GIN`; allow-Azure-services firewall rule |
+| `container_apps.tf` | Log Analytics workspace, managed environment `arxivisual-api-env`, and the three apps: `arxivisual-api` (external HTTP :8000), `arxivisual-temporal` (internal TCP :7233), `arxivisual-worker` (no ingress) |
+| `budgets.tf` | Subscription budget `arxivisual-monthly` ($300, 50%/90%/forecast-100% alerts) and billing-account budget `MonthlyReset` ($5) via **azapi** (azurerm has no billing-account budget resource) |
+| `github_oidc.tf` | Entra app `arxivisual-github-deploy`, its service principal, the GitHub OIDC federated credential (`repo:rajshah6/arXivisual:ref:refs/heads/main`), and its Contributor role on the RG |
+| `state.tf` | The `arxivisualtfstate` storage account + `tfstate` container (the backend manages state *in* it and Terraform also *manages* it) |
+| `imports.tf` | One `import` block per resource above |
+
+Not managed here: Vercel (frontend), Cloudflare R2 (object storage), Langfuse.
+
+## Bootstrap history
+
+The state storage account `arxivisualtfstate` and its `tfstate` container were
+created manually with the az CLI before the first `terraform init`
+(chicken-and-egg: the backend must exist before Terraform can run). They are
+also imported and managed by `state.tf`, so drift on them is visible like
+everything else.
+
+## Backend / auth
+
+State lives in `azurerm` backend
+`arxivisual-rg/arxivisualtfstate/tfstate/arxivisual.tfstate`.
+
+`use_azuread_auth = true` was attempted and **fails** with
+`AuthorizationPermissionMismatch`: the signed-in identity is subscription
+Owner, which has no blob *data-plane* role. The backend therefore uses its
+default flow - it lists the storage account keys via ARM (allowed for Owner)
+and authenticates to blob storage with the shared key. To move to AAD auth
+later:
+
+```sh
+az role assignment create \
+  --assignee <your-object-id> \
+  --role "Storage Blob Data Contributor" \
+  --scope "$(az storage account show -n arxivisualtfstate -g arxivisual-rg --query id -o tsv)"
+# then add `use_azuread_auth = true` back to the backend block in versions.tf
+```
+
+Provider auth is Azure CLI (`az login`) for azurerm, azuread, and azapi.
+
+## Usage
+
+```sh
+cd infra
+terraform init                       # backend + providers
+terraform validate
+terraform plan                       # review! see "Known first-apply diffs"
+terraform apply                      # ONLY after the plan is fully understood
+```
+
+Use the pinned Terraform version from `.terraform.lock.hcl`'s era (built and
+verified with Terraform 1.15.x, azurerm 4.81, azuread 3.9, azapi 2.12). Commit
+`.terraform.lock.hcl`; never commit `.terraform/`, state files, or
+`terraform.tfvars`.
+
+## Secrets
+
+No secret value exists anywhere in this directory. Every secret-bearing
+attribute reads a `sensitive = true` variable (see `variables.tf`):
+
+`postgres_admin_password`, `database_url`, `azure_openai_api_key`,
+`s3_access_key`, `s3_secret_key`, `langfuse_public_key`,
+`langfuse_secret_key`, `acr_admin_password`.
+
+Supply them either as environment variables:
+
+```sh
+export TF_VAR_postgres_admin_password='...'
+export TF_VAR_database_url='...'
+# ... etc
+```
+
+or in an untracked `terraform.tfvars` copied from
+`terraform.tfvars.example` (git-ignored - **never commit it**).
+
+For `plan` the actual values don't matter (Terraform can't diff them against
+Azure anyway); for the first `apply` they MUST be the real live values,
+because that apply re-submits every container app secret and the Postgres
+admin password. In particular `postgres_admin_password` must be the *current*
+DB password or the first apply will change it out from under the running apps.
+
+## Import-block lifecycle
+
+`imports.tf` maps every existing Azure resource ID to its Terraform address.
+`terraform plan` shows them as "N to import"; the first successful
+`terraform apply` records them in state. After that first apply the import
+blocks are inert and `imports.tf` can be deleted in a follow-up commit.
+
+## Known first-apply diffs
+
+The verified plan is: **26 to import, 0 to add, 5 to change, 0 to destroy**
+(see `PLAN_SNAPSHOT.txt`). No replacements, no destroys. The five in-place
+updates are benign:
+
+| Resource | Diff | Why it's benign |
+|---|---|---|
+| all 3 container apps | `- secret` / `+ secret` blocks | The ACA API never returns secret values, so imported state has none; first apply rewrites the identical values from the vars. |
+| `arxivisual-temporal` | probe `timeout 0 -> 1`, `success_count_threshold 0 -> 1` | Platform probe defaults made explicit; ingress is declared as the live http2 transport (gRPC via envoy TLS on :443). |
+| `arxivisual-temporal` | probe `timeout 0 -> 1`, readiness `success_count_threshold 0 -> 1` | The live probes omit these fields; 1/1 are the platform defaults already in effect, now written explicitly. |
+| `workspace-arxivisualrg2OvU` | `+ local_authentication_enabled = true` | API does not return the field; `true` is the current live behavior (local auth was never disabled). |
+| `arxivisual-db` | `+ administrator_password` | ARM never returns the password; the first apply re-submits `var.postgres_admin_password`. Supply the current live password. |
+
+Anything on a plan beyond this list (or beyond an intentional change) should
+be treated as a red flag - stop and investigate before applying.
+
+## azapi usage
+
+`MonthlyReset` is a Cost Management budget scoped to the *billing account*
+(`Microsoft.Billing/billingAccounts/...`), a scope the azurerm provider cannot
+express (`azurerm_consumption_budget_*` covers subscription / resource group /
+management group only). It is modeled as
+`azapi_resource` (`Microsoft.CostManagement/budgets@2023-11-01`) in
+`budgets.tf`. Everything else is plain azurerm/azuread.

--- a/infra/budgets.tf
+++ b/infra/budgets.tf
@@ -1,0 +1,84 @@
+# Subscription-scoped monthly cost budget ($300 in the billing currency) with
+# email alerts at 50% / 90% actual and 100% forecast.
+resource "azurerm_consumption_budget_subscription" "monthly" {
+  name            = "arxivisual-monthly"
+  subscription_id = "/subscriptions/${var.subscription_id}"
+
+  amount     = 300
+  time_grain = "Monthly"
+
+  time_period {
+    start_date = "2026-08-01T00:00:00Z"
+    end_date   = "2028-07-31T00:00:00Z"
+  }
+
+  notification {
+    enabled        = true
+    operator       = "GreaterThan"
+    threshold      = 50
+    threshold_type = "Actual"
+    contact_emails = ["ajithbon05@gmail.com"]
+  }
+
+  notification {
+    enabled        = true
+    operator       = "GreaterThan"
+    threshold      = 90
+    threshold_type = "Actual"
+    contact_emails = ["ajithbon05@gmail.com"]
+  }
+
+  notification {
+    enabled        = true
+    operator       = "GreaterThan"
+    threshold      = 100
+    threshold_type = "Forecasted"
+    contact_emails = ["ajithbon05@gmail.com"]
+  }
+}
+
+# "MonthlyReset" is a $5 budget scoped to the BILLING ACCOUNT (Microsoft
+# Customer Agreement), not the subscription or resource group. azurerm has no
+# resource type for billing-account budgets, so it is expressed with azapi.
+resource "azapi_resource" "billing_monthly_reset_budget" {
+  type      = "Microsoft.CostManagement/budgets@2023-11-01"
+  name      = "MonthlyReset"
+  parent_id = "/providers/Microsoft.Billing/billingAccounts/3f54dc1c-3b08-5841-bb04-33a83cf4e3a7:9dc3de7a-80d3-4d17-baf3-665da89267cd_2019-05-31"
+
+  body = {
+    properties = {
+      amount    = 5
+      category  = "Cost"
+      timeGrain = "Monthly"
+
+      timePeriod = {
+        startDate = "2026-07-01T00:00:00Z"
+        endDate   = "2030-06-30T00:00:00Z"
+      }
+
+      notifications = {
+        actual_GreaterThan_50_Percent = {
+          contactEmails = ["ajithbon05@gmail.com"]
+          enabled       = true
+          operator      = "GreaterThan"
+          threshold     = 50
+          thresholdType = "Actual"
+        }
+        actual_GreaterThan_80_Percent = {
+          contactEmails = ["ajithbon05@gmail.com"]
+          enabled       = true
+          operator      = "GreaterThan"
+          threshold     = 80
+          thresholdType = "Actual"
+        }
+        forecasted_GreaterThan_100_Percent = {
+          contactEmails = ["ajithbon05@gmail.com"]
+          enabled       = true
+          operator      = "GreaterThan"
+          threshold     = 100
+          thresholdType = "Forecasted"
+        }
+      }
+    }
+  }
+}

--- a/infra/container_apps.tf
+++ b/infra/container_apps.tf
@@ -1,0 +1,499 @@
+# Log Analytics workspace backing the Container Apps environment (auto-named
+# by the portal when the environment was created).
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = "workspace-arxivisualrg2OvU"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+# Container Apps managed environment (workload-profiles mode, Consumption
+# profile only).
+resource "azurerm_container_app_environment" "main" {
+  name                = "arxivisual-api-env"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  logs_destination           = "log-analytics"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
+}
+
+locals {
+  app_image = "ca82c08e2eadacr.azurecr.io/arxivisual-api:gh-d19c154f03c9b9d59a15510d932d9955d60da5ae"
+}
+
+# ---------------------------------------------------------------------------
+# arxivisual-api: external FastAPI service on port 8000.
+# Pulls its image with a system-assigned identity (AcrPull, see registry.tf).
+# ---------------------------------------------------------------------------
+resource "azurerm_container_app" "api" {
+  # The deploy workflow (gh-<sha> tags) owns the image; Terraform owns
+  # everything else. Without this, every CD deploy would appear as drift.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
+  name                         = "arxivisual-api"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8000
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server   = "ca82c08e2eadacr.azurecr.io"
+    identity = "system" # lowercase to match what the ACA API stores; "System" causes a perpetual cosmetic diff
+  }
+
+  secret {
+    name  = "database-url"
+    value = var.database_url
+  }
+  secret {
+    name  = "s3-access-key"
+    value = var.s3_access_key
+  }
+  secret {
+    name  = "s3-secret-key"
+    value = var.s3_secret_key
+  }
+  secret {
+    name  = "azure-openai-api-key"
+    value = var.azure_openai_api_key
+  }
+  secret {
+    name  = "langfuse-public-key"
+    value = var.langfuse_public_key
+  }
+  secret {
+    name  = "langfuse-secret-key"
+    value = var.langfuse_secret_key
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 2
+
+    container {
+      name   = "arxivisual-api"
+      image  = local.app_image
+      cpu    = 2.0
+      memory = "4Gi"
+
+      env {
+        name  = "LLM_PROVIDER"
+        value = "azure"
+      }
+      env {
+        name  = "AZURE_OPENAI_ENDPOINT"
+        value = "https://arxivisual-openai.openai.azure.com"
+      }
+      env {
+        name        = "AZURE_OPENAI_API_KEY"
+        secret_name = "azure-openai-api-key"
+      }
+      env {
+        name  = "AZURE_OPENAI_DEPLOYMENT"
+        value = "gpt-5-mini"
+      }
+      env {
+        name  = "STORAGE_MODE"
+        value = "r2"
+      }
+      env {
+        name  = "S3_ENDPOINT"
+        value = "https://0c4b2250cd401bcd63be9985bae2710a.r2.cloudflarestorage.com"
+      }
+      env {
+        name  = "S3_BUCKET"
+        value = "arxivisual"
+      }
+      env {
+        name        = "S3_ACCESS_KEY"
+        secret_name = "s3-access-key"
+      }
+      env {
+        name        = "S3_SECRET_KEY"
+        secret_name = "s3-secret-key"
+      }
+      env {
+        name  = "S3_PUBLIC_URL"
+        value = "https://pub-c68fa9a916b34af1bcbdb557f12d9287.r2.dev"
+      }
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "RENDER_MODE"
+        value = "local"
+      }
+      env {
+        name  = "AZURE_OPENAI_REASONING_EFFORT"
+        value = "medium"
+      }
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+      env {
+        name        = "LANGFUSE_PUBLIC_KEY"
+        secret_name = "langfuse-public-key"
+      }
+      env {
+        name        = "LANGFUSE_SECRET_KEY"
+        secret_name = "langfuse-secret-key"
+      }
+      env {
+        name  = "LANGFUSE_HOST"
+        value = "https://us.cloud.langfuse.com"
+      }
+      env {
+        name  = "LANGFUSE_TRACING_ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "ENABLE_VISUAL_QA"
+        value = "1"
+      }
+      env {
+        name  = "VISUAL_QA_MODEL"
+        value = "gpt-5.6-sol"
+      }
+
+      env {
+        name  = "USE_TEMPORAL"
+        value = "1"
+      }
+
+      env {
+        name  = "TEMPORAL_ADDRESS"
+        value = "arxivisual-temporal.internal.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io:443"
+      }
+
+      env {
+        name  = "TEMPORAL_TLS"
+        value = "1"
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# arxivisual-temporal: Temporal server (auto-setup image) on internal TCP 7233.
+# ---------------------------------------------------------------------------
+resource "azurerm_container_app" "temporal" {
+  name                         = "arxivisual-temporal"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  ingress {
+    external_enabled = false
+    target_port      = 7233
+    # gRPC over ACA's standard http2 ingress (envoy terminates TLS on :443 and
+    # forwards h2c) — raw TCP ingress proved unroutable on this environment.
+    transport        = "http2"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  secret {
+    name  = "pg-pwd"
+    value = var.postgres_admin_password
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 1
+
+    container {
+      name   = "arxivisual-temporal"
+      image  = "temporalio/auto-setup:1.23.1.1"
+      cpu    = 1.0
+      memory = "2Gi"
+
+      env {
+        name  = "DB"
+        value = "postgres12"
+      }
+      env {
+        name  = "DB_PORT"
+        value = "5432"
+      }
+      env {
+        name  = "POSTGRES_USER"
+        value = "rabidcheese9"
+      }
+      env {
+        name        = "POSTGRES_PWD"
+        secret_name = "pg-pwd"
+      }
+      env {
+        name  = "POSTGRES_SEEDS"
+        value = "arxivisual-db.postgres.database.azure.com"
+      }
+      env {
+        name  = "DBNAME"
+        value = "temporal"
+      }
+      env {
+        name  = "VISIBILITY_DBNAME"
+        value = "temporal_visibility"
+      }
+      env {
+        name  = "POSTGRES_TLS_ENABLED"
+        value = "true"
+      }
+      env {
+        name  = "POSTGRES_TLS_DISABLE_HOST_VERIFICATION"
+        value = "true"
+      }
+      env {
+        name  = "LOG_LEVEL"
+        value = "info"
+      }
+      env {
+        name  = "SQL_TLS_ENABLED"
+        value = "true"
+      }
+      env {
+        name  = "SQL_TLS"
+        value = "true"
+      }
+      env {
+        name  = "SQL_TLS_DISABLE_HOST_VERIFICATION"
+        value = "true"
+      }
+      env {
+        name  = "SQL_MAX_CONNS"
+        value = "2"
+      }
+      env {
+        name  = "SQL_MAX_IDLE_CONNS"
+        value = "1"
+      }
+      env {
+        name  = "NUM_HISTORY_SHARDS"
+        value = "1"
+      }
+
+      env {
+        name  = "BIND_ON_IP"
+        value = "0.0.0.0"
+      }
+
+      env {
+        name  = "TEMPORAL_BROADCAST_ADDRESS"
+        value = "127.0.0.1"
+      }
+
+      # The live probes only set port/interval/failure-threshold (+ initial
+      # delay on startup); timeout and success threshold are set explicitly to
+      # the Kubernetes/ACA platform defaults so the first apply materializes
+      # the values the platform already uses implicitly.
+      startup_probe {
+        transport               = "TCP"
+        port                    = 7233
+        initial_delay           = 10
+        interval_seconds        = 10
+        failure_count_threshold = 30
+        timeout                 = 1
+      }
+
+      readiness_probe {
+        transport               = "TCP"
+        port                    = 7233
+        interval_seconds        = 10
+        failure_count_threshold = 3
+        success_count_threshold = 1
+        timeout                 = 1
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# arxivisual-worker: Temporal worker, no ingress. Pulls the image with the
+# registry admin credential (stored as a container app secret).
+# ---------------------------------------------------------------------------
+resource "azurerm_container_app" "worker" {
+  # The deploy workflow (gh-<sha> tags) owns the image; Terraform owns
+  # everything else. Without this, every CD deploy would appear as drift.
+  lifecycle {
+    ignore_changes = [template[0].container[0].image]
+  }
+
+  name                         = "arxivisual-worker"
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+  max_inactive_revisions       = 100
+
+  registry {
+    server               = "ca82c08e2eadacr.azurecr.io"
+    username             = "ca82c08e2eadacr"
+    password_secret_name = "ca82c08e2eadacrazurecrio-ca82c08e2eadacr"
+  }
+
+  secret {
+    name  = "azure-openai-api-key"
+    value = var.azure_openai_api_key
+  }
+  secret {
+    name  = "s3-access-key"
+    value = var.s3_access_key
+  }
+  secret {
+    name  = "s3-secret-key"
+    value = var.s3_secret_key
+  }
+  secret {
+    name  = "database-url"
+    value = var.database_url
+  }
+  secret {
+    name  = "langfuse-public-key"
+    value = var.langfuse_public_key
+  }
+  secret {
+    name  = "langfuse-secret-key"
+    value = var.langfuse_secret_key
+  }
+  secret {
+    name  = "ca82c08e2eadacrazurecrio-ca82c08e2eadacr"
+    value = var.acr_admin_password
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 1
+
+    container {
+      name    = "arxivisual-worker"
+      image   = local.app_image
+      command = ["python", "/app/temporal_app/worker.py"]
+      cpu     = 2.0
+      memory  = "4Gi"
+
+      env {
+        name  = "LLM_PROVIDER"
+        value = "azure"
+      }
+      env {
+        name  = "AZURE_OPENAI_ENDPOINT"
+        value = "https://arxivisual-openai.openai.azure.com"
+      }
+      env {
+        name  = "AZURE_OPENAI_DEPLOYMENT"
+        value = "gpt-5-mini"
+      }
+      env {
+        name  = "STORAGE_MODE"
+        value = "r2"
+      }
+      env {
+        name  = "S3_ENDPOINT"
+        value = "https://0c4b2250cd401bcd63be9985bae2710a.r2.cloudflarestorage.com"
+      }
+      env {
+        name  = "S3_BUCKET"
+        value = "arxivisual"
+      }
+      env {
+        name  = "S3_PUBLIC_URL"
+        value = "https://pub-c68fa9a916b34af1bcbdb557f12d9287.r2.dev"
+      }
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "RENDER_MODE"
+        value = "local"
+      }
+      env {
+        name  = "AZURE_OPENAI_REASONING_EFFORT"
+        value = "medium"
+      }
+      env {
+        name  = "LANGFUSE_HOST"
+        value = "https://us.cloud.langfuse.com"
+      }
+      env {
+        name  = "LANGFUSE_TRACING_ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "ENABLE_VISUAL_QA"
+        value = "1"
+      }
+      env {
+        name  = "VISUAL_QA_MODEL"
+        value = "gpt-5.6-sol"
+      }
+      env {
+        name        = "AZURE_OPENAI_API_KEY"
+        secret_name = "azure-openai-api-key"
+      }
+      env {
+        name        = "S3_ACCESS_KEY"
+        secret_name = "s3-access-key"
+      }
+      env {
+        name        = "S3_SECRET_KEY"
+        secret_name = "s3-secret-key"
+      }
+      env {
+        name        = "DATABASE_URL"
+        secret_name = "database-url"
+      }
+      env {
+        name        = "LANGFUSE_PUBLIC_KEY"
+        secret_name = "langfuse-public-key"
+      }
+      env {
+        name        = "LANGFUSE_SECRET_KEY"
+        secret_name = "langfuse-secret-key"
+      }
+      env {
+        name  = "TEMPORAL_ADDRESS"
+        value = "arxivisual-temporal.internal.purplepond-ac9e2dc5.eastus2.azurecontainerapps.io:443"
+      }
+
+      env {
+        name  = "TEMPORAL_TLS"
+        value = "1"
+      }
+      env {
+        name  = "RENDER_CONCURRENCY"
+        value = "3"
+      }
+    }
+  }
+}

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -1,0 +1,65 @@
+# Postgres flexible server. NOTE: deliberately in westus3 (B1ms capacity was
+# unavailable in eastus2 at creation time) while the rest of the stack is in
+# eastus2.
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = "arxivisual-db"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "westus3"
+
+  version                       = "16"
+  administrator_login           = "rabidcheese9"
+  administrator_password        = var.postgres_admin_password
+  sku_name                      = "B_Standard_B1ms"
+  storage_mb                    = 32768
+  storage_tier                  = "P4"
+  auto_grow_enabled             = false
+  backup_retention_days         = 7
+  geo_redundant_backup_enabled  = false
+  zone                          = "3"
+  public_network_access_enabled = true
+
+  authentication {
+    active_directory_auth_enabled = false
+    password_auth_enabled         = true
+  }
+}
+
+# Application database.
+resource "azurerm_postgresql_flexible_server_database" "arxiviz" {
+  name      = "arxiviz"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# Temporal persistence store.
+resource "azurerm_postgresql_flexible_server_database" "temporal" {
+  name      = "temporal"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# Temporal visibility store.
+resource "azurerm_postgresql_flexible_server_database" "temporal_visibility" {
+  name      = "temporal_visibility"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# btree_gin is required by Temporal's advanced visibility schema.
+resource "azurerm_postgresql_flexible_server_configuration" "azure_extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "BTREE_GIN"
+}
+
+# 0.0.0.0-0.0.0.0 is Azure's "allow Azure services" sentinel rule; Container
+# Apps reach the DB through it.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_services" {
+  name             = "AllowAllAzureServicesAndResourcesWithinAzureIps_2026-8-19_12-29-0"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}

--- a/infra/github_oidc.tf
+++ b/infra/github_oidc.tf
@@ -1,0 +1,24 @@
+# GitHub Actions deploys via OIDC federation - no client secret exists.
+resource "azuread_application" "github_deploy" {
+  display_name = "arxivisual-github-deploy"
+}
+
+resource "azuread_service_principal" "github_deploy" {
+  client_id = azuread_application.github_deploy.client_id
+}
+
+# Trust tokens issued by GitHub Actions for pushes to rajshah6/arXivisual main.
+resource "azuread_application_federated_identity_credential" "github_main" {
+  application_id = azuread_application.github_deploy.id
+  display_name   = "github-arxivisual-main"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:rajshah6/arXivisual:ref:refs/heads/main"
+}
+
+# The deploy principal can manage everything inside the resource group.
+resource "azurerm_role_assignment" "github_deploy_contributor" {
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.github_deploy.object_id
+}

--- a/infra/imports.tf
+++ b/infra/imports.tf
@@ -1,0 +1,154 @@
+# ---------------------------------------------------------------------------
+# Import blocks binding every existing Azure resource to its Terraform
+# resource. These are consumed on the FIRST `terraform apply`; after the state
+# contains the resources, this whole file can be deleted.
+# ---------------------------------------------------------------------------
+
+locals {
+  sub = "/subscriptions/${var.subscription_id}"
+  rg  = "/subscriptions/${var.subscription_id}/resourceGroups/arxivisual-rg"
+}
+
+import {
+  to = azurerm_resource_group.main
+  id = local.rg
+}
+
+# --- Registry ---------------------------------------------------------------
+
+import {
+  to = azurerm_container_registry.main
+  id = "${local.rg}/providers/Microsoft.ContainerRegistry/registries/ca82c08e2eadacr"
+}
+
+import {
+  to = azurerm_role_assignment.api_acr_pull
+  id = "${local.rg}/providers/Microsoft.ContainerRegistry/registries/ca82c08e2eadacr/providers/Microsoft.Authorization/roleAssignments/b2a1a0f9-7530-4cca-a26d-1a05184135a4"
+}
+
+# --- Azure OpenAI -----------------------------------------------------------
+
+import {
+  to = azurerm_cognitive_account.openai
+  id = "${local.rg}/providers/Microsoft.CognitiveServices/accounts/arxivisual-openai"
+}
+
+import {
+  to = azurerm_cognitive_deployment.gpt_5_mini
+  id = "${local.rg}/providers/Microsoft.CognitiveServices/accounts/arxivisual-openai/deployments/gpt-5-mini"
+}
+
+import {
+  to = azurerm_cognitive_deployment.gpt_4o_mini_tts
+  id = "${local.rg}/providers/Microsoft.CognitiveServices/accounts/arxivisual-openai/deployments/gpt-4o-mini-tts"
+}
+
+import {
+  to = azurerm_cognitive_deployment.gpt_5_6_sol
+  id = "${local.rg}/providers/Microsoft.CognitiveServices/accounts/arxivisual-openai/deployments/gpt-5.6-sol"
+}
+
+# --- Database ---------------------------------------------------------------
+
+import {
+  to = azurerm_postgresql_flexible_server.main
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db"
+}
+
+import {
+  to = azurerm_postgresql_flexible_server_database.arxiviz
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db/databases/arxiviz"
+}
+
+import {
+  to = azurerm_postgresql_flexible_server_database.temporal
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db/databases/temporal"
+}
+
+import {
+  to = azurerm_postgresql_flexible_server_database.temporal_visibility
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db/databases/temporal_visibility"
+}
+
+import {
+  to = azurerm_postgresql_flexible_server_configuration.azure_extensions
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db/configurations/azure.extensions"
+}
+
+import {
+  to = azurerm_postgresql_flexible_server_firewall_rule.allow_azure_services
+  id = "${local.rg}/providers/Microsoft.DBforPostgreSQL/flexibleServers/arxivisual-db/firewallRules/AllowAllAzureServicesAndResourcesWithinAzureIps_2026-8-19_12-29-0"
+}
+
+# --- Container Apps ---------------------------------------------------------
+
+import {
+  to = azurerm_log_analytics_workspace.main
+  id = "${local.rg}/providers/Microsoft.OperationalInsights/workspaces/workspace-arxivisualrg2OvU"
+}
+
+import {
+  to = azurerm_container_app_environment.main
+  id = "${local.rg}/providers/Microsoft.App/managedEnvironments/arxivisual-api-env"
+}
+
+import {
+  to = azurerm_container_app.api
+  id = "${local.rg}/providers/Microsoft.App/containerApps/arxivisual-api"
+}
+
+import {
+  to = azurerm_container_app.temporal
+  id = "${local.rg}/providers/Microsoft.App/containerApps/arxivisual-temporal"
+}
+
+import {
+  to = azurerm_container_app.worker
+  id = "${local.rg}/providers/Microsoft.App/containerApps/arxivisual-worker"
+}
+
+# --- Budgets ----------------------------------------------------------------
+
+import {
+  to = azurerm_consumption_budget_subscription.monthly
+  id = "${local.sub}/providers/Microsoft.Consumption/budgets/arxivisual-monthly"
+}
+
+import {
+  to = azapi_resource.billing_monthly_reset_budget
+  id = "/providers/Microsoft.Billing/billingAccounts/3f54dc1c-3b08-5841-bb04-33a83cf4e3a7:9dc3de7a-80d3-4d17-baf3-665da89267cd_2019-05-31/providers/Microsoft.CostManagement/budgets/MonthlyReset"
+}
+
+# --- GitHub OIDC ------------------------------------------------------------
+
+import {
+  to = azuread_application.github_deploy
+  id = "/applications/133ab678-24c6-4f28-b383-53661fe8d6ff"
+}
+
+import {
+  to = azuread_service_principal.github_deploy
+  id = "/servicePrincipals/37b5aaca-7ddc-414b-a359-4880264f7433"
+}
+
+import {
+  to = azuread_application_federated_identity_credential.github_main
+  id = "133ab678-24c6-4f28-b383-53661fe8d6ff/federatedIdentityCredential/3934171f-dd96-416c-a4d5-4af4e94fc8e4"
+}
+
+import {
+  to = azurerm_role_assignment.github_deploy_contributor
+  id = "${local.rg}/providers/Microsoft.Authorization/roleAssignments/4cb5ec3f-2646-477c-81ea-6fbff0909aed"
+}
+
+# --- Terraform state storage ------------------------------------------------
+
+import {
+  to = azurerm_storage_account.tfstate
+  id = "${local.rg}/providers/Microsoft.Storage/storageAccounts/arxivisualtfstate"
+}
+
+import {
+  to = azurerm_storage_container.tfstate
+  id = "${local.rg}/providers/Microsoft.Storage/storageAccounts/arxivisualtfstate/blobServices/default/containers/tfstate"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,6 @@
+# Resource group holding everything (the Postgres server lives in westus3 but
+# still belongs to this eastus2 resource group).
+resource "azurerm_resource_group" "main" {
+  name     = "arxivisual-rg"
+  location = "eastus2"
+}

--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -1,0 +1,71 @@
+# Azure OpenAI account plus its three model deployments.
+resource "azurerm_cognitive_account" "openai" {
+  name                = "arxivisual-openai"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = "eastus2"
+  kind                = "OpenAI"
+  sku_name            = "S0"
+
+  custom_subdomain_name         = "arxivisual-openai"
+  public_network_access_enabled = true
+}
+
+# Main narration/scene-generation model.
+resource "azurerm_cognitive_deployment" "gpt_5_mini" {
+  name                 = "gpt-5-mini"
+  cognitive_account_id = azurerm_cognitive_account.openai.id
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-5-mini"
+    version = "2025-08-07"
+  }
+
+  sku {
+    name     = "GlobalStandard"
+    capacity = 250
+  }
+
+  rai_policy_name        = "Microsoft.DefaultV2"
+  version_upgrade_option = "OnceNewDefaultVersionAvailable"
+}
+
+# Voiceover text-to-speech model.
+resource "azurerm_cognitive_deployment" "gpt_4o_mini_tts" {
+  name                 = "gpt-4o-mini-tts"
+  cognitive_account_id = azurerm_cognitive_account.openai.id
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o-mini-tts"
+    version = "2025-12-15"
+  }
+
+  sku {
+    name     = "GlobalStandard"
+    capacity = 50
+  }
+
+  rai_policy_name        = "Microsoft.DefaultV2"
+  version_upgrade_option = "OnceNewDefaultVersionAvailable"
+}
+
+# Visual QA model (VISUAL_QA_MODEL env var in the API/worker apps).
+resource "azurerm_cognitive_deployment" "gpt_5_6_sol" {
+  name                 = "gpt-5.6-sol"
+  cognitive_account_id = azurerm_cognitive_account.openai.id
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-5.6-sol"
+    version = "2026-07-09"
+  }
+
+  sku {
+    name     = "GlobalStandard"
+    capacity = 250
+  }
+
+  rai_policy_name        = "Microsoft.DefaultV2"
+  version_upgrade_option = "OnceNewDefaultVersionAvailable"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,34 @@
+output "api_fqdn" {
+  description = "Public FQDN of the arxivisual-api container app."
+  value       = azurerm_container_app.api.ingress[0].fqdn
+}
+
+output "temporal_internal_fqdn" {
+  description = "Internal FQDN of the Temporal server (reachable only inside the environment)."
+  value       = azurerm_container_app.temporal.ingress[0].fqdn
+}
+
+output "container_app_environment_default_domain" {
+  description = "Default domain of the Container Apps environment."
+  value       = azurerm_container_app_environment.main.default_domain
+}
+
+output "acr_login_server" {
+  description = "Login server for the container registry."
+  value       = azurerm_container_registry.main.login_server
+}
+
+output "openai_endpoint" {
+  description = "Azure OpenAI endpoint URL."
+  value       = azurerm_cognitive_account.openai.endpoint
+}
+
+output "postgres_fqdn" {
+  description = "FQDN of the Postgres flexible server."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "github_deploy_client_id" {
+  description = "Client ID GitHub Actions uses for OIDC login (AZURE_CLIENT_ID repo secret)."
+  value       = azuread_application.github_deploy.client_id
+}

--- a/infra/registry.tf
+++ b/infra/registry.tf
@@ -1,0 +1,17 @@
+# Container registry that holds the arxivisual-api image (built/pushed by the
+# GitHub Actions deploy workflow). Admin user is enabled because the worker app
+# pulls with admin credentials; the API app pulls with its system identity.
+resource "azurerm_container_registry" "main" {
+  name                = "ca82c08e2eadacr"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Basic"
+  admin_enabled       = true
+}
+
+# The API container app pulls images using its system-assigned identity.
+resource "azurerm_role_assignment" "api_acr_pull" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_container_app.api.identity[0].principal_id
+}

--- a/infra/state.tf
+++ b/infra/state.tf
@@ -1,0 +1,26 @@
+# The Terraform state store itself. It was bootstrapped manually (chicken-and-
+# egg: the backend must exist before the first `terraform init`) and is now
+# managed here as well.
+resource "azurerm_storage_account" "tfstate" {
+  name                = "arxivisualtfstate"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  access_tier                     = "Hot"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+
+  network_rules {
+    default_action = "Allow"
+    bypass         = ["None"]
+  }
+}
+
+resource "azurerm_storage_container" "tfstate" {
+  name                  = "tfstate"
+  storage_account_id    = azurerm_storage_account.tfstate.id
+  container_access_type = "private"
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,24 @@
+# Copy to terraform.tfvars (git-ignored) and fill in the real values, or
+# export them as TF_VAR_* environment variables instead. NEVER commit real
+# values.
+
+# Postgres admin password for rabidcheese9@arxivisual-db (also the Temporal
+# app's pg-pwd secret).
+postgres_admin_password = "REPLACE_ME"
+
+# postgresql+asyncpg style connection string used by the API/worker apps.
+database_url = "postgresql://user:REPLACE_ME@arxivisual-db.postgres.database.azure.com:5432/arxiviz?sslmode=require"
+
+# az cognitiveservices account keys list -n arxivisual-openai -g arxivisual-rg
+azure_openai_api_key = "REPLACE_ME"
+
+# Cloudflare R2 credentials for the arxivisual bucket.
+s3_access_key = "REPLACE_ME"
+s3_secret_key = "REPLACE_ME"
+
+# Langfuse (us.cloud.langfuse.com) project keys.
+langfuse_public_key = "pk-lf-REPLACE_ME"
+langfuse_secret_key = "sk-lf-REPLACE_ME"
+
+# az acr credential show -n ca82c08e2eadacr --query "passwords[0].value"
+acr_admin_password = "REPLACE_ME"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,58 @@
+variable "subscription_id" {
+  description = "Azure subscription that hosts all arXivisual resources."
+  type        = string
+  default     = "4301c7fd-ffa2-4ad1-bca9-a15ef2d2bd59"
+}
+
+# ---------------------------------------------------------------------------
+# Secret values. NEVER commit real values; supply them via TF_VAR_* env vars
+# or an untracked terraform.tfvars (see README.md and terraform.tfvars.example).
+# ---------------------------------------------------------------------------
+
+variable "postgres_admin_password" {
+  description = "Password for the 'rabidcheese9' admin login on arxivisual-db. Also injected into the Temporal container app as the 'pg-pwd' secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "database_url" {
+  description = "Full Postgres connection string used by the API and worker apps ('database-url' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "azure_openai_api_key" {
+  description = "API key for the arxivisual-openai Cognitive account ('azure-openai-api-key' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_access_key" {
+  description = "Cloudflare R2 access key id ('s3-access-key' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_secret_key" {
+  description = "Cloudflare R2 secret access key ('s3-secret-key' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "langfuse_public_key" {
+  description = "Langfuse public key ('langfuse-public-key' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "langfuse_secret_key" {
+  description = "Langfuse secret key ('langfuse-secret-key' container app secret)."
+  type        = string
+  sensitive   = true
+}
+
+variable "acr_admin_password" {
+  description = "Admin password of the ca82c08e2eadacr registry, stored as the worker app's registry pull secret. Retrieve with: az acr credential show -n ca82c08e2eadacr."
+  type        = string
+  sensitive   = true
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+  }
+
+  # State storage was bootstrapped manually (see state.tf, which also codifies it).
+  #
+  # NOTE on auth: `use_azuread_auth = true` was attempted first but fails with
+  # AuthorizationPermissionMismatch because the signed-in user is subscription
+  # Owner without a blob DATA-plane role (Storage Blob Data Contributor). The
+  # backend therefore uses its default behavior: it looks up the storage
+  # account access key via ARM (the Owner role can list keys) and talks to the
+  # blob endpoint with the shared key. To switch to AAD auth later, grant
+  # yourself "Storage Blob Data Contributor" on arxivisualtfstate and add
+  # `use_azuread_auth = true` back.
+  backend "azurerm" {
+    resource_group_name  = "arxivisual-rg"
+    storage_account_name = "arxivisualtfstate"
+    container_name       = "tfstate"
+    key                  = "arxivisual.tfstate"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+
+  # All resource providers were registered when the infra was created by hand;
+  # never attempt registration from Terraform.
+  resource_provider_registrations = "none"
+}
+
+provider "azuread" {}
+
+provider "azapi" {
+  subscription_id = var.subscription_id
+}


### PR DESCRIPTION
The Terraform IaC step, as planned after Temporal. The entire live Azure estate is now code — reproducible, reviewable, and diffable.

## What's managed (26 resources)
| Area | Resources |
|---|---|
| Core | resource group, ACR (Basic), tfstate storage account + container |
| AI | Azure OpenAI account + 3 model deployments (`gpt-5-mini`, `gpt-4o-mini-tts`, `gpt-5.6-sol`) with exact versions/SKUs/capacities |
| Data | Postgres flexible server (westus3, B1ms, PG16) + `arxiviz`/`temporal`/`temporal_visibility` DBs + `azure.extensions=BTREE_GIN` + firewall |
| Compute | Container Apps environment + Log Analytics + **all three apps** (api / temporal / worker) with full env, secrets-as-variables, probes, and the http2 gRPC ingress |
| Governance | $300 subscription budget + $5 billing-account budget (via `azapi` — azurerm has no billing-scope budget resource) |
| CI/CD identity | The GitHub OIDC deploy app, SP, federated credential, and RG role assignment |

## Verified against production
```
Plan: 26 to import, 0 to add, 4 to change, 0 to destroy
```
Zero replacements, zero destroys. The 4 in-place diffs are documented in `infra/README.md` ("Known first-apply diffs"): secret-value rewrites (ACA's API never returns secret values) and write-only/platform-default fields (`administrator_password`, probe timeout defaults, LA auth flag). `PLAN_SNAPSHOT.txt` carries the action list.

## Design choices worth noting
- **CD owns images**: `api` and `worker` have `lifecycle.ignore_changes` on the container image, so `gh-<sha>` deploys from the workflow never show as drift — Terraform owns everything *else* about the apps.
- **Secrets policy**: no secret value appears anywhere in the repo; 8 sensitive variables come from `TF_VAR_*` env vars or an untracked `terraform.tfvars` (`terraform.tfvars.example` provided). The README documents supply and the AAD-auth role needed if you want keyless state access later.
- **Import blocks** (Terraform 1.5+ declarative style) can be deleted after the first `apply`.

## ⚠️ Applying affects production
The first `apply` executes the 26 imports + 4 benign writes. Recommended: run `terraform plan` yourself first (README has the exact steps), then apply once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production Azure infrastructure for containerized API, workflow, and worker services.
  * Added PostgreSQL databases, container registry, Azure OpenAI deployments, and secure Terraform state storage.
  * Added automated GitHub Actions authentication for deployments.
  * Added monthly subscription and billing-account budgets with actual-cost and forecast alerts.
* **Documentation**
  * Added infrastructure setup, deployment, credential, and usage documentation.
  * Added an example configuration file for required secrets and variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->