### PR TITLE
fix: viz-ID collision across sibling arXiv ids + generation backpressure

### DIFF
--- a/backend/jobs/worker.py
+++ b/backend/jobs/worker.py
@@ -239,7 +239,10 @@ async def _process_paper_job_impl(job_id: str, arxiv_id: str):
             viz_records = []
 
             # Use paper-based prefix for consistent viz_ids across re-runs
-            paper_suffix = arxiv_id.replace(".", "")[:8]  # e.g., "1706.03762" -> "17060376"
+            # Full sanitized arXiv id — a truncated prefix collided across
+            # sibling ids (e.g. 2608.23551 vs 2608.23553 both mapped to
+            # "26082355"), making papers overwrite each other's viz rows.
+            paper_suffix = arxiv_id.replace(".", "_").replace("/", "_")
 
             for i, visualization in enumerate(generated_visualizations):
                 # Create consistent viz_id based on paper and index, not job

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -118,7 +118,10 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
         generated = await generate_visualizations(structured_paper)
 
     render_inputs: list[RenderInput] = []
-    paper_suffix = params.arxiv_id.replace(".", "")[:8]
+    # Full sanitized arXiv id — a truncated prefix collided across sibling
+    # ids (e.g. 2608.23551 vs 2608.23553 both mapped to "26082355"), making
+    # papers overwrite each other's visualization rows via upsert.
+    paper_suffix = params.arxiv_id.replace(".", "_").replace("/", "_")
     async with async_session_maker() as db:
         for i, viz in enumerate(generated):
             viz_id = f"viz_{paper_suffix}_{i + 1}"

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -61,6 +61,12 @@ async def main() -> None:
     client = await Client.connect(address, namespace=namespace, tls=use_tls)
     logger.info("Connected. Render concurrency: %d", render_concurrency)
 
+    # Backpressure: observed in production that unbounded concurrent
+    # generations (each fanning out 5 LLM tasks + render tests) starve each
+    # other on the shared box until the activity timeout fires. Two papers
+    # generating at once is the sweet spot for this host; the rest queue on the
+    # Temporal server — which is exactly what it's for.
+    pipeline_concurrency = max(1, int(os.getenv("PIPELINE_CONCURRENCY", "2")))
     pipeline_worker = Worker(
         client,
         task_queue=TASK_QUEUE,
@@ -72,6 +78,7 @@ async def main() -> None:
             finalize_job,
             mark_job_failed,
         ],
+        max_concurrent_activities=pipeline_concurrency,
     )
     render_worker = Worker(
         client,

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -66,10 +66,14 @@ class PaperPipelineWorkflow:
                 retry_policy=_INFRA_RETRY,
             )
 
+            # 40 min: measured generation is ~2-8 min alone, but under
+            # multi-paper load it queues behind renders on the shared CPUs —
+            # 25 min timed out in production the first night. (Queue WAIT
+            # doesn't count here; start_to_close covers execution only.)
             render_inputs: list[RenderInput] = await workflow.execute_activity(
                 generate_visualizations_for_paper,
                 params,
-                start_to_close_timeout=timedelta(minutes=25),
+                start_to_close_timeout=timedelta(minutes=40),
                 retry_policy=_NO_RETRY,
             )
 

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -150,3 +150,17 @@ class TestWorkflowOrchestration:
                     await handle.result()
 
         asyncio.run(run())
+
+
+def test_viz_ids_do_not_collide_across_sibling_arxiv_ids():
+    """Regression: the old 8-char digit prefix collided for sibling ids
+    (2608.23551 vs 2608.23553 -> both "26082355"), so papers overwrote each
+    other's visualization rows via upsert. Found live in production."""
+    def suffix(arxiv_id: str) -> str:
+        return arxiv_id.replace(".", "_").replace("/", "_")
+
+    a, b = suffix("2608.23551"), suffix("2608.23553")
+    assert a != b
+    assert a == "2608_23551"
+    # Old-style ids (e.g. math/0211159) sanitize to filesystem/URL-safe form too.
+    assert suffix("math/0211159") == "math_0211159"


### PR DESCRIPTION
Two findings from the first hours of **real multi-tenant traffic** on the durable pipeline (8 public papers flowed through Temporal tonight).

## 1. viz-ID collision — silent cross-paper data corruption (pre-existing, caught by observation)
viz ids used `arxiv_id.replace(".","")[:8]`, so sibling ids collide: `2608.23551` and `2608.23553` both map to `viz_26082355_N`. Because records are **upserted by viz_id**, the second paper re-points the row's `paper_id`/`section_id`/video at itself — papers literally steal each other's videos. Observed live: querying `2608.23551` returned another paper's title with its viz rows overwritten.

**Fix:** full sanitized arXiv id — `viz_2608_23551_1` — in both the Temporal and legacy paths. Regression test covers sibling ids and old-style (`math/0211159`) ids.

## 2. Generation starvation under load
With the flag on, every public submission runs concurrently on the worker; generations (each fanning 5 LLM tasks + in-process render tests) starved each other until the 25-min activity timeout fired (`Activity not found on completion` in the SDK logs — the activity finished after Temporal had already timed it out). Generation deliberately never auto-retries (cost fuse), so those jobs failed honestly.

**Fix:** `max_concurrent_activities` on the pipeline queue (`PIPELINE_CONCURRENCY`, default 2) — surplus papers **queue on the Temporal server, which is exactly what it's for** — plus the generate timeout widened to 40 min (start_to_close counts execution only, not queue wait).

## Durability evidence from tonight (the kill test, effectively run by production)
The worker was killed at 23:39:43 while public workflows were mid-flight; logs show a render **retrying at 23:40:25, seconds after reconnect** (`_INFRA_RETRY` doing its job), and the paper stream continuing at 23:40:36. Jobs now survive worker death — the exact failure that used to create zombie jobs.

**67 tests pass.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented visualization results for similarly named papers from overwriting one another.
  * Improved identifier handling for paper references containing dots or slashes.
  * Increased generation time allowance to reduce failures during busy periods.

* **Performance**
  * Added configurable limits for concurrent processing, helping balance throughput and system capacity.

* **Tests**
  * Added coverage to verify that visualization identifiers remain distinct and properly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->