### PR TITLE
feat: closed-loop visual QA repair — judge findings drive targeted regeneration

### DIFF
--- a/backend/rendering/__init__.py
+++ b/backend/rendering/__init__.py
@@ -55,7 +55,12 @@ async def render_manim(code: str, scene_name: str, quality: str = "low_quality")
         return await render_manim_local(code, scene_name, quality)
 
 
-async def process_visualization(viz_id: str, manim_code: str, quality: str = "low_quality") -> str:
+async def process_visualization(
+    viz_id: str,
+    manim_code: str,
+    quality: str = "low_quality",
+    collect_qa: bool = False,
+):
     """
     Process a visualization: render Manim code and save the video.
 
@@ -63,9 +68,14 @@ async def process_visualization(viz_id: str, manim_code: str, quality: str = "lo
         viz_id: Unique identifier for this visualization
         manim_code: Complete Manim Python code
         quality: Rendering quality ("low_quality", "medium_quality", "high_quality")
+        collect_qa: When True, run the visual QA judge INLINE and return
+            ``(video_url, verdict)`` so the caller (the Temporal render
+            activity) can drive a repair pass. When False (legacy path),
+            returns just the URL and QA runs as background observe-mode.
 
     Returns:
-        URL path to the rendered video (e.g., "/api/video/viz_001")
+        URL path to the rendered video, or ``(url, VisualQAResult | None)``
+        when ``collect_qa`` is True.
 
     Raises:
         RuntimeError: If rendering fails
@@ -87,6 +97,11 @@ async def process_visualization(viz_id: str, manim_code: str, quality: str = "lo
     video_url = await save_video(video_bytes, f"{viz_id}.mp4")
     logger.info(f"[Processing Visualization] Video saved successfully")
     logger.info(f"[Processing Visualization] Video URL: {video_url}")
+
+    if collect_qa:
+        # Inline judging for the repair loop: the activity needs the verdict.
+        verdict = await _judge_and_score(viz_id, video_bytes)
+        return video_url, verdict
 
     # Visual QA (observe mode): judge sampled frames for overlap/cutoff defects.
     # Dispatched as supervised background work — logs + Langfuse score only,
@@ -118,14 +133,17 @@ def _dispatch_visual_qa(viz_id: str, video_bytes: bytes) -> None:
     task.add_done_callback(_done)
 
 
-async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
-    """Run the vision layout judge; log + score only."""
+async def _judge_and_score(viz_id: str, video_bytes: bytes):
+    """Run the vision layout judge; log + Langfuse-score; return the verdict.
+
+    Never raises — a QA failure returns None so callers can proceed.
+    """
     try:
         from agents.visual_qa import judge_video
 
         verdict = await judge_video(video_bytes, viz_id=viz_id)
         if verdict is None:
-            return
+            return None
         if verdict.has_defects:
             logger.warning(
                 "[VisualQA] %s severity=%s overlap=%s cutoff=%s collisions=%s issues=%s",
@@ -146,5 +164,12 @@ async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
         except Exception as exc:
             # Distinguish broken telemetry from intentional unconfiguration.
             logger.warning("[VisualQA] Langfuse scoring failed for %s: %s", viz_id, exc)
+        return verdict
     except Exception as exc:
-        logger.warning("[VisualQA] Observe-mode QA failed for %s: %s", viz_id, exc)
+        logger.warning("[VisualQA] QA failed for %s: %s", viz_id, exc)
+        return None
+
+
+async def _observe_visual_qa(viz_id: str, video_bytes: bytes) -> None:
+    """Background observe-mode wrapper around the judge."""
+    await _judge_and_score(viz_id, video_bytes)

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -35,12 +35,33 @@ class RenderInput:
     job_id: str
     viz_id: str
     manim_code: str
+    # Set on repair re-renders so the activity doesn't recommend repairing the
+    # repair (one round max, decided by the workflow).
+    is_repair: bool = False
 
 
 @dataclass
 class RenderResult:
     viz_id: str
     succeeded: bool
+    # Visual QA verdict for the rendered video (empty/none when QA is off,
+    # failed, or unavailable). The workflow uses repair_recommended — computed
+    # HERE from env + severity so the workflow itself stays deterministic.
+    severity: str = "none"
+    issues: list[str] = None  # type: ignore[assignment]
+    repair_recommended: bool = False
+
+    def __post_init__(self) -> None:
+        if self.issues is None:
+            self.issues = []
+
+
+@dataclass
+class RepairInput:
+    job_id: str
+    viz_id: str
+    manim_code: str
+    issues: list[str]
 
 
 @dataclass
@@ -151,35 +172,124 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
 
 @activity.defn
 async def render_visualization(params: RenderInput) -> RenderResult:
-    """Render one video and record its status. Never raises for a render
-    failure — the outcome travels back to the workflow, which owns aggregation.
-    (Raising is reserved for infrastructure faults, which Temporal retries.)"""
+    """Render one video, judge it (when visual QA is on), record status.
+
+    Never raises for a render failure — the outcome travels back to the
+    workflow, which owns aggregation. (Raising is reserved for infrastructure
+    faults, which Temporal retries.) The repair recommendation is computed
+    here from env so the workflow stays deterministic on replay.
+    """
+    import os
+
     from db.connection import async_session_maker
     from db import queries
     from rendering import process_visualization
 
+    qa_enabled = os.getenv("ENABLE_VISUAL_QA", "0") == "1"
+    repair_enabled = os.getenv("VISUAL_QA_REPAIR", "0") == "1"
+
     succeeded = True
     video_url: str | None = None
     error: str | None = None
+    severity = "none"
+    issues: list[str] = []
     try:
-        video_url = await process_visualization(
-            viz_id=params.viz_id,
-            manim_code=params.manim_code,
-            quality="low_quality",
-        )
+        if qa_enabled:
+            video_url, verdict = await process_visualization(
+                viz_id=params.viz_id,
+                manim_code=params.manim_code,
+                quality="low_quality",
+                collect_qa=True,
+            )
+            if verdict is not None:
+                severity = verdict.severity
+                issues = list(verdict.issues)
+        else:
+            video_url = await process_visualization(
+                viz_id=params.viz_id,
+                manim_code=params.manim_code,
+                quality="low_quality",
+            )
     except Exception as exc:
         succeeded = False
         error = str(exc)
         logger.error("Render failed for %s: %s", params.viz_id, error)
 
-    async with async_session_maker() as db:
-        await queries.update_visualization_status(
-            db, params.viz_id,
-            status="complete" if succeeded else "failed",
-            video_url=video_url,
-            error=error,
+    if params.is_repair and not succeeded:
+        # A failed repair re-render must not clobber the original video's
+        # record — the pre-repair video is still stored and serving.
+        logger.warning("Repair re-render failed for %s; keeping original video", params.viz_id)
+    else:
+        async with async_session_maker() as db:
+            await queries.update_visualization_status(
+                db, params.viz_id,
+                status="complete" if succeeded else "failed",
+                video_url=video_url,
+                error=error,
+            )
+    return RenderResult(
+        viz_id=params.viz_id,
+        succeeded=succeeded,
+        severity=severity,
+        issues=issues,
+        repair_recommended=(
+            repair_enabled
+            and succeeded
+            and severity == "major"
+            and not params.is_repair
+        ),
+    )
+
+
+REPAIR_PROMPT = """You are fixing LAYOUT DEFECTS in a working Manim animation.
+A vision model inspected the rendered video frames and found these problems:
+
+{issues}
+
+Here is the current code (it renders successfully — do NOT restructure it):
+
+```python
+{code}
+```
+
+Fix ONLY the layout problems listed above: reposition or scale elements, add
+FadeOut between beats, move labels off arrows, keep everything inside x in
+[-6, 6], y in [-3.5, 3.5]. PRESERVE the narration text, voiceover structure,
+scene class name, beat comments, and overall animation flow exactly.
+
+Return ONLY the complete corrected Python code. No markdown, no prose."""
+
+
+@activity.defn
+async def repair_visualization_code(params: RepairInput) -> str:
+    """Targeted layout repair: judge findings -> focused LLM fix -> validated code.
+
+    Raises on failure (unusable output) so the workflow keeps the original
+    video — a defective video beats no video.
+    """
+    from agents.base import call_llm
+    from agents.code_validator import CodeValidator
+
+    prompt = REPAIR_PROMPT.format(
+        issues="\n".join(f"- {i}" for i in params.issues[:8]),
+        code=params.manim_code,
+    )
+    raw = await call_llm(prompt, max_tokens=10000, name="visual_qa_repair")
+
+    # Strip a markdown fence if the model added one despite instructions.
+    import re
+
+    fence = re.search(r"```(?:python)?\s*\n(.*?)```", raw, re.DOTALL)
+    code = (fence.group(1) if fence else raw).strip()
+
+    validation = CodeValidator().validate(code)
+    if not validation.is_valid:
+        raise RuntimeError(
+            f"Repair produced invalid code for {params.viz_id}: "
+            + "; ".join(validation.issues_found[:3])
         )
-    return RenderResult(viz_id=params.viz_id, succeeded=succeeded)
+    logger.info("Repair code ready for %s (%d chars)", params.viz_id, len(validation.code))
+    return validation.code
 
 
 @activity.defn

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -31,6 +31,7 @@ from temporalio.worker import Worker
 
 from temporal_app.activities import (
     finalize_job,
+    repair_visualization_code,
     generate_visualizations_for_paper,
     ingest_paper,
     mark_job_failed,
@@ -77,6 +78,7 @@ async def main() -> None:
             update_render_progress,
             finalize_job,
             mark_job_failed,
+            repair_visualization_code,
         ],
         max_concurrent_activities=pipeline_concurrency,
     )

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -35,11 +35,13 @@ with workflow.unsafe.imports_passed_through():
         ProgressUpdate,
         RenderInput,
         RenderResult,
+        RepairInput,
         finalize_job,
         generate_visualizations_for_paper,
         ingest_paper,
         mark_job_failed,
         render_visualization,
+        repair_visualization_code,
         update_render_progress,
     )
 
@@ -97,8 +99,10 @@ class PaperPipelineWorkflow:
 
             succeeded = 0
             completed = 0
+            results: list[RenderResult] = []
             for task in asyncio.as_completed(render_tasks):
                 result: RenderResult = await task
+                results.append(result)
                 completed += 1
                 if result.succeeded:
                     succeeded += 1
@@ -109,8 +113,26 @@ class PaperPipelineWorkflow:
                     retry_policy=_INFRA_RETRY,
                 )
 
+            # Repair pass (one round per viz, activity-gated via env): the
+            # judge's specific findings drive a targeted layout fix, then a
+            # re-render overwrites the video in place. A failed repair keeps
+            # the original video — defective beats absent.
+            code_by_viz = {ri.viz_id: ri.manim_code for ri in render_inputs}
+            to_repair = [r for r in results if r.repair_recommended]
+            if to_repair:
+                workflow.logger.info(
+                    "Repairing %d/%d defective visualization(s)", len(to_repair), total
+                )
+                repaired_ok = await asyncio.gather(
+                    *[self._repair_one(params.job_id, r, code_by_viz[r.viz_id]) for r in to_repair]
+                )
+                workflow.logger.info(
+                    "Repair pass: %d/%d now defect-free", sum(repaired_ok), len(to_repair)
+                )
+
             await self._finalize(params.job_id, succeeded=succeeded, total=total)
-            return f"rendered {succeeded}/{total}"
+            defective = sum(1 for r in results if r.severity == "major")
+            return f"rendered {succeeded}/{total} ({defective} flagged, {len(to_repair)} repaired)"
         except Exception:
             # Mark the job failed so pollers see the truth, then let Temporal
             # record the workflow failure with full history for debugging.
@@ -121,6 +143,38 @@ class PaperPipelineWorkflow:
                 retry_policy=_INFRA_RETRY,
             )
             raise
+
+    async def _repair_one(self, job_id: str, result: RenderResult, code: str) -> bool:
+        """Repair one defective visualization; returns True if the re-render
+        came back defect-free. Never raises — original video stays on failure."""
+        try:
+            fixed_code = await workflow.execute_activity(
+                repair_visualization_code,
+                RepairInput(
+                    job_id=job_id,
+                    viz_id=result.viz_id,
+                    manim_code=code,
+                    issues=result.issues,
+                ),
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=_NO_RETRY,  # a repair is one LLM call — don't double-spend
+            )
+            rerender: RenderResult = await workflow.execute_activity(
+                render_visualization,
+                RenderInput(
+                    job_id=job_id,
+                    viz_id=result.viz_id,
+                    manim_code=fixed_code,
+                    is_repair=True,
+                ),
+                task_queue=RENDER_TASK_QUEUE,
+                start_to_close_timeout=timedelta(minutes=15),
+                retry_policy=_NO_RETRY,  # original video already exists as fallback
+            )
+            return rerender.succeeded and rerender.severity != "major"
+        except Exception as exc:
+            workflow.logger.warning("Repair failed for %s: %s", result.viz_id, exc)
+            return False
 
     async def _finalize(self, job_id: str, succeeded: int, total: int) -> None:
         await workflow.execute_activity(

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -15,7 +15,7 @@ import uuid
 
 import pytest
 
-from temporal_app.activities import PipelineInput, ProgressUpdate, RenderInput, RenderResult
+from temporal_app.activities import PipelineInput, ProgressUpdate, RenderInput, RenderResult, RepairInput
 from temporal_app.workflows import RENDER_TASK_QUEUE, TASK_QUEUE, PaperPipelineWorkflow
 
 requires_temporal = pytest.mark.skipif(
@@ -102,7 +102,7 @@ class TestWorkflowOrchestration:
 
     def test_happy_path_orders_and_aggregates(self, calls):
         result = asyncio.run(self._run(calls, viz_count=3))
-        assert result == "rendered 3/3"
+        assert result == "rendered 3/3 (0 flagged, 0 repaired)"
         assert calls["ingest"] == 1 and calls["generate"] == 1
         assert sorted(calls["render"]) == ["viz_1", "viz_2", "viz_3"]
         # Progress is monotonically driven by the workflow as results arrive.
@@ -112,7 +112,7 @@ class TestWorkflowOrchestration:
 
     def test_partial_failure_reaches_finalize_with_honest_counts(self, calls):
         result = asyncio.run(self._run(calls, viz_count=3, fail_viz_ids=frozenset({"viz_2"})))
-        assert result == "rendered 2/3"
+        assert result.startswith("rendered 2/3")
         assert calls["finalize"] == [(2, 3)]
 
     def test_zero_visualizations_finalizes_as_empty(self, calls):
@@ -164,3 +164,97 @@ def test_viz_ids_do_not_collide_across_sibling_arxiv_ids():
     assert a == "2608_23551"
     # Old-style ids (e.g. math/0211159) sanitize to filesystem/URL-safe form too.
     assert suffix("math/0211159") == "math_0211159"
+
+
+@requires_temporal
+class TestRepairLoop:
+    """The closed loop: judge findings -> targeted repair -> re-render."""
+
+    def _acts(self, calls, defective=frozenset(), repair_fixes=True):
+        from temporalio import activity
+
+        @activity.defn(name="ingest_paper")
+        async def ingest(params: PipelineInput) -> None: ...
+
+        @activity.defn(name="generate_visualizations_for_paper")
+        async def generate(params: PipelineInput) -> list[RenderInput]:
+            return [
+                RenderInput(job_id=params.job_id, viz_id=f"viz_{i}", manim_code=f"code{i}")
+                for i in (1, 2)
+            ]
+
+        @activity.defn(name="render_visualization")
+        async def render(params: RenderInput) -> RenderResult:
+            calls["renders"].append((params.viz_id, params.is_repair))
+            if params.is_repair:
+                # Post-repair verdict depends on whether the fix worked.
+                sev = "none" if repair_fixes else "major"
+                return RenderResult(viz_id=params.viz_id, succeeded=True, severity=sev)
+            defect = params.viz_id in defective
+            return RenderResult(
+                viz_id=params.viz_id, succeeded=True,
+                severity="major" if defect else "none",
+                issues=["label overlaps arrow"] if defect else [],
+                repair_recommended=defect,
+            )
+
+        @activity.defn(name="repair_visualization_code")
+        async def repair(params: RepairInput) -> str:
+            calls["repairs"].append((params.viz_id, tuple(params.issues)))
+            return "fixed " + params.manim_code
+
+        @activity.defn(name="update_render_progress")
+        async def progress(params: ProgressUpdate) -> None: ...
+
+        @activity.defn(name="finalize_job")
+        async def finalize(params: ProgressUpdate) -> None:
+            calls["finalize"].append((params.completed, params.total))
+
+        @activity.defn(name="mark_job_failed")
+        async def failed(params: PipelineInput) -> None: ...
+
+        return [ingest, generate, progress, finalize, failed, repair], [render]
+
+    def _run(self, calls, **kw):
+        from temporalio.testing import WorkflowEnvironment
+        from temporalio.worker import Worker
+
+        async def go():
+            pipeline_acts, render_acts = self._acts(calls, **kw)
+            async with await WorkflowEnvironment.start_local() as env:
+                async with Worker(
+                    env.client, task_queue=TASK_QUEUE,
+                    workflows=[PaperPipelineWorkflow], activities=pipeline_acts,
+                ), Worker(env.client, task_queue=RENDER_TASK_QUEUE, activities=render_acts):
+                    return await env.client.execute_workflow(
+                        PaperPipelineWorkflow.run,
+                        PipelineInput(job_id="job_r", arxiv_id="1706.03762"),
+                        id=f"paper-repair-{uuid.uuid4().hex[:8]}",
+                        task_queue=TASK_QUEUE,
+                    )
+        return asyncio.run(go())
+
+    def test_defective_render_triggers_targeted_repair_and_rerender(self):
+        calls = {"renders": [], "repairs": [], "finalize": []}
+        result = self._run(calls, defective=frozenset({"viz_2"}))
+        # Repair got the judge's SPECIFIC issues, and only for the flagged viz.
+        assert calls["repairs"] == [("viz_2", ("label overlaps arrow",))]
+        # viz_2 rendered twice (initial + repair), viz_1 once.
+        assert calls["renders"].count(("viz_2", False)) == 1
+        assert calls["renders"].count(("viz_2", True)) == 1
+        assert calls["renders"].count(("viz_1", False)) == 1
+        assert "1 repaired" in result
+
+    def test_clean_renders_skip_repair_entirely(self):
+        calls = {"renders": [], "repairs": [], "finalize": []}
+        result = self._run(calls, defective=frozenset())
+        assert calls["repairs"] == []
+        assert result == "rendered 2/2 (0 flagged, 0 repaired)"
+
+    def test_repair_never_cascades_into_second_round(self):
+        # Even when the repair DOESN'T fix the defect, exactly one repair
+        # round runs (is_repair renders never recommend another repair).
+        calls = {"renders": [], "repairs": [], "finalize": []}
+        self._run(calls, defective=frozenset({"viz_1", "viz_2"}), repair_fixes=False)
+        assert len(calls["repairs"]) == 2
+        assert len([r for r in calls["renders"] if r[1]]) == 2  # exactly 2 re-renders


### PR DESCRIPTION
The experiment's conclusion, implemented. Baseline: **100% of production videos have major layout defects**, and the prompt-only A/B **proved guidance alone doesn't move that number** (3/3 → 4/4). So the judge's *specific findings* now drive the fix.

## The loop
```
render → vision judge (inline, in-activity)
       → severity=major? → targeted repair (LLM: fix ONLY the listed issues,
                           preserve narration/structure, syntax-validated)
       → re-render (overwrites video in place) → re-judge
```

## Safety design (same philosophy as everything else this week)
- **Flag-gated**: `VISUAL_QA_REPAIR=1`, default OFF — merging changes nothing
- **Deterministic workflow**: the repair recommendation is computed in the *activity* from env + severity, so workflow replay never consults the environment
- **One round max** per visualization — repairs structurally cannot cascade
- **Failed repairs are harmless**: `_NO_RETRY` on both repair activities (no double LLM spend), and a failed repair re-render skips the DB write so the original video keeps serving — *defective beats absent*
- Workflow result string now reports `(N flagged, M repaired)` for at-a-glance defect/repair rates; per-render `visual_qa_defect` scores continue flowing to Langfuse

## Verification
3 new orchestration tests against a real local Temporal server:
- targeted repair receives the judge's **exact issues** and fires only for flagged viz
- clean renders skip the pass entirely
- repairs **never cascade** into a second round even when the fix doesn't take
**10/10 integration tests, 67 fast tests pass.**

## Rollout
Merge (inert) → deploy → set `VISUAL_QA_REPAIR=1` → re-process a defective paper → the before/after defect rate is the headline number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual quality checks for rendered videos, with severity ratings and identified issues.
  * Automatically recommends and attempts targeted repairs for visual defects.
  * Re-renders repaired visualizations while preserving the original when repairs fail.
  * Workflow results now report flagged and successfully repaired visualizations.
* **Bug Fixes**
  * Prevented repeated repair attempts and repair cascades.
  * Preserved existing rendering behavior when quality checks are not requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->