### PR TITLE
feat: LLM evaluation suite gating CI on generation-quality regressions

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,85 @@
+# Nightly LLM generation-quality evals — gates on regressions via
+# backend/evals/check_regression.py (see backend/evals/README.md).
+#
+# Required repository secrets (Settings > Secrets and variables > Actions):
+#   AZURE_OPENAI_API_KEY      — Azure OpenAI key used by the agent pipeline
+#   AZURE_OPENAI_ENDPOINT     — e.g. https://<resource>.openai.azure.com
+#   AZURE_OPENAI_DEPLOYMENT   — deployment name (e.g. gpt-5-mini)
+# The run makes real, billable LLM calls (~$0.05–0.15 per paper without
+# rendering); paper count and per-paper viz cap keep cost bounded.
+name: Evals
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # nightly 06:00 UTC — evaluates 5 golden-set papers
+  workflow_dispatch:
+    inputs:
+      papers:
+        description: "Number of golden-set papers to evaluate"
+        required: false
+        default: "3"
+
+# Never overlap eval runs (they share the LLM quota); queue instead of cancel
+# so a manual dispatch doesn't kill a nightly run mid-flight.
+concurrency:
+  group: evals
+  cancel-in-progress: false
+
+jobs:
+  evals:
+    name: Golden-set generation evals
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      LLM_PROVIDER: azure
+      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+      AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+      # Cost control: cheapest reasoning tier is plenty for the eval workload.
+      AZURE_OPENAI_REASONING_EFFORT: low
+      # Evals measure the LLM gates, not ffmpeg: disables local render testing.
+      # run_evals.py also forces this before importing the pipeline.
+      RENDER_MODE: modal
+    steps:
+      - uses: actions/checkout@v4
+
+      # No rendering happens, but `uv sync` still builds manim's manimpango
+      # from sdist on Linux (no manylinux wheels), which needs pango/cairo
+      # headers. Same apt line as ci.yml.
+      - name: Install system build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libcairo2-dev libpango1.0-dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run golden-set evals
+        run: |
+          uv run python evals/run_evals.py \
+            --papers ${{ github.event.inputs.papers || '5' }} \
+            --max-viz 2 \
+            --output report.json
+
+      - name: Check for regressions
+        run: uv run python evals/check_regression.py report.json evals/baselines.json
+
+      - name: Upload eval report
+        if: always() # keep the report even when the regression gate fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: backend/report.json
+          if-no-files-found: warn

--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -13,7 +13,7 @@ import re
 import sys
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 try:
     from langfuse import observe
@@ -95,6 +95,19 @@ VOICEOVER_TARGET_DURATION_SECONDS = (30, 45)
 VOICE_QUALITY_STRICT = True
 VOICE_QUALITY_RETRIES = 2
 VOICE_FAIL_BEHAVIOR = "return_silent"  # drop_viz | return_silent | hard_error
+
+# Optional observation seam for the eval harness (backend/evals). When set, it
+# is called after every quality gate as metrics_hook(gate_name, attempt, passed).
+# None (the default) changes no behavior.
+metrics_hook: Optional[Callable[[str, int, bool], None]] = None
+
+
+def _report_gate(gate: str, attempt: int, passed: bool) -> None:
+    if metrics_hook is not None:
+        try:
+            metrics_hook(gate, attempt, passed)
+        except Exception:  # noqa: BLE001 — metrics must never break generation
+            logger.debug("metrics_hook raised for gate %s", gate, exc_info=True)
 
 
 def _extract_voiceover_metadata(code: str) -> tuple[list[str], list[str]]:
@@ -355,6 +368,7 @@ async def generate_single_visualization(
             # Stage 1: code validation
             logger.info("    [1/4] CodeValidator: Checking syntax & structure...")
             validation = validator.validate(code_result.code)
+            _report_gate("code_validator", attempt, validation.is_valid and not validation.needs_regeneration)
             if validation.needs_regeneration or not validation.is_valid:
                 logger.warning(
                     "    [1/4] FAILED: %s issues - regenerating",
@@ -371,6 +385,7 @@ async def generate_single_visualization(
             if spatial_validator:
                 logger.info("    [2/4] SpatialValidator: Checking positioning...")
                 spatial_result = spatial_validator.validate(current_code)
+                _report_gate("spatial_validator", attempt, not spatial_result.needs_regeneration)
                 if spatial_result.needs_regeneration:
                     logger.warning(
                         "    [2/4] FAILED: bounds=%s overlaps=%s - regenerating",
@@ -402,6 +417,7 @@ async def generate_single_visualization(
                     plan=plan,
                     candidate=candidate,
                 )
+                _report_gate("voiceover_script_validator", attempt, not voice_result.needs_regeneration)
 
                 if voice_result.needs_regeneration:
                     logger.warning(
@@ -423,6 +439,7 @@ async def generate_single_visualization(
             if render_tester:
                 logger.info("    [4/4] RenderTester: Testing import & execution...")
                 render_result = await render_tester.test_render(current_code)
+                _report_gate("render_tester", attempt, render_result.success)
                 if not render_result.success:
                     logger.warning(
                         "    [4/4] FAILED: %s - %s",

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -1,0 +1,90 @@
+# Generation-quality evals
+
+A golden-set eval harness for the multi-agent Manim generation pipeline
+(`agents/pipeline.py`). It measures per-gate LLM generation quality on a fixed
+set of real arXiv papers and **fails CI when any aggregate metric regresses
+below baseline** — see `.github/workflows/evals.yml` (nightly at 06:00 UTC,
+plus manual `workflow_dispatch`).
+
+## What it measures
+
+Each golden-set paper (`golden_set.json`, 8 papers spanning core ML,
+theory/optimization, and applied CV) is fetched and ingested for real, then run
+through the real pipeline with the metrics hook attached
+(`agents.pipeline.metrics_hook` → `evals/metrics.py:GateMetrics`). Local render
+testing is disabled (`RENDER_MODE=modal`), so the run measures the **LLM
+quality gates**, not ffmpeg/cairo:
+
+| Gate | What it checks |
+|---|---|
+| `code_validator` | AST syntax + structure (deterministic) |
+| `spatial_validator` | positioning / bounds / overlaps (deterministic) |
+| `voiceover_script_validator` | narration quality (heuristics + LLM judge) |
+| `render_tester` | *disabled in evals* (import/execution test) |
+
+Reported per gate (aggregate and per paper): **first-attempt pass rate**,
+**eventual pass rate** (within the retry budget), and **average attempts to
+pass**. Per paper: candidates run, visualizations validated vs returned, and
+wall-clock time. The headline `viz_yield_rate` counts only visualizations that
+actually cleared every enabled gate — silent fallbacks
+(`VOICE_FAIL_BEHAVIOR=return_silent`) do not inflate it.
+
+## Running locally
+
+Real LLM calls and real arXiv fetches — you need the provider env
+(`backend/.env` works, `agents/base.py` loads it):
+
+```bash
+export AZURE_OPENAI_API_KEY=... AZURE_OPENAI_ENDPOINT=... AZURE_OPENAI_DEPLOYMENT=...
+export AZURE_OPENAI_REASONING_EFFORT=low   # cost control
+
+cd backend
+uv run python evals/run_evals.py --papers 2 --max-viz 2 --output report.json
+uv run python evals/check_regression.py report.json evals/baselines.json
+```
+
+- `--papers N` — first N papers of `golden_set.json` (default: all 8; order is
+  cheapest/most load-bearing first)
+- `--max-viz M` — cap visualizations per paper (default 2)
+- `check_regression.py` exits 1 with a verdict table on any regression.
+
+**Cost:** roughly **$0.05–0.15 per paper** at 2 visualizations and low
+reasoning effort (no rendering). Nightly CI runs 5 papers; manual dispatch
+defaults to 3.
+
+## Baselines and tightening procedure
+
+`baselines.json` holds minimum thresholds against `report["aggregate"]`
+(dotted-path keys, `{"min": x}` / `{"max": x}`). The initial values carry
+**generous slack** — they catch collapses, not drift:
+
+- `viz_yield_rate >= 0.5`
+- `code_validator` first-attempt `>= 0.4`, eventual `>= 0.7`
+- `spatial_validator` / `voiceover_script_validator` eventual `>= 0.7`
+
+**Tighten once 3+ real nightly runs establish variance.** Procedure:
+
+1. Download the `eval-report` artifacts from the last 3+ green nightly runs.
+2. For each baselined metric, take the minimum observed value across runs.
+3. Set the threshold to that floor minus a small variance margin (~0.05–0.10
+   for rates), and consider adding `{"max": ...}` caps on `avg_attempts`.
+4. Land the `baselines.json` change with the run links in the PR description.
+
+A metric *missing* from a report (a gate that never ran) fails the check on
+purpose — silently losing a gate is a regression.
+
+## Layout
+
+```
+evals/
+├── golden_set.json      # 8 fixed papers + why each is in the set
+├── metrics.py           # GateMetrics collector + aggregate_summaries (stdlib-only)
+├── run_evals.py         # CLI runner: ingest → generate → report.json
+├── baselines.json       # regression thresholds (see tightening procedure)
+└── check_regression.py  # report vs baselines → exit 1 on regression
+```
+
+The pipeline seam is a single optional module-level callback
+(`agents.pipeline.metrics_hook`) invoked after each gate with
+`(gate_name, attempt, passed)`; it is `None` in production and never affects
+generation behavior. Unit tests: `tests/test_evals.py` (no network).

--- a/backend/evals/baselines.json
+++ b/backend/evals/baselines.json
@@ -1,0 +1,17 @@
+{
+  "_comment": [
+    "Regression thresholds for check_regression.py. Keys under 'metrics' are",
+    "dotted paths into report['aggregate']; values are {'min': x} or {'max': x}.",
+    "These carry generous initial slack. Once 3+ real nightly runs establish",
+    "variance, tighten them toward the observed floor — procedure in",
+    "backend/evals/README.md. render_tester has no threshold: evals run with",
+    "RENDER_MODE=modal, so that gate is disabled by design."
+  ],
+  "metrics": {
+    "viz_yield_rate": { "min": 0.5 },
+    "gates.code_validator.first_attempt_rate": { "min": 0.4 },
+    "gates.code_validator.eventual_rate": { "min": 0.7 },
+    "gates.spatial_validator.eventual_rate": { "min": 0.7 },
+    "gates.voiceover_script_validator.eventual_rate": { "min": 0.7 }
+  }
+}

--- a/backend/evals/check_regression.py
+++ b/backend/evals/check_regression.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Gate CI on generation-quality regressions.
+
+Reads an eval report (run_evals.py output) and a baselines file, compares every
+baseline threshold against the report's aggregate metrics, prints a verdict
+table, and exits 1 if any metric regresses below its floor (or above its cap).
+
+A metric that is missing from the report (e.g. a gate that never ran) counts as
+a failure: silently losing a gate IS a regression.
+
+Usage (from backend/):
+    uv run python evals/check_regression.py report.json evals/baselines.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+
+def resolve_metric(aggregate: dict, dotted_path: str) -> Optional[Any]:
+    """Look up a dotted path (e.g. 'gates.code_validator.eventual_rate')."""
+    node: Any = aggregate
+    for part in dotted_path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def evaluate_thresholds(aggregate: dict, thresholds: dict) -> list[dict]:
+    """Return one row per threshold: {metric, constraint, actual, ok, detail}."""
+    rows = []
+    for metric, spec in thresholds.items():
+        actual = resolve_metric(aggregate, metric)
+        minimum = spec.get("min") if isinstance(spec, dict) else spec
+        maximum = spec.get("max") if isinstance(spec, dict) else None
+
+        if actual is None:
+            ok = False
+            detail = "metric missing from report"
+        elif not isinstance(actual, (int, float)):
+            ok = False
+            detail = f"metric is not numeric: {actual!r}"
+        else:
+            ok = True
+            detail = ""
+            if minimum is not None and actual < minimum:
+                ok = False
+                detail = f"below minimum {minimum}"
+            if maximum is not None and actual > maximum:
+                ok = False
+                detail = f"above maximum {maximum}"
+
+        constraint = []
+        if minimum is not None:
+            constraint.append(f">= {minimum}")
+        if maximum is not None:
+            constraint.append(f"<= {maximum}")
+
+        rows.append(
+            {
+                "metric": metric,
+                "constraint": " and ".join(constraint) or "-",
+                "actual": actual,
+                "ok": ok,
+                "detail": detail,
+            }
+        )
+    return rows
+
+
+def print_table(rows: list[dict]) -> None:
+    width = max([len(r["metric"]) for r in rows] + [len("metric")]) + 2
+    print(f"{'metric':<{width}}{'required':>12}{'actual':>10}  status")
+    print("-" * (width + 32))
+    for r in rows:
+        status = "OK" if r["ok"] else f"FAIL ({r['detail']})"
+        actual = "-" if r["actual"] is None else r["actual"]
+        print(f"{r['metric']:<{width}}{r['constraint']:>12}{str(actual):>10}  {status}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail (exit 1) when eval aggregates regress below baselines."
+    )
+    parser.add_argument("report", help="report.json produced by run_evals.py")
+    parser.add_argument("baselines", help="baselines.json with metric thresholds")
+    args = parser.parse_args(argv)
+
+    report = json.loads(Path(args.report).read_text())
+    baselines = json.loads(Path(args.baselines).read_text())
+
+    thresholds = {
+        k: v
+        for k, v in baselines.get("metrics", {}).items()
+        if not k.startswith("_")
+    }
+    if not thresholds:
+        print("No thresholds defined in baselines file.", file=sys.stderr)
+        return 1
+
+    aggregate = report.get("aggregate", {})
+    rows = evaluate_thresholds(aggregate, thresholds)
+
+    papers = aggregate.get("papers_evaluated")
+    print(
+        f"Regression check: {len(rows)} thresholds vs aggregate of "
+        f"{papers if papers is not None else '?'} paper(s)\n"
+    )
+    print_table(rows)
+
+    failures = [r for r in rows if not r["ok"]]
+    if failures:
+        print(
+            f"\nREGRESSION: {len(failures)}/{len(rows)} metric(s) below baseline.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nAll {len(rows)} metrics within baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/evals/golden_set.json
+++ b/backend/evals/golden_set.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Golden-set papers for generation-quality evals. Order matters: --papers N takes the first N, so cheaper, most load-bearing papers come first (the nightly run uses 5, manual dispatch defaults to 3). The longest/most expensive papers sit at the end.",
+  "papers": [
+    {
+      "arxiv_id": "1706.03762",
+      "title": "Attention Is All You Need",
+      "why": "Core ML architecture paper and the project's canonical demo; attention data-flow diagrams stress the planner and spatial gate."
+    },
+    {
+      "arxiv_id": "1512.03385",
+      "title": "Deep Residual Learning for Image Recognition",
+      "why": "Short, dense architecture paper; residual-block diagrams test structural visualizations."
+    },
+    {
+      "arxiv_id": "2010.11929",
+      "title": "An Image is Worth 16x16 Words (ViT)",
+      "why": "Patch-embedding pipeline; tests grid/patch layouts that historically trigger spatial-validator failures."
+    },
+    {
+      "arxiv_id": "1810.04805",
+      "title": "BERT: Pre-training of Deep Bidirectional Transformers",
+      "why": "Masked-LM objectives; tests token-level sequence visualizations and narration alignment."
+    },
+    {
+      "arxiv_id": "1406.2661",
+      "title": "Generative Adversarial Networks",
+      "why": "Theory-flavored minimax game with equations; tests conceptual/game-dynamics visuals and equation narration."
+    },
+    {
+      "arxiv_id": "1412.6980",
+      "title": "Adam: A Method for Stochastic Optimization",
+      "why": "Optimization theory: update-rule math and convergence intuition; stresses equation-heavy voiceover quality."
+    },
+    {
+      "arxiv_id": "2304.02643",
+      "title": "Segment Anything",
+      "why": "Applied CV system paper; prompt/mask pipeline visuals outside the pure-architecture core."
+    },
+    {
+      "arxiv_id": "2005.14165",
+      "title": "Language Models are Few-Shot Learners (GPT-3)",
+      "why": "Very long applied paper; stresses ingestion + section summarization and plot-style scaling visuals. Kept last for cost."
+    }
+  ]
+}

--- a/backend/evals/metrics.py
+++ b/backend/evals/metrics.py
@@ -1,0 +1,164 @@
+"""Gate-level metrics collection for the generation-quality eval harness.
+
+Consumes the ``(gate_name, attempt, passed)`` events emitted through
+``agents.pipeline.metrics_hook`` and turns them into per-paper and aggregate
+quality metrics. Stdlib-only on purpose: importable (and unit-testable)
+without the ML dependency stack or any network access.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass, field
+from typing import Optional
+
+#: Gates in pipeline order. Every generate_single_visualization run evaluates
+#: ``code_validator`` first on attempt 0, exactly once — which is what lets the
+#: collector split events into per-visualization traces without a viz id.
+GATE_ORDER = (
+    "code_validator",
+    "spatial_validator",
+    "voiceover_script_validator",
+    "render_tester",
+)
+CODE_GATE = GATE_ORDER[0]
+
+
+@dataclass
+class GateEvent:
+    gate: str
+    attempt: int
+    passed: bool
+
+
+@dataclass
+class VizTrace:
+    """Ordered gate events for one generate_single_visualization run."""
+
+    events: list[GateEvent] = field(default_factory=list)
+
+    @property
+    def succeeded(self) -> bool:
+        """True when the final attempt cleared every enabled gate.
+
+        The pipeline breaks out of its retry loop only when an attempt passes
+        all gates, so the last recorded event of a successful run is a pass;
+        an exhausted run always ends on the failing gate's event. (A "silent
+        fallback" visualization returned by VOICE_FAIL_BEHAVIOR=return_silent
+        therefore does NOT count as succeeded — this metric measures whether
+        the LLM actually satisfied the gates.)
+        """
+        return bool(self.events) and self.events[-1].passed
+
+    @property
+    def attempts_used(self) -> int:
+        """Number of generation attempts consumed (1-based)."""
+        if not self.events:
+            return 0
+        return 1 + max(e.attempt for e in self.events)
+
+
+class GateMetrics:
+    """Collects pipeline gate events and summarizes them.
+
+    Attribution of events to visualization runs works without a viz id:
+
+    * every run emits ``(code_validator, attempt=0)`` exactly once, before any
+      other event — so that event starts a new trace;
+    * concurrent runs are separated by a ``ContextVar``: asyncio gives each
+      gathered task its own Context copy, so the "current trace" pointer set
+      inside one task is invisible to its siblings, while this collector's
+      trace list (a shared object) sees every append.
+    """
+
+    def __init__(self) -> None:
+        self.traces: list[VizTrace] = []
+        self._current: contextvars.ContextVar[Optional[VizTrace]] = contextvars.ContextVar(
+            f"gate_metrics_current_{id(self)}", default=None
+        )
+
+    def hook(self, gate: str, attempt: int, passed: bool) -> None:
+        """Signature-compatible with ``agents.pipeline.metrics_hook``."""
+        trace = self._current.get()
+        if trace is None or (gate == CODE_GATE and attempt == 0):
+            trace = VizTrace()
+            self.traces.append(trace)
+            self._current.set(trace)
+        trace.events.append(GateEvent(gate=gate, attempt=attempt, passed=passed))
+
+    def summary(self) -> dict:
+        """Per-paper summary: raw counts only, so summaries aggregate exactly."""
+        gates: dict[str, dict] = {}
+        for gate in GATE_ORDER:
+            evaluated = [t for t in self.traces if any(e.gate == gate for e in t.events)]
+            if not evaluated:
+                continue  # gate disabled (or never reached) in this run
+
+            first = [
+                e
+                for t in evaluated
+                for e in t.events
+                if e.gate == gate and e.attempt == 0
+            ]
+
+            eventual_passes = 0
+            attempts_to_pass_total = 0
+            for t in evaluated:
+                pass_attempts = [e.attempt for e in t.events if e.gate == gate and e.passed]
+                if pass_attempts:
+                    eventual_passes += 1
+                    attempts_to_pass_total += min(pass_attempts) + 1
+
+            gates[gate] = {
+                "vizzes_evaluated": len(evaluated),
+                "first_attempt_evals": len(first),
+                "first_attempt_passes": sum(1 for e in first if e.passed),
+                "eventual_passes": eventual_passes,
+                "total_evals": sum(
+                    1 for t in evaluated for e in t.events if e.gate == gate
+                ),
+                "attempts_to_pass_total": attempts_to_pass_total,
+            }
+
+        return {
+            "candidates_run": len(self.traces),
+            "visualizations_validated": sum(1 for t in self.traces if t.succeeded),
+            "gates": gates,
+        }
+
+
+def _rate(numerator: int, denominator: int) -> Optional[float]:
+    return round(numerator / denominator, 4) if denominator else None
+
+
+def aggregate_summaries(summaries: list[dict]) -> dict:
+    """Combine per-paper summaries into the aggregate metrics that
+    ``baselines.json`` thresholds are checked against (see check_regression.py).
+    """
+    candidates = sum(s["candidates_run"] for s in summaries)
+    validated = sum(s["visualizations_validated"] for s in summaries)
+
+    gates: dict[str, dict] = {}
+    for gate in GATE_ORDER:
+        rows = [s["gates"][gate] for s in summaries if gate in s.get("gates", {})]
+        if not rows:
+            continue
+        first_evals = sum(r["first_attempt_evals"] for r in rows)
+        first_passes = sum(r["first_attempt_passes"] for r in rows)
+        evaluated = sum(r["vizzes_evaluated"] for r in rows)
+        eventual = sum(r["eventual_passes"] for r in rows)
+        attempts_total = sum(r["attempts_to_pass_total"] for r in rows)
+        gates[gate] = {
+            "vizzes_evaluated": evaluated,
+            "first_attempt_rate": _rate(first_passes, first_evals),
+            "eventual_rate": _rate(eventual, evaluated),
+            "avg_attempts": _rate(attempts_total, eventual),
+        }
+
+    return {
+        "papers_evaluated": len(summaries),
+        "candidates_run": candidates,
+        "visualizations_validated": validated,
+        "viz_yield_rate": _rate(validated, candidates),
+        "gates": gates,
+    }

--- a/backend/evals/run_evals.py
+++ b/backend/evals/run_evals.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Golden-set eval runner for the arXivisual generation pipeline.
+
+For each golden-set paper this runner does a REAL arXiv fetch + ingestion and
+runs the REAL multi-agent LLM pipeline (agents.pipeline.generate_visualizations)
+with the GateMetrics hook attached — but with local render testing disabled
+(RENDER_MODE=modal), so the run measures the LLM quality gates (CodeValidator,
+SpatialValidator, VoiceoverScriptValidator), not ffmpeg/cairo.
+
+Requires the LLM provider env (AZURE_OPENAI_API_KEY / AZURE_OPENAI_ENDPOINT /
+AZURE_OPENAI_DEPLOYMENT): this makes real, billable LLM calls. Cost control:
+--papers limits golden-set coverage, --max-viz caps visualizations per paper.
+
+Usage (from backend/):
+    uv run python evals/run_evals.py --papers 3 --max-viz 2 --output report.json
+    uv run python evals/check_regression.py report.json evals/baselines.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from evals.metrics import GateMetrics, aggregate_summaries  # noqa: E402
+
+GOLDEN_SET_PATH = Path(__file__).resolve().parent / "golden_set.json"
+
+
+def _load_pipeline():
+    """Import the pipeline with local render testing disabled.
+
+    ENABLE_RENDER_TESTING is derived from RENDER_MODE at agents.pipeline import
+    time, so the env var must be set BEFORE the import. Deferred into a helper
+    (rather than module top-level) so `--help` and the unit tests can import
+    this module without env side effects or the ML dependency stack.
+    """
+    os.environ["RENDER_MODE"] = "modal"
+    from agents import pipeline
+    from ingestion import ingest_paper
+
+    if pipeline.ENABLE_RENDER_TESTING:
+        raise RuntimeError(
+            "agents.pipeline was imported before run_evals could set "
+            "RENDER_MODE=modal; render testing would skew the eval."
+        )
+    return pipeline, ingest_paper
+
+
+def load_golden_set(limit: int | None = None) -> list[dict]:
+    entries = json.loads(GOLDEN_SET_PATH.read_text())["papers"]
+    if limit is not None:
+        entries = entries[: max(limit, 0)]
+    return entries
+
+
+async def eval_paper(entry: dict, max_viz: int, pipeline, ingest_paper) -> dict:
+    """Ingest one paper and run generation with the metrics hook attached."""
+    result: dict = {
+        "arxiv_id": entry["arxiv_id"],
+        "title": entry.get("title", ""),
+        "why": entry.get("why", ""),
+        "error": None,
+    }
+    metrics = GateMetrics()
+    pipeline.metrics_hook = metrics.hook
+    started = time.monotonic()
+    vizzes: list = []
+    try:
+        paper = await ingest_paper(entry["arxiv_id"], force_refresh=True)
+        vizzes = await pipeline.generate_visualizations(
+            paper, max_visualizations=max_viz
+        )
+    except Exception as exc:  # noqa: BLE001 — one bad paper must not kill the run
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        pipeline.metrics_hook = None
+
+    result["wall_clock_seconds"] = round(time.monotonic() - started, 1)
+    result["visualizations_returned"] = len(vizzes)
+    result.update(metrics.summary())
+    return result
+
+
+async def run_all(entries: list[dict], max_viz: int) -> list[dict]:
+    """Evaluate papers sequentially inside ONE event loop.
+
+    Sequential keeps LLM concurrency bounded (each paper already fans out its
+    own visualization tasks); one loop keeps base.py's cached AsyncOpenAI
+    client bound to a live loop across papers.
+    """
+    pipeline, ingest_paper = _load_pipeline()
+    results = []
+    for i, entry in enumerate(entries, 1):
+        print(f"\n[{i}/{len(entries)}] {entry['arxiv_id']} — {entry.get('title', '')}")
+        result = await eval_paper(entry, max_viz, pipeline, ingest_paper)
+        status = result["error"] or (
+            f"{result['visualizations_validated']}/{result['candidates_run']} validated "
+            f"in {result['wall_clock_seconds']}s"
+        )
+        print(f"    -> {status}")
+        results.append(result)
+    return results
+
+
+def build_report(paper_results: list[dict], max_viz: int) -> dict:
+    ok = [p for p in paper_results if p.get("error") is None]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "config": {
+            "max_visualizations": max_viz,
+            "render_testing_enabled": False,
+            "papers_requested": len(paper_results),
+        },
+        "papers": paper_results,
+        "aggregate": aggregate_summaries(ok),
+    }
+
+
+def print_summary(report: dict) -> None:
+    print("\n" + "=" * 72)
+    print("Per-paper results")
+    print("-" * 72)
+    print(f"{'paper':<14}{'cand':>6}{'valid':>7}{'returned':>10}{'wall(s)':>10}  error")
+    for p in report["papers"]:
+        print(
+            f"{p['arxiv_id']:<14}{p['candidates_run']:>6}"
+            f"{p['visualizations_validated']:>7}{p['visualizations_returned']:>10}"
+            f"{p['wall_clock_seconds']:>10}  {p['error'] or '-'}"
+        )
+
+    agg = report["aggregate"]
+    print("-" * 72)
+    print(
+        f"Aggregate: {agg['papers_evaluated']} papers, "
+        f"{agg['visualizations_validated']}/{agg['candidates_run']} visualizations "
+        f"validated (viz_yield_rate={agg['viz_yield_rate']})"
+    )
+    print(f"\n{'gate':<28}{'first-attempt':>14}{'eventual':>10}{'avg attempts':>14}")
+    for gate, row in agg["gates"].items():
+        print(
+            f"{gate:<28}{str(row['first_attempt_rate']):>14}"
+            f"{str(row['eventual_rate']):>10}{str(row['avg_attempts']):>14}"
+        )
+    print("=" * 72)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run generation-quality evals over the golden paper set."
+    )
+    parser.add_argument(
+        "--papers",
+        type=int,
+        default=None,
+        metavar="N",
+        help="evaluate only the first N golden-set papers (default: all)",
+    )
+    parser.add_argument(
+        "--max-viz",
+        type=int,
+        default=2,
+        metavar="M",
+        help="cap visualizations generated per paper (cost control, default: 2)",
+    )
+    parser.add_argument(
+        "--output",
+        default="report.json",
+        help="path for the JSON report (default: report.json)",
+    )
+    args = parser.parse_args(argv)
+
+    entries = load_golden_set(args.papers)
+    if not entries:
+        print("No golden-set papers selected.", file=sys.stderr)
+        return 1
+
+    print(
+        f"Evaluating {len(entries)} golden-set paper(s), "
+        f"max {args.max_viz} visualization(s) each (render testing disabled)."
+    )
+    results = asyncio.run(run_all(entries, args.max_viz))
+
+    report = build_report(results, args.max_viz)
+    output = Path(args.output)
+    output.write_text(json.dumps(report, indent=2) + "\n")
+    print_summary(report)
+    print(f"\nReport written to {output}")
+
+    if all(p["error"] for p in results):
+        print("ERROR: every paper failed to evaluate.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_evals.py
+++ b/backend/tests/test_evals.py
@@ -1,0 +1,512 @@
+"""Unit tests for the generation-quality eval harness (backend/evals).
+
+No network, no LLM calls: the pipeline is driven with fakes, and the
+report-writing / regression-checking path runs on synthetic metrics.
+"""
+
+import asyncio
+import contextvars
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from agents import pipeline
+from evals import check_regression
+from evals.metrics import GateMetrics, aggregate_summaries
+from evals.run_evals import build_report, load_golden_set
+from models.generation import (
+    GeneratedCode,
+    Scene,
+    ValidatorOutput,
+    VisualizationCandidate,
+    VisualizationPlan,
+    VisualizationType,
+)
+from models.spatial import SpatialValidatorOutput
+from models.voiceover import VoiceoverValidationOutput
+
+BASELINES_PATH = BACKEND_ROOT / "evals" / "baselines.json"
+
+
+# ---------------------------------------------------------------------------
+# GateMetrics: hook counting math
+# ---------------------------------------------------------------------------
+
+
+def _events(trace):
+    return [(e.gate, e.attempt, e.passed) for e in trace.events]
+
+
+def test_hook_splits_traces_on_code_gate_attempt_zero():
+    gm = GateMetrics()
+    # viz A: clean first-attempt pass through two gates
+    gm.hook("code_validator", 0, True)
+    gm.hook("spatial_validator", 0, True)
+    # viz B: passes only on attempt 2
+    gm.hook("code_validator", 0, False)
+    gm.hook("code_validator", 1, True)
+    gm.hook("spatial_validator", 1, False)
+    gm.hook("code_validator", 2, True)
+    gm.hook("spatial_validator", 2, True)
+
+    assert len(gm.traces) == 2
+    a, b = gm.traces
+    assert _events(a) == [("code_validator", 0, True), ("spatial_validator", 0, True)]
+    assert a.succeeded and a.attempts_used == 1
+    assert b.succeeded and b.attempts_used == 3
+
+    summary = gm.summary()
+    assert summary["candidates_run"] == 2
+    assert summary["visualizations_validated"] == 2
+
+    code = summary["gates"]["code_validator"]
+    assert code == {
+        "vizzes_evaluated": 2,
+        "first_attempt_evals": 2,
+        "first_attempt_passes": 1,
+        "eventual_passes": 2,
+        "total_evals": 4,
+        "attempts_to_pass_total": 3,  # A passes attempt 1, B attempt 2
+    }
+
+    spatial = summary["gates"]["spatial_validator"]
+    assert spatial == {
+        "vizzes_evaluated": 2,
+        "first_attempt_evals": 1,  # B never reached spatial on attempt 0
+        "first_attempt_passes": 1,
+        "eventual_passes": 2,
+        "total_evals": 3,
+        "attempts_to_pass_total": 4,  # A attempt 1, B attempt 3
+    }
+
+
+def test_exhausted_run_counts_as_not_validated():
+    gm = GateMetrics()
+    gm.hook("code_validator", 0, True)
+    gm.hook("spatial_validator", 0, False)
+    gm.hook("code_validator", 1, False)
+    gm.hook("code_validator", 2, False)  # retry budget exhausted, last event fails
+
+    [trace] = gm.traces
+    assert not trace.succeeded
+    summary = gm.summary()
+    assert summary["candidates_run"] == 1
+    assert summary["visualizations_validated"] == 0
+    assert summary["gates"]["code_validator"]["eventual_passes"] == 1
+    assert summary["gates"]["spatial_validator"]["eventual_passes"] == 0
+    # A gate that never ran is absent from the summary.
+    assert "voiceover_script_validator" not in summary["gates"]
+
+
+def test_hook_separates_concurrent_tasks_via_contexts():
+    """Interleaved events from two contexts (as asyncio.gather produces) must
+    land in the right trace: each task context keeps its own current-trace
+    pointer."""
+    gm = GateMetrics()
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+
+    ctx_a.run(gm.hook, "code_validator", 0, True)
+    ctx_b.run(gm.hook, "code_validator", 0, False)
+    ctx_a.run(gm.hook, "spatial_validator", 0, False)
+    ctx_b.run(gm.hook, "code_validator", 1, True)
+    ctx_a.run(gm.hook, "code_validator", 1, True)
+    ctx_b.run(gm.hook, "spatial_validator", 1, True)
+    ctx_a.run(gm.hook, "spatial_validator", 1, True)
+
+    assert len(gm.traces) == 2
+    a, b = gm.traces
+    assert _events(a) == [
+        ("code_validator", 0, True),
+        ("spatial_validator", 0, False),
+        ("code_validator", 1, True),
+        ("spatial_validator", 1, True),
+    ]
+    assert _events(b) == [
+        ("code_validator", 0, False),
+        ("code_validator", 1, True),
+        ("spatial_validator", 1, True),
+    ]
+    assert a.succeeded and b.succeeded
+
+
+def test_aggregate_summaries_math():
+    gm = GateMetrics()
+    gm.hook("code_validator", 0, True)
+    gm.hook("spatial_validator", 0, True)
+    gm.hook("code_validator", 0, False)
+    gm.hook("code_validator", 1, True)
+    gm.hook("spatial_validator", 1, False)
+    gm.hook("code_validator", 2, True)
+    gm.hook("spatial_validator", 2, True)
+
+    agg = aggregate_summaries([gm.summary()])
+    assert agg["papers_evaluated"] == 1
+    assert agg["candidates_run"] == 2
+    assert agg["visualizations_validated"] == 2
+    assert agg["viz_yield_rate"] == 1.0
+
+    code = agg["gates"]["code_validator"]
+    assert code["first_attempt_rate"] == 0.5
+    assert code["eventual_rate"] == 1.0
+    assert code["avg_attempts"] == 1.5
+
+    spatial = agg["gates"]["spatial_validator"]
+    assert spatial["first_attempt_rate"] == 1.0
+    assert spatial["avg_attempts"] == 2.0
+
+
+def test_aggregate_summaries_handles_missing_gates_and_empty_input():
+    paper_with_spatial = GateMetrics()
+    paper_with_spatial.hook("code_validator", 0, True)
+    paper_with_spatial.hook("spatial_validator", 0, True)
+
+    paper_without_spatial = GateMetrics()
+    paper_without_spatial.hook("code_validator", 0, False)
+    paper_without_spatial.hook("code_validator", 1, False)
+    paper_without_spatial.hook("code_validator", 2, False)
+
+    agg = aggregate_summaries(
+        [paper_with_spatial.summary(), paper_without_spatial.summary()]
+    )
+    assert agg["viz_yield_rate"] == 0.5
+    assert agg["gates"]["spatial_validator"]["vizzes_evaluated"] == 1
+    assert agg["gates"]["code_validator"]["first_attempt_rate"] == 0.5
+    # code_validator never passed for paper 2 -> avg over the single pass
+    assert agg["gates"]["code_validator"]["avg_attempts"] == 1.0
+
+    empty = aggregate_summaries([])
+    assert empty["papers_evaluated"] == 0
+    assert empty["viz_yield_rate"] is None
+    assert empty["gates"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline seam: metrics_hook wiring (fakes, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def _candidate() -> VisualizationCandidate:
+    return VisualizationCandidate(
+        section_id="section-1",
+        concept_name="Scaled Dot-Product Attention",
+        concept_description="Query-key similarity, softmax, value aggregation.",
+        visualization_type=VisualizationType.DATA_FLOW,
+        priority=5,
+        context="Attention(Q,K,V)=softmax(QK^T/sqrt(d_k))V",
+    )
+
+
+def _plan() -> VisualizationPlan:
+    return VisualizationPlan(
+        concept_name="Scaled Dot-Product Attention",
+        visualization_type=VisualizationType.DATA_FLOW,
+        duration_seconds=30,
+        scenes=[
+            Scene(
+                order=1,
+                description="beat",
+                duration_seconds=10,
+                transitions="Write",
+                elements=["Text"],
+            )
+        ],
+        narration_points=[],
+    )
+
+
+def _code(tag: str) -> GeneratedCode:
+    return GeneratedCode(
+        code=f"# {tag}\nfrom manim import *\n",
+        scene_class_name="Viz",
+        dependencies=["manim"],
+        voiceover_enabled=False,
+        narration_lines=[],
+        narration_beats=[],
+    )
+
+
+class _FakePaper:
+    def get_section_by_id(self, _sid):
+        return None
+
+    def get_context(self):
+        return "context"
+
+
+class _FakePlanner:
+    async def run(self, candidate, full_section_content, paper_context):
+        return _plan()
+
+
+class _FakeGenerator:
+    def __init__(self):
+        self.calls = 0
+
+    async def run(self, **_kwargs):
+        self.calls += 1
+        return _code(f"attempt-{self.calls}")
+
+    async def run_with_feedback(self, **_kwargs):
+        self.calls += 1
+        return _code(f"attempt-{self.calls}")
+
+
+class _FlakyValidator:
+    """Fails the first N validations, passes afterwards."""
+
+    def __init__(self, fail_first: int = 0):
+        self.calls = 0
+        self.fail_first = fail_first
+
+    def validate(self, code):
+        self.calls += 1
+        if self.calls <= self.fail_first:
+            return ValidatorOutput(
+                is_valid=False,
+                code=code,
+                issues_found=["SyntaxError: unexpected token"],
+                needs_regeneration=True,
+            )
+        return ValidatorOutput(
+            is_valid=True, code=code, issues_found=[], needs_regeneration=False
+        )
+
+
+class _PassingSpatial:
+    def validate(self, code):
+        return SpatialValidatorOutput(
+            has_spatial_issues=False, needs_regeneration=False
+        )
+
+
+class _PassingVoice:
+    def validate(self, generated_code, plan, candidate):
+        return VoiceoverValidationOutput(
+            is_valid=True,
+            score_alignment=0.9,
+            score_educational=0.9,
+            needs_regeneration=False,
+        )
+
+
+def _run_single(monkeypatch, *, voiceover=False, validator=None, voice=None):
+    monkeypatch.setattr(pipeline, "ENABLE_VOICEOVER", voiceover)
+    return asyncio.run(
+        pipeline.generate_single_visualization(
+            candidate=_candidate(),
+            paper=_FakePaper(),
+            planner=_FakePlanner(),
+            generator=_FakeGenerator(),
+            validator=validator or _FlakyValidator(),
+            spatial_validator=_PassingSpatial(),
+            voiceover_script_validator=voice,
+            render_tester=None,
+        )
+    )
+
+
+def test_metrics_hook_defaults_to_none():
+    assert pipeline.metrics_hook is None
+
+
+def test_pipeline_reports_gate_events_through_hook(monkeypatch):
+    gm = GateMetrics()
+    monkeypatch.setattr(pipeline, "metrics_hook", gm.hook)
+
+    viz = _run_single(monkeypatch, validator=_FlakyValidator(fail_first=1))
+
+    assert viz is not None
+    [trace] = gm.traces
+    assert _events(trace) == [
+        ("code_validator", 0, False),
+        ("code_validator", 1, True),
+        ("spatial_validator", 1, True),
+    ]
+    assert trace.succeeded
+
+
+def test_pipeline_reports_voiceover_gate(monkeypatch):
+    gm = GateMetrics()
+    monkeypatch.setattr(pipeline, "metrics_hook", gm.hook)
+
+    viz = _run_single(monkeypatch, voiceover=True, voice=_PassingVoice())
+
+    assert viz is not None
+    [trace] = gm.traces
+    assert _events(trace) == [
+        ("code_validator", 0, True),
+        ("spatial_validator", 0, True),
+        ("voiceover_script_validator", 0, True),
+    ]
+
+
+def test_raising_hook_never_breaks_generation(monkeypatch):
+    def bad_hook(gate, attempt, passed):
+        raise RuntimeError("metrics exploded")
+
+    monkeypatch.setattr(pipeline, "metrics_hook", bad_hook)
+    viz = _run_single(monkeypatch)
+    assert viz is not None
+
+
+# ---------------------------------------------------------------------------
+# check_regression: pass/fail logic on synthetic reports
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(**overrides):
+    aggregate = {
+        "papers_evaluated": 2,
+        "candidates_run": 4,
+        "visualizations_validated": 3,
+        "viz_yield_rate": 0.75,
+        "gates": {
+            "code_validator": {
+                "first_attempt_rate": 0.5,
+                "eventual_rate": 1.0,
+                "avg_attempts": 1.5,
+            },
+            "spatial_validator": {
+                "first_attempt_rate": 0.75,
+                "eventual_rate": 0.75,
+                "avg_attempts": 1.2,
+            },
+            "voiceover_script_validator": {
+                "first_attempt_rate": 0.5,
+                "eventual_rate": 0.75,
+                "avg_attempts": 1.8,
+            },
+        },
+    }
+    aggregate.update(overrides)
+    return aggregate
+
+
+def test_evaluate_thresholds_pass_fail_missing_and_max():
+    thresholds = {
+        "viz_yield_rate": {"min": 0.5},
+        "gates.code_validator.eventual_rate": {"min": 0.7},
+        "gates.code_validator.avg_attempts": {"max": 2.0},
+        "gates.render_tester.eventual_rate": {"min": 0.7},  # gate disabled -> missing
+    }
+    rows = {
+        r["metric"]: r
+        for r in check_regression.evaluate_thresholds(_aggregate(), thresholds)
+    }
+    assert rows["viz_yield_rate"]["ok"]
+    assert rows["gates.code_validator.eventual_rate"]["ok"]
+    assert rows["gates.code_validator.avg_attempts"]["ok"]
+    assert not rows["gates.render_tester.eventual_rate"]["ok"]
+    assert "missing" in rows["gates.render_tester.eventual_rate"]["detail"]
+
+
+def test_evaluate_thresholds_flags_regression_and_bare_numbers():
+    rows = check_regression.evaluate_thresholds(
+        _aggregate(viz_yield_rate=0.25),
+        {"viz_yield_rate": 0.5},  # bare number == minimum
+    )
+    assert rows == [
+        {
+            "metric": "viz_yield_rate",
+            "constraint": ">= 0.5",
+            "actual": 0.25,
+            "ok": False,
+            "detail": "below minimum 0.5",
+        }
+    ]
+
+
+def _write(tmp_path, name, payload):
+    path = tmp_path / name
+    path.write_text(json.dumps(payload))
+    return str(path)
+
+
+def test_check_regression_main_exit_codes(tmp_path, capsys):
+    baselines = {"metrics": {"viz_yield_rate": {"min": 0.5}}}
+    good = _write(tmp_path, "good.json", {"aggregate": _aggregate()})
+    bad = _write(
+        tmp_path, "bad.json", {"aggregate": _aggregate(viz_yield_rate=0.1)}
+    )
+    baselines_path = _write(tmp_path, "baselines.json", baselines)
+
+    assert check_regression.main([good, baselines_path]) == 0
+    assert check_regression.main([bad, baselines_path]) == 1
+    out = capsys.readouterr()
+    assert "REGRESSION" in out.err
+
+
+def test_check_regression_empty_baselines_fails(tmp_path):
+    report = _write(tmp_path, "r.json", {"aggregate": _aggregate()})
+    empty = _write(tmp_path, "b.json", {"metrics": {}})
+    assert check_regression.main([report, empty]) == 1
+
+
+# ---------------------------------------------------------------------------
+# End to end (mocked metrics): report writing -> regression check
+# ---------------------------------------------------------------------------
+
+
+def _paper_result(arxiv_id: str, gm: GateMetrics, error=None) -> dict:
+    return {
+        "arxiv_id": arxiv_id,
+        "title": "t",
+        "why": "w",
+        "error": error,
+        "wall_clock_seconds": 12.3,
+        "visualizations_returned": len(gm.traces),
+        **gm.summary(),
+    }
+
+
+def test_report_writing_and_regression_check_end_to_end(tmp_path):
+    """GateMetrics -> build_report -> report.json -> check_regression against
+    the REAL baselines.json — the exact chain the CI workflow runs."""
+    healthy = GateMetrics()
+    for _ in range(2):  # two vizzes, all LLM gates pass first attempt
+        healthy.hook("code_validator", 0, True)
+        healthy.hook("spatial_validator", 0, True)
+        healthy.hook("voiceover_script_validator", 0, True)
+
+    errored = GateMetrics()  # ingestion failed: no events, error recorded
+
+    report = build_report(
+        [
+            _paper_result("1706.03762", healthy),
+            _paper_result("9999.99999", errored, error="ValueError: not found"),
+        ],
+        max_viz=2,
+    )
+    # Errored papers are excluded from the aggregate.
+    assert report["aggregate"]["papers_evaluated"] == 1
+    assert report["aggregate"]["viz_yield_rate"] == 1.0
+
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report, indent=2))
+
+    assert check_regression.main([str(report_path), str(BASELINES_PATH)]) == 0
+
+    # Now degrade code quality below the baseline floor and expect a failure.
+    degraded = GateMetrics()
+    degraded.hook("code_validator", 0, False)
+    degraded.hook("code_validator", 1, False)
+    degraded.hook("code_validator", 2, False)
+    bad_report = build_report([_paper_result("1706.03762", degraded)], max_viz=2)
+    bad_path = tmp_path / "bad_report.json"
+    bad_path.write_text(json.dumps(bad_report))
+    assert check_regression.main([str(bad_path), str(BASELINES_PATH)]) == 1
+
+
+def test_golden_set_shape_and_limit():
+    entries = load_golden_set()
+    assert len(entries) == 8
+    for entry in entries:
+        assert entry["arxiv_id"] and entry["why"]
+    assert [e["arxiv_id"] for e in load_golden_set(3)] == [
+        e["arxiv_id"] for e in entries[:3]
+    ]


### PR DESCRIPTION
The third build of the batch: a golden-set eval harness measuring what unit tests can't — **whether the LLM pipeline still produces good output** — wired into a nightly workflow that fails on regression.

## What it measures
Per gate (code / spatial / voiceover): **first-attempt pass rate** (the best prompt-quality signal), eventual pass rate, attempts used. Per paper: visualization yield, wall-clock. Runs real ingestion + real generation with render-testing disabled (`RENDER_MODE=modal` set pre-import), so it measures the LLM gates, not ffmpeg — **~$0.05–0.15/paper**.

## Design points worth reviewing
- **18-line seam** in `agents/pipeline.py`: an optional module-level `metrics_hook` called after each gate verdict; zero behavior change when `None`
- Concurrent generation runs attributed via a per-collector `ContextVar` — `asyncio.gather` tasks can't cross-contaminate traces
- Silent-fallback visualizations (`return_silent`) can't inflate yield
- **A missing metric counts as a regression** — a gate silently vanishing is itself a bug
- Golden set: 8 verified classics (Attention → GPT-3), cheapest-first, each with a rationale
- Baselines start generous; README documents the tightening procedure after 3+ nightly runs establish variance

## CI
`evals.yml`: nightly 06:00 UTC (5 papers) + manual dispatch (3), concurrency-grouped, 45-min timeout, `report.json` uploaded as artifact even on failure. Repo secrets (`AZURE_OPENAI_API_KEY/ENDPOINT/DEPLOYMENT`) are already set.

## Tests
15 new, no network: metric math, concurrent attribution, exhausted-run accounting, regression pass/fail/missing/max logic, and a mocked end-to-end chain against the **real** baselines.json. **82 passed, 4 skipped.**