### PR TITLE
docs: rewrite backend/CLAUDE.md and backend/README.md to match reality

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,285 +1,112 @@
-# Team 3: Rendering Backend & Infrastructure
+# arXivisual Backend — Agent Context
 
-## Mission
-
-Build the video rendering infrastructure that takes Manim code from Team 2, renders it serverlessly via Modal.com, stores videos in S3/R2, and exposes REST API endpoints that Team 4 (Frontend) consumes.
-
----
+FastAPI service that turns an arXiv ID into narrated Manim explainer videos, live on Azure Container Apps
+(arxivisual.org). Deep dive: `../docs/ARCHITECTURE.md`. Infra (Terraform, production): `../infra/README.md`.
 
 ## Architecture
 
 ```
-Team 2 Output                    Team 3 Infrastructure                       Team 4 Input
-     │                                    │                                       │
-     ▼                                    ▼                                       ▼
-[Manim Code] ──► [Modal.com Runner] ──► [S3/R2 Storage] ──► [REST API] ──► [Frontend]
-                       │                                         │
-                       ▼                                         ▼
-              [PostgreSQL Cache]                          [JSON + Video URLs]
-                       │
-                       ▼
-               [Redis Job Queue]
+POST /api/process  (api/routes.py: rate-limit + dedupe [api/throttle.py] + stale-job reap [db/queries.py])
+        │
+        ├─ USE_TEMPORAL=1 → Temporal workflow  paper-{arxiv_id}   (temporal_app/workflows.py, durable)
+        └─ off / Temporal error → FastAPI BackgroundTasks legacy path (jobs/worker.py) — fail-open
+        │
+  ingest (ingestion/) → agent pipeline (agents/pipeline.py) → parallel renders
+  (rendering/local_runner.py: manim subprocess + TTS) → Cloudflare R2 upload (rendering/storage.py)
+  → visual QA (agents/visual_qa.py) → repair pass (temporal_app/activities.py) → honest finalize
+        │
+  Postgres via async SQLAlchemy (db/) ← frontend polls GET /api/status/{job_id}
 ```
 
----
+- **LLM**: Azure OpenAI GPT-5 family, provider-switchable via `agents/base.py` (Dedalus = legacy fallback).
+- **TTS**: Azure OpenAI `gpt-4o-mini-tts` as manim-voiceover `OpenAIService`; env routed to Azure's
+  OpenAI-compatible endpoint at render time by `rendering/local_runner.py:_tts_subprocess_env`.
+- **Rendering**: local subprocess (`RENDER_MODE=local`, the default and what prod runs). Modal exists
+  (`rendering/modal_runner.py`) only as an unused optional mode. **There is no Redis anywhere.**
+- **DB**: Postgres (asyncpg) when `DATABASE_URL` set, SQLite `./arxiviz.db` locally. No alembic — schema is
+  `Base.metadata.create_all` in `db/connection.py:init_db()` at startup.
+- **Observability**: Langfuse v3 (OTel-based) — `langfuse.openai` drop-in client wraps every LLM call, plus
+  `@observe` spans; active iff both `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set.
 
-## What We Build
+## Pipeline stages (agents/pipeline.py)
 
-1. **Modal.com Manim Runner** - Serverless Manim code execution
-2. **S3/R2 Video Storage** - Upload and serve rendered videos
-3. **PostgreSQL Database** - Paper metadata, job status, cached results
-4. **Redis Job Queue** - Async processing with progress tracking
-5. **FastAPI REST API** - Contract with Team 4 (Frontend)
+| # | Stage | File | Kind |
+|---|-------|------|------|
+| 1 | SectionAnalyzer | `agents/section_analyzer.py` | LLM: pick concepts worth animating |
+| 2 | VisualizationPlanner | `agents/visualization_planner.py` | LLM: scene-by-scene storyboard |
+| 3 | ManimGenerator (voice-aware) | `agents/manim_generator.py` | LLM: full `VoiceoverScene` code, few-shot by viz type |
+| 4 | CodeValidator | `agents/code_validator.py` | gate: AST/structure/auto-fixes, no LLM |
+| 5 | SpatialValidator | `agents/spatial_validator.py` | gate: bounds/overlap regex, no LLM |
+| 6 | VoiceoverScriptValidator | `agents/voiceover_script_validator.py` | gate: narration quality, heuristics + LLM judge |
+| 7 | RenderTester | `agents/render_tester.py` | gate: compile + import test (auto-skipped when `RENDER_MODE=modal`) |
 
----
+Gate failure → regenerate with combined feedback (`MAX_RETRIES=3` + `VOICE_QUALITY_RETRIES=2` attempts); all
+attempts failing → `VOICE_FAIL_BEHAVIOR="return_silent"`. Gates report to the eval harness through the
+`agents.pipeline.metrics_hook` seam (None in production). After rendering, a vision judge samples frames for
+layout defects (`agents/visual_qa.py`); on the Temporal path a `severity=major` verdict can drive one
+closed-loop layout repair + re-render (`temporal_app/activities.py:repair_visualization_code`).
 
-## Key Commands
+## Commands (from `backend/`)
 
 ```bash
-# Run API server (development)
-uvicorn main:app --reload --port 8000
-
-# Test Modal function locally
-modal run rendering/modal_runner.py
-
-# Deploy Modal function
-modal deploy rendering/modal_runner.py
-
-# Run database migrations
-alembic upgrade head
-
-# Start Redis (Docker)
-docker run -d --name arxiviz-redis -p 6379:6379 redis:7
-
-# Start PostgreSQL (Docker)
-docker run -d --name arxiviz-postgres -e POSTGRES_USER=arxiviz -e POSTGRES_PASSWORD=arxiviz -e POSTGRES_DB=arxiviz -p 5432:5432 postgres:15
+uv sync --extra dev                          # install (dev extra = pytest)
+uv run pytest tests/                         # unit suite (~89 tests, hermetic; CI hard gate on py3.11+3.13)
+TEMPORAL_TESTS=1 uv run pytest tests/test_temporal_pipeline.py   # integration (downloads Temporal dev server)
+uvx ruff check .                             # lint — HARD CI gate; the tree is ruff-clean (policy in pyproject)
+uv run uvicorn main:app --reload             # API on :8000, docs at /docs
+uv run python -m temporal_app.worker         # Temporal worker (paper-pipeline + paper-render queues)
+uv run python evals/run_evals.py --papers 2 --max-viz 2 --output report.json   # real LLM spend (~$0.05–0.15/paper)
+uv run python evals/check_regression.py report.json evals/baselines.json
 ```
 
----
+CI (`.github/workflows/`): `ci.yml` — backend pytest, frontend tsc + build, docker image build (hard gates;
+backend ruff and frontend eslint are both HARD gates). `security.yml` — gitleaks secret scan (blocking) + npm/pip audit
+(advisory). `evals.yml` — nightly 06:00 UTC golden-set evals, fails on baseline regression. `deploy-backend.yml`
+— Azure OIDC login, ACR build, Container App roll, health verify.
 
-## API Endpoints (We Own This Contract)
+## Env vars (\* = secret; template: `.env.example`)
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/process` | Start processing a paper |
-| GET | `/api/status/{job_id}` | Poll processing status |
-| GET | `/api/paper/{arxiv_id}` | Get processed paper with videos |
-| GET | `/api/video/{video_id}` | Get video URL |
-| GET | `/api/health` | Health check |
+- `AZURE_OPENAI_API_KEY`\*, `AZURE_OPENAI_ENDPOINT` — primary provider (auto-detected; `LLM_PROVIDER=azure|dedalus` forces).
+- `AZURE_OPENAI_DEPLOYMENT` (default `gpt-5`), `AZURE_OPENAI_REASONING_EFFORT` (default `low`).
+- `DEDALUS_API_KEY`\* — legacy fallback provider (also powers optional Context7 docs via `agents/context7_docs.py`).
+- `DATABASE_URL`\* — Postgres; `postgres://` is auto-rewritten to `postgresql+asyncpg://`. Unset = SQLite.
+- `STORAGE_MODE` `local|r2`; for r2: `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`\*, `S3_SECRET_KEY`\*, `S3_PUBLIC_URL`.
+- `LANGFUSE_PUBLIC_KEY`\*, `LANGFUSE_SECRET_KEY`\*, `LANGFUSE_HOST`, `LANGFUSE_TRACING_ENVIRONMENT`.
+- `ENVIRONMENT=production` — disables `POST /api/render` (404) unless `RENDER_API_SECRET`\* matches the
+  `X-Render-Secret` header. The endpoint executes caller-supplied Python; keep it locked.
+- `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_GLOBAL` (30/h), `RATE_LIMIT_PROCESS_WINDOW_SECONDS`
+  (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600) — cost fuse on `/api/process` (`api/throttle.py`).
+- `TEMPORAL_ADDRESS` (`localhost:7233`), `TEMPORAL_NAMESPACE` (`default`), `TEMPORAL_TLS=1` (prod reaches
+  Temporal via HTTP/2 ingress behind TLS :443 — raw TCP ingress is unroutable on Container Apps).
 
-### Response Schemas
+## Feature flags
 
-```python
-# POST /api/process
-{"job_id": "uuid", "status": "queued", "paper_id": "1706.03762"}
+- `USE_TEMPORAL=1` — durable orchestration; any Temporal error falls back (fail-open) to the legacy in-process path.
+- `ENABLE_VISUAL_QA=1` — vision judge on rendered frames (observe-only on legacy path; verdict feeds repair on Temporal path).
+- `VISUAL_QA_REPAIR=1` — one repair round for `major` defects (Temporal path only). Also: `VISUAL_QA_MODEL`
+  (`gpt-5-mini`), `VISUAL_QA_FRAMES` (3).
+- `VOICEOVER_TTS_SERVICE` `openai|gtts` (default `openai` = Azure-routed), `VOICEOVER_VOICE_NAME` (`nova`),
+  `VOICEOVER_TTS_MODEL` (`gpt-4o-mini-tts`), `VOICEOVER_CACHE_DIR` (`/tmp/arxivisual-tts-cache`).
+- `RENDER_CONCURRENCY` (3) — parallel manim renders per host; `PIPELINE_CONCURRENCY` (2) — concurrent
+  generations on the Temporal worker (surplus queues on the server).
+- `RENDER_MODE` `local|modal` (default `local`; `modal` also disables the local RenderTester gate).
 
-# GET /api/status/{job_id}
-{
-  "job_id": "uuid",
-  "status": "processing",  # queued | processing | completed | failed
-  "progress": 0.6,
-  "sections_completed": 3,
-  "sections_total": 5,
-  "current_step": "Rendering videos",
-  "error": null
-}
+## Conventions — do not violate
 
-# GET /api/paper/{arxiv_id}
-{
-  "paper_id": "1706.03762",
-  "title": "Attention Is All You Need",
-  "authors": ["Ashish Vaswani", ...],
-  "abstract": "...",
-  "pdf_url": "https://arxiv.org/pdf/1706.03762",
-  "sections": [
-    {"id": "s1", "title": "Introduction", "content": "...", "video_url": "/api/video/xyz"}
-  ]
-}
-```
-
----
-
-## File Structure
-
-```
-backend/
-├── __init__.py
-├── main.py                      # FastAPI app entry point
-├── CLAUDE.md                    # This file
-├── requirements.txt
-├── .env.example
-├── rendering/
-│   ├── __init__.py              # process_visualization(), process_all_visualizations()
-│   ├── modal_runner.py          # Modal.com function: render_manim()
-│   └── storage.py               # upload_video(), get_video_url()
-├── db/
-│   ├── __init__.py
-│   ├── models.py                # Paper, Section, Visualization, ProcessingJob
-│   ├── connection.py            # async engine, session factory
-│   └── queries.py               # get_paper(), create_job(), update_status()
-├── queue/
-│   ├── __init__.py
-│   └── worker.py                # process_paper_job(), create_job()
-└── api/
-    ├── __init__.py
-    ├── routes.py                # FastAPI router with all endpoints
-    └── schemas.py               # Pydantic request/response models
-```
-
----
-
-## Environment Variables Required
-
-```env
-# Database
-DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/arxiviz
-
-# Redis
-REDIS_URL=redis://localhost:6379
-
-# S3/R2 Storage
-S3_ENDPOINT=https://xxx.r2.cloudflarestorage.com
-S3_BUCKET=arxiviz-videos
-S3_ACCESS_KEY=your_key
-S3_SECRET_KEY=your_secret
-S3_PUBLIC_URL=https://videos.arxiviz.org
-
-# Modal.com
-MODAL_TOKEN_ID=your_id
-MODAL_TOKEN_SECRET=your_secret
-```
-
----
-
-## Integration Points
-
-### Input from Team 2
-We receive `list[Visualization]` where each has:
-- `manim_code`: Complete Python code to render
-- `section_id`: Which section this visualization belongs to
-- `concept`: Human-readable description (e.g., "Scaled Dot-Product Attention")
-
-### Output to Team 4
-- REST API with JSON responses
-- Video URLs pointing to S3/R2 public bucket
-- Progress updates via `/api/status/{job_id}` polling
-
----
-
-## Dependencies
-
-```
-# API
-fastapi>=0.109.0
-uvicorn>=0.27.0
-python-multipart>=0.0.6
-
-# Database
-sqlalchemy>=2.0.0
-asyncpg>=0.29.0
-alembic>=1.13.0
-
-# Storage
-boto3>=1.34.0
-
-# Queue
-redis>=5.0.0
-
-# Modal.com
-modal>=0.60.0
-
-# Utilities
-pydantic>=2.0.0
-python-dotenv>=1.0.0
-httpx>=0.26.0
-```
-
----
-
-## Development Strategy
-
-### Phase 1: Local Development (No External Services)
-- Use existing `manim-mcp-server` for local Manim execution
-- Use local filesystem instead of S3 for videos
-- Use SQLite instead of PostgreSQL
-- Mock Team 2 input with hardcoded test Manim code
-
-### Phase 2: Infrastructure Setup
-- Set up PostgreSQL (Docker)
-- Set up Redis (Docker)
-- Set up Cloudflare R2 bucket
-- Authenticate with Modal.com (`modal token new`)
-
-### Phase 3: Modal.com Integration
-- Deploy Manim runner to Modal.com
-- Test with real rendering
-- Connect to S3/R2 for video storage
-
-### Phase 4: Full API Implementation
-- Implement all FastAPI endpoints
-- Test with curl/Postman
-- Verify response schemas match Team 4 expectations
-
----
-
-## Existing Resources
-
-### 1. manim-mcp-server/ (in repo)
-Local Manim execution - use for development:
-```
-manim-mcp-server/src/manim_server.py
-```
-
-### 2. Original MVP Code (recoverable from git)
-```bash
-git show da1116e^:server/render/render_tile.py  # Manim CLI pattern
-git show da1116e^:server/render/templates/attention_edges_3d.py  # Example template
-git show da1116e^:server/schemas.py  # Pydantic models
-```
-
-### 3. Documentation
-- `docs/AgentDocs/TEAM3_BACKEND.md` - Full implementation guide
-- `docs/AgentDocs/API_SPEC.md` - Detailed API specification
-- `docs/AgentDocs/MANIM_PATTERNS.md` - Manim code examples
-
----
-
-## Test Cases
-
-### Test Modal Runner
-```bash
-modal run rendering/modal_runner.py
-# Should create test_output.mp4
-```
-
-### Test API Endpoints
-```bash
-# Start server
-uvicorn main:app --reload
-
-# Test process
-curl -X POST http://localhost:8000/api/process \
-  -H "Content-Type: application/json" \
-  -d '{"arxiv_id": "1706.03762"}'
-
-# Test status
-curl http://localhost:8000/api/status/{job_id}
-
-# Test paper
-curl http://localhost:8000/api/paper/1706.03762
-```
-
-### Reference Paper
-Test with: **"Attention Is All You Need"** (arXiv:1706.03762)
-
----
-
-## Verification Checklist
-
-- [ ] Modal.com runner can render test Manim code
-- [ ] Videos upload to S3/R2 successfully
-- [ ] PostgreSQL stores paper metadata
-- [ ] Redis tracks job progress
-- [ ] All 4 API endpoints work
-- [ ] Response schemas match Team 4 expectations
-- [ ] End-to-end test with Attention paper
+1. **Per-task DB sessions.** `AsyncSession` is not concurrency-safe: every concurrent task/activity opens its
+   own `async_session_maker()` (see `jobs/worker.py:_render_one`, all of `temporal_app/activities.py`). Never
+   share one session across `asyncio.gather`ed tasks.
+2. **Workflow code stays deterministic and sandbox-clean.** `temporal_app/workflows.py`: no I/O, no env reads,
+   no heavy imports — side effects and env-derived decisions (e.g. `repair_recommended`) belong in activities.
+3. **Never pass `cache_dir` as a str to manim-voiceover** — it crashes the cache lookup. Narration-cache
+   persistence is the runner's symlink (`local_runner.py:_link_persistent_voiceover_cache`); leave the library
+   on its default Path-typed codepath.
+4. **viz IDs use the full sanitized arXiv id**: `viz_{arxiv_id with ./ → _}_{n}`. A truncated prefix collided
+   across sibling ids (2608.23551 vs 2608.23553) and papers overwrote each other's rows.
+5. **Infra changes go through `infra/*.tf`** (terraform plan first — it manages live production), never ad-hoc `az`.
+6. **DB datetime columns are naive UTC** (`datetime.utcnow`). Do not introduce tz-aware datetimes; the dedupe
+   and reaper queries compare naive values.
+7. **All LLM calls route through `agents/base.py`** (`call_llm` / `BaseAgent._call_llm`) — provider switching
+   and Langfuse tracing live there.
+8. **Keep `pytest` hermetic.** `testpaths=["tests"]` exists because scripts under `tools/` fire real API calls
+   on collection; new tests must not need network or real keys.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,345 +1,87 @@
-# ArXiviz Backend - Team 2 AI Generation Pipeline
+# arXivisual Backend
 
-This is the core AI pipeline that transforms structured paper data into validated Manim visualization code with AI-generated voiceovers.
+FastAPI backend that turns an arXiv paper ID into narrated, animated explainer videos. An agent pipeline
+(Azure OpenAI, GPT-5 family) reads the paper, picks the concepts worth animating, writes Manim code with a
+synced voiceover, validates it through four quality gates, renders it, and serves the videos alongside the
+parsed paper. Runs in production on Azure Container Apps behind arxivisual.org.
 
----
+- Full architecture walkthrough: [`../docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md)
+- Infrastructure (Terraform, production Azure): [`../infra/README.md`](../infra/README.md)
 
-## Quick Reference
+## Quick start
 
-```bash
-# All commands from the backend/ directory
-
-# Setup
-cp .env.example .env              # Then edit .env with your API keys
-uv sync                           # Install all dependencies
-
-# Test
-uv run python tools/test_pipeline.py                         # Offline (no API key)
-uv run python tools/test_pipeline.py --online                # Full pipeline test
-uv run python tools/test_pipeline.py --online --test analyzer    # Individual agent
-
-# Run
-uv run python tools/run_demo.py                              # Generate visualizations
-uv run python tools/run_demo.py --max 3 --verbose            # 3 visualizations, debug logs
-uv run python tools/run_demo.py --render --quality low       # Generate + render at 480p
-
-# Render manually
-cd generated_output
-uv run manim -ql filename.py                           # Preview quality
-uv run manim -qm filename.py                           # Medium quality
-```
-
----
-
-## Environment Setup
-
-### 1. Install uv (if not already installed)
+Requires [uv](https://docs.astral.sh/uv/) and Python 3.11–3.13. Rendering also needs a LaTeX distribution and
+ffmpeg locally (`brew install --cask basictex` + `brew install ffmpeg` on macOS).
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
+cd backend
+cp .env.example .env        # then fill in your Azure OpenAI keys (see below)
+uv sync --extra dev         # install everything into .venv
+uv run uvicorn main:app --reload
 ```
 
-### 2. Create your `.env` file
+The API is now at `http://localhost:8000` (interactive docs at `/docs`). Kick off a paper:
 
 ```bash
-cp .env.example .env
+curl -X POST http://localhost:8000/api/process \
+  -H "Content-Type: application/json" \
+  -d '{"arxiv_id": "1706.03762"}'
+# then poll:  GET /api/status/{job_id}   and finally:  GET /api/paper/1706.03762
 ```
 
-Edit `.env` with your keys:
+## Environment
 
-```env
-# REQUIRED:
-DEDALUS_API_KEY=dsk-your-dedalus-key
+All configuration lives in `.env` — copy [`.env.example`](.env.example) and fill in the blanks. The essentials:
 
-# REQUIRED - For AI voiceovers:
-ELEVEN_API_KEY=your-elevenlabs-key       # elevenlabs.io free tier works
-```
+| Variable | Purpose |
+|---|---|
+| `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` | LLM provider (required). `AZURE_OPENAI_DEPLOYMENT` defaults to `gpt-5`. |
+| `VOICEOVER_TTS_SERVICE` | `openai` (default — Azure OpenAI `gpt-4o-mini-tts`, no extra key) or `gtts` (free fallback). |
+| `DATABASE_URL` | Postgres in production; unset = local SQLite (`./arxiviz.db`), zero setup. |
+| `STORAGE_MODE` | `local` (default, videos in `./media/videos/`) or `r2` (Cloudflare R2, needs `S3_*` vars). |
+| `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | Optional — enables LLM tracing/cost tracking in Langfuse. |
+| `USE_TEMPORAL` | Optional — `1` routes jobs through a Temporal workflow for durable, restart-safe execution. |
 
-### 3. Install dependencies
+## Tests and lint
 
 ```bash
-uv sync    # Creates .venv, resolves deps, installs everything
+uv run pytest tests/                    # unit suite — hermetic, no API keys or network needed
+TEMPORAL_TESTS=1 uv run pytest tests/test_temporal_pipeline.py   # Temporal integration (downloads a local dev server)
+uvx ruff check .                        # lint (hard CI gate; tree is ruff-clean)
 ```
 
-That's it. `uv run` automatically uses the virtual environment.
-
----
-
-## How the Pipeline Works (Step by Step)
-
-Here's exactly what happens when you run `uv run python tools/run_demo.py`:
-
-### Step 0: Input Construction
-
-Currently, `tools/run_demo.py` and `tools/test_pipeline.py` construct a **hardcoded** `StructuredPaper` object simulating what Team 1 would provide. This includes:
-- Paper metadata (title, authors, abstract, arXiv ID)
-- Sections with their text content
-- Equations extracted from each section (LaTeX)
-
-When Team 1 is ready, this will be replaced by actual arXiv paper fetching.
-
-### Step 1: Section Analysis (SectionAnalyzer)
-
-**File:** `agents/section_analyzer.py` | **Prompt:** `prompts/section_analyzer.md`
-
-The pipeline loops through every section and asks Claude: *"Does this section contain concepts that would benefit from a Manim visualization?"*
-
-**Filtering (before sending to Claude):**
-- Skips sections titled "References", "Bibliography", "Acknowledgments", "Related Work"
-- Skips sections shorter than 100 characters
-
-**What Claude returns (per section):**
-```json
-{
-  "needs_visualization": true,
-  "reasoning": "Contains the core attention formula...",
-  "candidates": [
-    {
-      "section_id": "section-3-2",
-      "concept_name": "Scaled Dot-Product Attention",
-      "concept_description": "Q, K, V matrix flow through dot product...",
-      "visualization_type": "data_flow",
-      "priority": 5,
-      "context": "Attention(Q,K,V) = softmax(QK^T/sqrt(d_k))V"
-    }
-  ]
-}
-```
-
-**After analysis:** Candidates are sorted by priority (highest first) and limited to `MAX_VISUALIZATIONS` (default: 5).
-
-### Step 2: Visualization Planning (VisualizationPlanner)
-
-**File:** `agents/visualization_planner.py` | **Prompt:** `prompts/visualization_planner.md`
-
-For each candidate, Claude creates a scene-by-scene storyboard:
-
-```json
-{
-  "concept_name": "Scaled Dot-Product Attention",
-  "duration_seconds": 24,
-  "scenes": [
-    {"order": 1, "description": "Title: 'Attention Mechanism'", "duration_seconds": 4},
-    {"order": 2, "description": "Show Q, K, V as colored blocks", "duration_seconds": 6},
-    {"order": 3, "description": "Animate dot product computation", "duration_seconds": 8},
-    {"order": 4, "description": "Show softmax + final output", "duration_seconds": 6}
-  ],
-  "narration_points": [
-    "Query vectors search for relevant keys in the input.",
-    "The dot product measures similarity between positions.",
-    "Softmax normalizes scores into attention weights."
-  ]
-}
-```
-
-The planner now targets a 30-45 second quality window by default.
-
-### Step 3: Manim Code Generation (ManimGenerator)
-
-**File:** `agents/manim_generator.py` | **Prompt:** `prompts/manim_generator.md`
-
-Claude writes complete, runnable Manim Python code. Key features:
-
-**Few-shot example selection:** The generator picks the example file that matches the visualization type:
-- `data_flow` candidate → sends `examples/data_flow.py` as reference
-- `architecture` candidate → sends `examples/architecture_diagram.py`
-- etc.
-
-This dramatically improves code quality because Claude sees a working pattern to follow.
-
-**System prompt:** `prompts/system/manim_reference.md` is sent as the system message to every LLM call. It's a curated Manim API reference covering mobjects, animations, positioning, colors, and screen dimensions.
-
-**Voice-aware generation (new):**
-- If voiceover is enabled, the generator emits `VoiceoverScene` code directly
-- It inserts beat-level voice blocks using `with self.voiceover(text=\"...\") as tracker:`
-- Narrated `self.play(...)` calls are timed with `run_time=tracker.duration`
-- It extracts and returns narration metadata (`narration_lines`, `narration_beats`)
-
-**Output:** A `GeneratedCode` object with code + scene class + narration metadata.
-
-### Step 4: Multi-Stage Validation + Voice Quality Gate
-
-Each generated visualization passes through validation stages. If any fail, combined feedback is sent to `ManimGenerator.run_with_feedback()` for regeneration.
-
-#### Stage 1: CodeValidator (`agents/code_validator.py`)
-
-Pure Python static analysis (no LLM call):
-- **AST parse** - catches syntax errors
-- **Import check** - ensures `from manim import *` exists (auto-adds if missing)
-- **Scene class check** - looks for `class Name(Scene):`
-- **Construct method check** - looks for `def construct(self):`
-- **MathTex safety** - detects dangerous splitting patterns that crash Manim (e.g., splitting `\frac{}{}` across MathTex arguments)
-- **Auto-fixes** - color typos (`GREY`→`GRAY`), method case (`fadein`→`FadeIn`), unclosed brackets
-
-#### Stage 2: SpatialValidator (`agents/spatial_validator.py`)
-
-Regex-based static analysis (no LLM call):
-- **Bounds checking** - detects elements positioned outside screen (|x|>7 or |y|>4)
-- **Overlap detection** - finds elements at similar positions that may overlap
-- **Spacing issues** - flags `next_to()` or `arrange()` calls missing `buff` parameter
-- **Positioning suggestions** - recommends relative positioning over hardcoded coordinates
-
-Screen safe area: x in [-6, 6], y in [-3.5, 3.5]
-
-#### Stage 3: VoiceoverScriptValidator (`agents/voiceover_script_validator.py`)
-
-Strict quality gate for narration (enabled in unified voice mode):
-- Requires `VoiceoverScene` and `set_speech_service(...)`
-- Requires tracker-timed narrated plays (`run_time=tracker.duration`)
-- Rejects narration that starts with animation-command language
-- Enforces narration length window (12-24 words)
-- Enforces minimum narration coverage across content beats
-- Scores alignment and educational quality (thresholds: 0.85 / 0.85)
-
-#### Stage 4: RenderTester (`agents/render_tester.py`)
-
-Runtime validation (no LLM call):
-- Writes code to a temp file
-- Compiles with `compile()` (catches syntax errors with line numbers)
-- Imports the module with `importlib` (catches NameError, ImportError, TypeError, etc.)
-- Verifies a Scene class with `construct()` method exists
-- 30-second timeout (Manim imports can be slow)
-
-**Retry feedback loop:** When validation fails, the pipeline builds a combined error message like:
-
-```
-SYNTAX ISSUES:
-- No Scene class found
-
-SPATIAL ISSUES DETECTED:
-- Line 15: Element 'box1' at x=8.0 is outside screen bounds
-
-RUNTIME ERROR DETECTED:
-- Error Type: NameError
-- Error Message: name 'InvalidClass' is not defined
-```
-
-This is sent to `ManimGenerator.run_with_feedback()` along with the previous broken code, so Claude can see exactly what went wrong and fix it.
-
-### Step 5: Legacy Voiceover Fallback (optional)
-
-**File:** `agents/voiceover_generator.py`
-
-By default, voice is generated *inside* `ManimGenerator` (unified mode).  
-`VoiceoverGenerator` is kept as a legacy post-transform fallback mode and is disabled by default.
-Strict fallback policy:
-- If voice quality fails after retry budget, visualization is dropped (`VOICE_FAIL_BEHAVIOR=\"drop_viz\"`).
-
-### Step 6: Output
-
-The final `Visualization` object is returned with:
-- `manim_code`: Fully validated Python file (with or without voiceover)
-- `concept`: What this visualization explains
-- `section_id`: Which paper section it belongs to
-- `storyboard`: The original plan (JSON) for reference
-
-`tools/run_demo.py` saves each visualization as a `.py` file in `generated_output/`.
-
----
-
-## Configuration
-
-Pipeline behavior is controlled by constants at the top of `agents/pipeline.py`:
-
-```python
-MAX_VISUALIZATIONS = 5      # Max visualizations per paper
-MAX_RETRIES = 3             # Code generation retry limit
-CONCURRENT_ANALYSIS = True  # Analyze sections in parallel
-CONCURRENT_GENERATION = True # Generate visualizations in parallel
-ENABLE_SPATIAL_VALIDATION = True   # Check positioning/overlaps
-ENABLE_RENDER_TESTING = True       # Runtime import validation
-ENABLE_VOICEOVER = True
-VOICE_MODE = "unified_generator"      # unified_generator | legacy_post_transform
-VOICE_QUALITY_STRICT = True
-VOICE_QUALITY_RETRIES = 2
-VOICE_FAIL_BEHAVIOR = "drop_viz"      # drop_viz | return_silent | hard_error
-VOICEOVER_TTS_SERVICE = "elevenlabs"
-VOICEOVER_VOICE_NAME = "Adam"
-VOICEOVER_NARRATION_STYLE = "concept_teacher"
-VOICEOVER_TARGET_DURATION_SECONDS = (30, 45)
-```
-
-### Model Selection
-
-The LLM model is configured in `agents/base.py`:
-
-```python
-DEFAULT_MODEL = "claude-sonnet-4-5-20250929"             # Sonnet (anthropic/claude-sonnet-4-5-20250929 for Dedalus)
-```
-
-### ElevenLabs Voices
-
-Available voices (configured in `agents/voiceover_generator.py`):
-
-| Voice | ID | Style |
-|-------|-----|-------|
-| Adam (default) | `pNInz6obpgDQGcFmaJgB` | Deep, warm male |
-| Antoni | `ErXwobaYiN019PkySvjV` | Young male |
-| Bella | `EXAVITQu4vr4xnSDxMaL` | Friendly female |
-| Josh | `TxGEqnHWrfWFTfGW9XjX` | Conversational male |
-| Rachel | `21m00Tcm4TlvDq8ikWAM` | Clear female |
-
----
-
-## Adding a New Visualization Type
-
-1. **Add the type** to `models/generation.py`:
-   ```python
-   class VisualizationType(str, Enum):
-       # ... existing types ...
-       COMPARISON = "comparison"  # New!
-   ```
-
-2. **Create a few-shot example** at `examples/comparison.py`:
-   ```python
-   from manim import *
-
-   class ComparisonExample(Scene):
-       def construct(self):
-           # Your example code here
-           pass
-   ```
-
-3. **Register it** in `agents/manim_generator.py`:
-   ```python
-   EXAMPLE_FILES = {
-       # ... existing mappings ...
-       VisualizationType.COMPARISON: "comparison.py",
-   }
-   ```
-
-4. **Add guidance** to `prompts/visualization_planner.md`:
-   ```markdown
-   ### For `comparison` (Before/After, Baseline vs Proposed):
-   - Show both approaches side by side
-   - Highlight the differences
-   - ...
-   ```
-
----
-
-## Troubleshooting
-
-### "No API key found"
-- Make sure `.env` exists in the `backend/` directory (not the project root)
-- Check the key is not still the placeholder value from `.env.example`
-
-### "Pipeline generated 0 visualizations"
-- Check the logs for which stage failed (analyzer, planner, generator, or validation)
-- Run with `--verbose` flag for detailed logs
-- Try running individual tests: `uv run python tools/test_pipeline.py --online --test analyzer`
-
-### Manim render fails
-- Make sure you have LaTeX installed: `brew install --cask basictex` (macOS)
-- After installing: `sudo tlmgr update --self && sudo tlmgr install standalone preview`
-- Or use `Text()` instead of `MathTex()` in your examples to avoid LaTeX dependency
-
-### Voiceover fails
-- Check `ELEVEN_API_KEY` is set in `.env`
-- ElevenLabs free tier has character limits - check your usage at elevenlabs.io
-- The pipeline continues without voiceovers if this fails (graceful degradation)
-
-### "Module not found" errors
-- Run `uv sync` to ensure all dependencies are installed
-- Make sure you're running from the `backend/` directory
-- Use `uv run python ...` not bare `python ...`
+CI (`.github/workflows/ci.yml`) runs the unit suite on Python 3.11 and 3.13, typechecks and builds the
+frontend, and builds the backend Docker image. A blocking secret scan and a nightly LLM-quality eval run
+(`evals/` — see [`evals/README.md`](evals/README.md)) round it out; deploys go to Azure via GitHub OIDC.
+
+## How a paper becomes videos
+
+1. **Ingest** (`ingestion/`) — fetch metadata + ar5iv HTML (PDF fallback), parse into sections, store in the DB.
+2. **Analyze & plan** (`agents/section_analyzer.py`, `agents/visualization_planner.py`) — find up to 5
+   visualization-worthy concepts and storyboard each one.
+3. **Generate** (`agents/manim_generator.py`) — write complete Manim `VoiceoverScene` code, narration included,
+   guided by few-shot examples per visualization type.
+4. **Validate** — four gates with a feedback-and-regenerate loop: code structure (`code_validator`), on-screen
+   layout (`spatial_validator`), narration quality (`voiceover_script_validator`), and a real import/compile
+   test (`render_tester`).
+5. **Render** (`rendering/local_runner.py`) — Manim subprocess renders each scene; narration is synthesized via
+   Azure OpenAI TTS and cached across retries. Videos upload to Cloudflare R2 (or local disk in dev).
+6. **Visual QA** (`agents/visual_qa.py`) — a vision model inspects sampled frames for overlaps/cut-offs; on the
+   Temporal path, badly defective videos get one targeted repair-and-re-render pass.
+
+Orchestration is either a durable Temporal workflow (`temporal_app/`, `USE_TEMPORAL=1` — survives restarts,
+dedupes by paper, checkpoints the LLM spend) or a plain FastAPI background task (`jobs/worker.py`, the
+default). The public `/api/process` endpoint is protected by per-IP and global rate limits plus duplicate-job
+detection (`api/throttle.py`).
+
+## API surface
+
+| Method | Endpoint | Description |
+|---|---|---|
+| POST | `/api/process` | Start processing a paper (rate-limited, deduped) |
+| GET | `/api/status/{job_id}` | Poll job progress |
+| GET | `/api/paper/{arxiv_id}` | Processed paper with sections + video URLs |
+| GET | `/api/papers` | List processed papers |
+| GET | `/api/video/{video_id}` | Serve/redirect to a rendered video |
+| POST | `/api/render` | Render raw Manim code — dev only; disabled in production without a secret |
+| GET | `/api/health` | Health of DB, Manim, and storage |


### PR DESCRIPTION
The last stale-docs item. **backend/CLAUDE.md is injected into every AI-agent session as authoritative context** and still described the hackathon fiction — Modal as the render backend, a Redis queue that never existed, alembic commands with no alembic, required keys for long-gone services (Dedalus/ElevenLabs), Team 2/3/4 framing. Every removed claim and every new claim was verified against the checkout (commands run, constants read, health output checked). CLAUDE.md 286→112 lines; README 346→87. Includes the current feature flags and the hard-won conventions (per-task AsyncSession, deterministic workflows, no str cache_dir, Terraform-only infra changes, naive-UTC datetimes).