### PR TITLE
feat: vision-grounded repair v2 — the repair model sees the defect frames

### DIFF
--- a/backend/agents/visual_qa.py
+++ b/backend/agents/visual_qa.py
@@ -176,3 +176,85 @@ async def judge_video(video_bytes: bytes, viz_id: str = "") -> VisualQAResult | 
     except Exception as exc:
         logger.warning("[VisualQA] Judge call failed for %s: %s", viz_id, exc)
         return None
+
+
+# ---------------------------------------------------------------------------
+# Vision-grounded repair (v2)
+#
+# Two production experiments proved text-only feedback insufficient for layout:
+# prompt hardening moved the defect rate 0%, and a text-only repair pass fixed
+# 0/6 flagged videos (the model fixes the issues it is TOLD about, then the
+# judge finds the ones the text never captured). The fix the data demands:
+# show the repair model the actual defective frames.
+# ---------------------------------------------------------------------------
+
+VISUAL_QA_REPAIR_MODEL = os.getenv("VISUAL_QA_REPAIR_MODEL", VISUAL_QA_MODEL)
+
+REPAIR_VISION_PROMPT = """You are repairing layout defects in a Manim animation.
+The attached frames were rendered from the code below and show the ACTUAL defects
+on screen. Study the frames first: identify exactly which elements overlap, collide
+with arrows, or are cut off by the frame edges, and where they sit.
+
+The judge flagged these issues:
+{issues}
+
+Fix ONLY the layout problems you can SEE in the frames (the list above may be
+incomplete — trust the pixels): reposition or scale the offending elements, add
+FadeOut between beats so diagrams never stack, move labels off arrows with
+next_to(..., buff=0.3), and keep everything inside x in [-6, 6], y in [-3.5, 3.5]
+(scale_to_fit_width(12) for wide groups). PRESERVE the narration text, voiceover
+structure, scene class name, beat comments, and overall animation flow exactly.
+
+Current code:
+```python
+{code}
+```
+
+Return ONLY the complete corrected Python code. No markdown, no prose."""
+
+
+async def repair_code_with_frames(
+    code: str, issues: list[str], video_bytes: bytes, viz_id: str = ""
+) -> str | None:
+    """Vision-grounded layout repair: defect frames + issues + code -> new code.
+
+    Returns the model's raw output (caller strips fences and validates), or
+    None when the vision path is unavailable — the caller falls back to
+    text-only repair, so this can never make things worse.
+    """
+    if get_provider() != "azure":
+        return None
+    try:
+        frames = await asyncio.to_thread(sample_frames, video_bytes)
+    except Exception as exc:
+        logger.warning("[VisualQA] Repair frame sampling failed for %s: %s", viz_id, exc)
+        return None
+
+    content: list[dict] = [
+        {
+            "type": "text",
+            "text": REPAIR_VISION_PROMPT.format(
+                issues="\n".join(f"- {i}" for i in issues[:8]) or "- (see frames)",
+                code=code,
+            ),
+        }
+    ]
+    for frame in frames:
+        b64 = base64.b64encode(frame).decode()
+        content.append(
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+        )
+
+    try:
+        client = _get_azure_client()
+        resp = await client.chat.completions.create(
+            model=_azure_model(VISUAL_QA_REPAIR_MODEL),
+            messages=[{"role": "user", "content": content}],
+            # Full corrected scene (~3-4k tokens) + reasoning headroom.
+            max_completion_tokens=16000,
+        )
+        out = resp.choices[0].message.content or ""
+        return out if out.strip() else None
+    except Exception as exc:
+        logger.warning("[VisualQA] Vision repair call failed for %s: %s", viz_id, exc)
+        return None

--- a/backend/agents/visual_qa.py
+++ b/backend/agents/visual_qa.py
@@ -28,12 +28,12 @@ from pydantic import BaseModel, Field
 
 # Handle imports for both package and direct execution
 try:
-    from .base import _azure_model, _get_azure_client, get_provider
+    from .base import _azure_model, _get_azure_client, _with_trace_name, get_provider
 except ImportError:  # pragma: no cover - direct execution path
     import sys
 
     sys.path.insert(0, str(Path(__file__).parent.parent))
-    from agents.base import _azure_model, _get_azure_client, get_provider
+    from agents.base import _azure_model, _get_azure_client, _with_trace_name, get_provider
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,29 @@ logger = logging.getLogger(__name__)
 VISUAL_QA_ENABLED = os.getenv("ENABLE_VISUAL_QA", "0") == "1"
 VISUAL_QA_MODEL = os.getenv("VISUAL_QA_MODEL", "gpt-5-mini")
 VISUAL_QA_FRAMES = max(1, int(os.getenv("VISUAL_QA_FRAMES", "3")))
+
+def format_issue_list(issues: list[str], limit: int = 8) -> str:
+    """Render judge issues as a bullet list for repair prompts (shared)."""
+    return "\n".join(f"- {i}" for i in issues[:limit]) or "- (see frames)"
+
+
+def _frame_parts(frames: list[bytes]) -> list[dict]:
+    """Encode sampled frames as chat image parts (shared by judge and repair)."""
+    return [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(f).decode()}"},
+        }
+        for f in frames
+    ]
+
+
+# The invariant half of every repair prompt — one place to edit.
+REPAIR_OUTPUT_CONTRACT = """PRESERVE the narration text, voiceover structure, scene class name, beat comments,
+and overall animation flow exactly.
+
+Return ONLY the complete corrected Python code. No markdown, no prose."""
+
 
 JUDGE_PROMPT = """You are a visual QA judge for auto-generated Manim educational videos.
 Inspect these frames (sampled from one video) for LAYOUT DEFECTS only, not content quality:
@@ -155,19 +178,19 @@ async def judge_video(video_bytes: bytes, viz_id: str = "") -> VisualQAResult | 
         logger.warning("[VisualQA] Frame sampling failed for %s: %s", viz_id, exc)
         return None
 
-    content: list[dict] = [{"type": "text", "text": JUDGE_PROMPT}]
-    for frame in frames:
-        b64 = base64.b64encode(frame).decode()
-        content.append(
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
-        )
+    content: list[dict] = [{"type": "text", "text": JUDGE_PROMPT}, *_frame_parts(frames)]
 
     try:
         client = _get_azure_client()
         resp = await client.chat.completions.create(
-            model=_azure_model(VISUAL_QA_MODEL),
-            messages=[{"role": "user", "content": content}],
-            max_completion_tokens=4096,
+            **_with_trace_name(
+                {
+                    "model": _azure_model(VISUAL_QA_MODEL),
+                    "messages": [{"role": "user", "content": content}],
+                    "max_completion_tokens": 4096,
+                },
+                "visual_qa_judge",
+            )
         )
         verdict = _parse_verdict(resp.choices[0].message.content or "")
         verdict.judge_model = VISUAL_QA_MODEL
@@ -202,15 +225,14 @@ Fix ONLY the layout problems you can SEE in the frames (the list above may be
 incomplete — trust the pixels): reposition or scale the offending elements, add
 FadeOut between beats so diagrams never stack, move labels off arrows with
 next_to(..., buff=0.3), and keep everything inside x in [-6, 6], y in [-3.5, 3.5]
-(scale_to_fit_width(12) for wide groups). PRESERVE the narration text, voiceover
-structure, scene class name, beat comments, and overall animation flow exactly.
+(scale_to_fit_width(12) for wide groups).
 
 Current code:
 ```python
 {code}
 ```
 
-Return ONLY the complete corrected Python code. No markdown, no prose."""
+{contract}"""
 
 
 async def repair_code_with_frames(
@@ -234,24 +256,26 @@ async def repair_code_with_frames(
         {
             "type": "text",
             "text": REPAIR_VISION_PROMPT.format(
-                issues="\n".join(f"- {i}" for i in issues[:8]) or "- (see frames)",
+                issues=format_issue_list(issues),
                 code=code,
+                contract=REPAIR_OUTPUT_CONTRACT,
             ),
-        }
+        },
+        *_frame_parts(frames),
     ]
-    for frame in frames:
-        b64 = base64.b64encode(frame).decode()
-        content.append(
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
-        )
 
     try:
         client = _get_azure_client()
         resp = await client.chat.completions.create(
-            model=_azure_model(VISUAL_QA_REPAIR_MODEL),
-            messages=[{"role": "user", "content": content}],
-            # Full corrected scene (~3-4k tokens) + reasoning headroom.
-            max_completion_tokens=16000,
+            **_with_trace_name(
+                {
+                    "model": _azure_model(VISUAL_QA_REPAIR_MODEL),
+                    "messages": [{"role": "user", "content": content}],
+                    # Full corrected scene (~3-4k tokens) + reasoning headroom.
+                    "max_completion_tokens": 16000,
+                },
+                "visual_qa_repair_vision",
+            )
         )
         out = resp.choices[0].message.content or ""
         return out if out.strip() else None

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -254,6 +254,14 @@ async def create_visualization(
     return viz
 
 
+async def get_visualization(db: AsyncSession, viz_id: str) -> Visualization | None:
+    """Get a single visualization by id."""
+    result = await db.execute(
+        select(Visualization).where(Visualization.id == viz_id)
+    )
+    return result.scalar_one_or_none()
+
+
 async def update_visualization_status(
     db: AsyncSession,
     viz_id: str,

--- a/backend/rendering/storage.py
+++ b/backend/rendering/storage.py
@@ -58,6 +58,11 @@ class LocalStorageBackend:
             return file_path
         return None
 
+    async def load_video(self, video_id: str) -> bytes | None:
+        """Authoritative read of a stored video (no CDN in the path)."""
+        path = self.get_video_path(video_id)
+        return path.read_bytes() if path else None
+
     def get_video_url(self, video_id: str) -> str | None:
         if self.get_video_path(video_id):
             return f"/api/video/{video_id}"
@@ -138,6 +143,24 @@ class R2StorageBackend:
     def get_video_path(self, video_id: str) -> Path | None:
         # Cloud storage has no local path
         return None
+
+    async def load_video(self, video_id: str) -> bytes | None:
+        """Authoritative S3 GetObject read.
+
+        The public URL is behind a CDN with a one-year cache on a STABLE key
+        (re-runs overwrite videos/{viz_id}.mp4), so an edge cache can serve a
+        previous run's video. Anything that must see the just-uploaded bytes —
+        e.g. vision-grounded repair — reads through this, never the public URL.
+        """
+        key = self._key(video_id)
+        try:
+            resp = await asyncio.to_thread(
+                self.client.get_object, Bucket=self.bucket, Key=key
+            )
+            return resp["Body"].read()
+        except Exception as e:
+            logger.warning(f"  [R2Storage] load_video failed for {key}: {e}")
+            return None
 
     def get_video_url(self, video_id: str) -> str | None:
         key = self._key(video_id)

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -254,33 +254,23 @@ Here is the current code (it renders successfully — do NOT restructure it):
 
 Fix ONLY the layout problems listed above: reposition or scale elements, add
 FadeOut between beats, move labels off arrows, keep everything inside x in
-[-6, 6], y in [-3.5, 3.5]. PRESERVE the narration text, voiceover structure,
-scene class name, beat comments, and overall animation flow exactly.
+[-6, 6], y in [-3.5, 3.5].
 
-Return ONLY the complete corrected Python code. No markdown, no prose."""
+{contract}"""
 
 
 async def _fetch_rendered_video(viz_id: str) -> bytes | None:
-    """Download the just-rendered video for vision-grounded repair.
+    """Authoritative read of the just-rendered video for vision-grounded repair.
 
-    Only absolute URLs (R2 mode — what production runs) are fetched; local-mode
-    relative URLs return None and the caller falls back to text-only repair.
+    Reads through the storage backend (S3 GetObject / local file), NEVER the
+    public URL: the CDN caches the stable per-viz key for up to a year, so a
+    re-run could otherwise repair against the previous run's frames. Any
+    failure returns None — the caller falls back to text-only repair.
     """
-    import httpx
-
-    from db import queries
-    from db.connection import async_session_maker
-
-    async with async_session_maker() as db:
-        viz = await queries.get_visualization(db, viz_id)
-        url = viz.video_url if viz else None
-    if not url or not url.startswith("http"):
-        return None
     try:
-        async with httpx.AsyncClient(timeout=60) as http:
-            resp = await http.get(url)
-            resp.raise_for_status()
-            return resp.content
+        from rendering import get_backend
+
+        return await get_backend().load_video(viz_id)
     except Exception as exc:
         logger.warning("Could not fetch video for repair of %s: %s", viz_id, exc)
         return None
@@ -299,39 +289,52 @@ async def repair_visualization_code(params: RepairInput) -> str:
     """
     from agents.base import call_llm
     from agents.code_validator import CodeValidator
-    from agents.visual_qa import repair_code_with_frames
+    from agents.visual_qa import format_issue_list, repair_code_with_frames
 
-    raw = None
+    def _extract_and_validate(raw: str):
+        """Fence-strip + gate. Returns validated code or None."""
+        import re
+
+        fence = re.search(r"```(?:python)?\s*\n(.*?)```", raw, re.DOTALL)
+        candidate = (fence.group(1) if fence else raw).strip()
+        validation = CodeValidator().validate(candidate)
+        return validation.code if validation.is_valid else None
+
+    # Attempt 1: vision-grounded. EVERY vision failure mode — video fetch, frame
+    # sampling, model call, empty output, or invalid code — falls through to the
+    # text-only attempt (consistent contract: garbage is treated like absence).
+    code = None
     video_bytes = await _fetch_rendered_video(params.viz_id)
     if video_bytes:
         raw = await repair_code_with_frames(
             params.manim_code, params.issues, video_bytes, viz_id=params.viz_id
         )
         if raw:
-            logger.info("Vision-grounded repair produced code for %s", params.viz_id)
+            code = _extract_and_validate(raw)
+            if code:
+                logger.info("Vision-grounded repair produced code for %s", params.viz_id)
+            else:
+                logger.warning(
+                    "Vision repair output failed validation for %s; trying text-only",
+                    params.viz_id,
+                )
 
-    if raw is None:
-        logger.info("Falling back to text-only repair for %s", params.viz_id)
+    if code is None:
+        logger.info("Text-only repair for %s", params.viz_id)
+        from agents.visual_qa import REPAIR_OUTPUT_CONTRACT
+
         prompt = REPAIR_PROMPT.format(
-            issues="\n".join(f"- {i}" for i in params.issues[:8]),
+            issues=format_issue_list(params.issues),
             code=params.manim_code,
+            contract=REPAIR_OUTPUT_CONTRACT,
         )
         raw = await call_llm(prompt, max_tokens=10000, name="visual_qa_repair")
+        code = _extract_and_validate(raw)
 
-    # Strip a markdown fence if the model added one despite instructions.
-    import re
-
-    fence = re.search(r"```(?:python)?\s*\n(.*?)```", raw, re.DOTALL)
-    code = (fence.group(1) if fence else raw).strip()
-
-    validation = CodeValidator().validate(code)
-    if not validation.is_valid:
-        raise RuntimeError(
-            f"Repair produced invalid code for {params.viz_id}: "
-            + "; ".join(validation.issues_found[:3])
-        )
-    logger.info("Repair code ready for %s (%d chars)", params.viz_id, len(validation.code))
-    return validation.code
+    if code is None:
+        raise RuntimeError(f"Repair produced invalid code for {params.viz_id}")
+    logger.info("Repair code ready for %s (%d chars)", params.viz_id, len(code))
+    return code
 
 
 @activity.defn

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -260,21 +260,63 @@ scene class name, beat comments, and overall animation flow exactly.
 Return ONLY the complete corrected Python code. No markdown, no prose."""
 
 
+async def _fetch_rendered_video(viz_id: str) -> bytes | None:
+    """Download the just-rendered video for vision-grounded repair.
+
+    Only absolute URLs (R2 mode — what production runs) are fetched; local-mode
+    relative URLs return None and the caller falls back to text-only repair.
+    """
+    import httpx
+
+    from db import queries
+    from db.connection import async_session_maker
+
+    async with async_session_maker() as db:
+        viz = await queries.get_visualization(db, viz_id)
+        url = viz.video_url if viz else None
+    if not url or not url.startswith("http"):
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=60) as http:
+            resp = await http.get(url)
+            resp.raise_for_status()
+            return resp.content
+    except Exception as exc:
+        logger.warning("Could not fetch video for repair of %s: %s", viz_id, exc)
+        return None
+
+
 @activity.defn
 async def repair_visualization_code(params: RepairInput) -> str:
     """Targeted layout repair: judge findings -> focused LLM fix -> validated code.
 
-    Raises on failure (unusable output) so the workflow keeps the original
-    video — a defective video beats no video.
+    v2 is vision-grounded: the rendered video is fetched back, defect frames are
+    sampled, and the repair model SEES the actual defects (two experiments proved
+    text-only feedback insufficient — the model fixes what it's told about while
+    the judge finds what the text never captured). Falls back to text-only repair
+    when the video can't be retrieved, and raises on unusable output so the
+    workflow keeps the original video — a defective video beats no video.
     """
     from agents.base import call_llm
     from agents.code_validator import CodeValidator
+    from agents.visual_qa import repair_code_with_frames
 
-    prompt = REPAIR_PROMPT.format(
-        issues="\n".join(f"- {i}" for i in params.issues[:8]),
-        code=params.manim_code,
-    )
-    raw = await call_llm(prompt, max_tokens=10000, name="visual_qa_repair")
+    raw = None
+    video_bytes = await _fetch_rendered_video(params.viz_id)
+    if video_bytes:
+        raw = await repair_code_with_frames(
+            params.manim_code, params.issues, video_bytes, viz_id=params.viz_id
+        )
+        if raw:
+            logger.info("Vision-grounded repair produced code for %s", params.viz_id)
+
+    if raw is None:
+        logger.info("Falling back to text-only repair for %s", params.viz_id)
+        prompt = REPAIR_PROMPT.format(
+            issues="\n".join(f"- {i}" for i in params.issues[:8]),
+            code=params.manim_code,
+        )
+        raw = await call_llm(prompt, max_tokens=10000, name="visual_qa_repair")
 
     # Strip a markdown fence if the model added one despite instructions.
     import re

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -274,9 +274,8 @@ def test_fetch_rendered_video_skips_relative_and_missing_urls():
     class _Viz:
         video_url = "/api/video/viz_x"  # relative — local mode
 
-    with patch.object(activities, "_fetch_rendered_video", wraps=activities._fetch_rendered_video):
-        with patch("db.queries.get_visualization", new=AsyncMock(return_value=_Viz())):
-            out = asyncio.run(activities._fetch_rendered_video("viz_x"))
+    with patch("db.queries.get_visualization", new=AsyncMock(return_value=_Viz())):
+        out = asyncio.run(activities._fetch_rendered_video("viz_x"))
     assert out is None
 
     with patch("db.queries.get_visualization", new=AsyncMock(return_value=None)):

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -263,21 +263,27 @@ class TestRepairLoop:
         assert len([r for r in calls["renders"] if r[1]]) == 2  # exactly 2 re-renders
 
 
-def test_fetch_rendered_video_skips_relative_and_missing_urls():
-    """Local-mode relative URLs (and missing rows) must fall back to text-only
-    repair rather than attempting a download."""
+def test_fetch_rendered_video_reads_storage_and_fails_open():
+    """The repair video read goes through the storage backend (authoritative —
+    the public CDN URL can serve a previous run's video for the same key), and
+    ANY failure returns None so the caller falls back to text-only repair."""
     import asyncio
-    from unittest.mock import AsyncMock, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from temporal_app import activities
 
-    class _Viz:
-        video_url = "/api/video/viz_x"  # relative — local mode
-
-    with patch("db.queries.get_visualization", new=AsyncMock(return_value=_Viz())):
+    backend = MagicMock()
+    backend.load_video = AsyncMock(return_value=b"mp4-bytes")
+    with patch("rendering.get_backend", return_value=backend):
         out = asyncio.run(activities._fetch_rendered_video("viz_x"))
-    assert out is None
+    assert out == b"mp4-bytes"
+    backend.load_video.assert_awaited_once_with("viz_x")
 
-    with patch("db.queries.get_visualization", new=AsyncMock(return_value=None)):
-        out = asyncio.run(activities._fetch_rendered_video("viz_missing"))
-    assert out is None
+    # Missing object -> None
+    backend.load_video = AsyncMock(return_value=None)
+    with patch("rendering.get_backend", return_value=backend):
+        assert asyncio.run(activities._fetch_rendered_video("viz_gone")) is None
+
+    # Backend construction blowing up (e.g. missing R2 env) -> None, not raise
+    with patch("rendering.get_backend", side_effect=RuntimeError("no creds")):
+        assert asyncio.run(activities._fetch_rendered_video("viz_x")) is None

--- a/backend/tests/test_temporal_pipeline.py
+++ b/backend/tests/test_temporal_pipeline.py
@@ -261,3 +261,24 @@ class TestRepairLoop:
         self._run(calls, defective=frozenset({"viz_1", "viz_2"}), repair_fixes=False)
         assert len(calls["repairs"]) == 2
         assert len([r for r in calls["renders"] if r[1]]) == 2  # exactly 2 re-renders
+
+
+def test_fetch_rendered_video_skips_relative_and_missing_urls():
+    """Local-mode relative URLs (and missing rows) must fall back to text-only
+    repair rather than attempting a download."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from temporal_app import activities
+
+    class _Viz:
+        video_url = "/api/video/viz_x"  # relative — local mode
+
+    with patch.object(activities, "_fetch_rendered_video", wraps=activities._fetch_rendered_video):
+        with patch("db.queries.get_visualization", new=AsyncMock(return_value=_Viz())):
+            out = asyncio.run(activities._fetch_rendered_video("viz_x"))
+    assert out is None
+
+    with patch("db.queries.get_visualization", new=AsyncMock(return_value=None)):
+        out = asyncio.run(activities._fetch_rendered_video("viz_missing"))
+    assert out is None

--- a/backend/tests/test_visual_qa.py
+++ b/backend/tests/test_visual_qa.py
@@ -113,11 +113,16 @@ class TestVisionGroundedRepair:
         )
         assert out is None
 
-    def test_prompt_includes_issues_and_code(self):
+    def test_prompt_includes_issues_code_and_contract(self):
         text = visual_qa.REPAIR_VISION_PROMPT.format(
-            issues="- labels overlap arrows", code="from manim import *"
+            issues="- labels overlap arrows",
+            code="from manim import *",
+            contract=visual_qa.REPAIR_OUTPUT_CONTRACT,
         )
         assert "labels overlap arrows" in text
         assert "from manim import *" in text
         # The prompt must tell the model to trust the pixels over the list.
         assert "trust the pixels" in text
+        # The shared output contract (one place to edit) must arrive intact.
+        assert "PRESERVE the narration text" in text
+        assert text.rstrip().endswith("No markdown, no prose.")

--- a/backend/tests/test_visual_qa.py
+++ b/backend/tests/test_visual_qa.py
@@ -89,3 +89,35 @@ def test_judge_video_survives_ffmpeg_failure(monkeypatch):
     monkeypatch.setattr(visual_qa, "sample_frames", boom)
     result = asyncio.run(visual_qa.judge_video(b"not-a-video"))
     assert result is None
+
+
+class TestVisionGroundedRepair:
+    """v2 repair: the model sees the defect frames; text-only is the fallback."""
+
+    def test_non_azure_provider_returns_none(self, monkeypatch):
+        monkeypatch.setattr(visual_qa, "get_provider", lambda: "dedalus")
+        out = asyncio.run(
+            visual_qa.repair_code_with_frames("code", ["overlap"], b"video")
+        )
+        assert out is None
+
+    def test_frame_sampling_failure_returns_none(self, monkeypatch):
+        monkeypatch.setattr(visual_qa, "get_provider", lambda: "azure")
+
+        def boom(video_bytes, count=3):
+            raise RuntimeError("ffprobe failed")
+
+        monkeypatch.setattr(visual_qa, "sample_frames", boom)
+        out = asyncio.run(
+            visual_qa.repair_code_with_frames("code", ["overlap"], b"video")
+        )
+        assert out is None
+
+    def test_prompt_includes_issues_and_code(self):
+        text = visual_qa.REPAIR_VISION_PROMPT.format(
+            issues="- labels overlap arrows", code="from manim import *"
+        )
+        assert "labels overlap arrows" in text
+        assert "from manim import *" in text
+        # The prompt must tell the model to trust the pixels over the list.
+        assert "trust the pixels" in text


### PR DESCRIPTION
The most important build available, per the data: two production experiments proved **text-only feedback can't fix layout** (prompt hardening moved the defect rate 0%; text-only repair fixed **0/6** — the model fixes what it's told about while the judge finds what the text never captured). v2 shows the repair model the actual defective frames.

## Design
- `repair_code_with_frames()` (agents/visual_qa.py): defect frames + judge issues + code → multimodal repair call. The prompt's key instruction: *"the list above may be incomplete — **trust the pixels**"* — the deliberate inversion of v1's failure mode.
- The activity fetches the just-rendered video **through the storage backend (S3 GetObject), never the public URL** — the CDN caches the stable per-viz key for a year, so a re-run could otherwise repair against the previous run's frames.
- **Every** vision failure mode (fetch, sampling, model call, empty output, invalid code) falls through to the v1 text-only path; raise only when both attempts are unusable. `RepairInput` and all workflow interfaces unchanged.

## Reviewed before shipping (two-axis: Standards + Spec, parallel sub-agents)
The Spec axis caught three real defects pre-merge — the CDN staleness race, a fetch path that didn't fail open, and an inconsistent fallback contract — all fixed. Standards axis: vision calls now carry **named Langfuse spans** (`visual_qa_judge`, `visual_qa_repair_vision`), and the duplicated prompt tail / frame encoder / issue formatter are extracted to shared helpers.

## Verification
- 86 unit tests + **11 Temporal integration tests** (repair-loop orchestration) pass; ruff clean
- Benchmark plan post-merge: deploy → re-run the baseline paper → compare "(N flagged, M repaired)" against v1's 0/6, with organic traffic accumulating the ongoing rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision-assisted visual QA repairs using frames from rendered videos.
  * Automatically falls back to text-based repair when visual analysis is unavailable or unsuccessful.
  * Added support for retrieving rendered videos from local and cloud storage.

* **Bug Fixes**
  * Improved repair validation and handling of missing videos, storage errors, and invalid generated code.

* **Tests**
  * Added coverage for vision-assisted repairs, storage retrieval, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->