### PR TITLE
tune: widen repair timeout to 18m; document measured vision-repair results

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -83,8 +83,12 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
 
 - `USE_TEMPORAL=1` — durable orchestration; any Temporal error falls back (fail-open) to the legacy in-process path.
 - `ENABLE_VISUAL_QA=1` — vision judge on rendered frames (observe-only on legacy path; verdict feeds repair on Temporal path).
-- `VISUAL_QA_REPAIR=1` — one repair round for `major` defects (Temporal path only). Also: `VISUAL_QA_MODEL`
-  (`gpt-5-mini`), `VISUAL_QA_FRAMES` (3).
+- `VISUAL_QA_REPAIR=1` — one **vision-grounded** repair round for `major` defects (Temporal path only): the
+  rendered video is read back through the storage backend (never the CDN URL — stable keys cache for a year),
+  defect frames are sampled, and the repair model sees the pixels. Text-only repair is the fallback for every
+  vision-failure mode. Measured: text-only fixed 0/6; vision-grounded fixed 2/4 in its first production run.
+  Also: `VISUAL_QA_MODEL` (`gpt-5-mini`), `VISUAL_QA_REPAIR_MODEL` (defaults to the judge model),
+  `VISUAL_QA_FRAMES` (3).
 - `VOICEOVER_TTS_SERVICE` `openai|gtts` (default `openai` = Azure-routed), `VOICEOVER_VOICE_NAME` (`nova`),
   `VOICEOVER_TTS_MODEL` (`gpt-4o-mini-tts`), `VOICEOVER_CACHE_DIR` (`/tmp/arxivisual-tts-cache`).
 - `RENDER_CONCURRENCY` (3) — parallel manim renders per host; `PIPELINE_CONCURRENCY` (2) — concurrent

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -154,7 +154,10 @@ class PaperPipelineWorkflow:
                     manim_code=code,
                     issues=result.issues,
                 ),
-                start_to_close_timeout=timedelta(minutes=10),
+                # 18 min: vision-grounded repair (frames + 16k reasoning budget)
+                # measured slower than the text path — a 10-min cap timed out a
+                # repair that was on track in the first production benchmark.
+                start_to_close_timeout=timedelta(minutes=18),
                 retry_policy=_NO_RETRY,  # a repair is one LLM call — don't double-spend
             )
             rerender: RenderResult = await workflow.execute_activity(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,8 @@ You give the system an arXiv paper ID. It gives you back narrated, animated expl
 2. **Generate** (0.50) — run the agent pipeline to produce validated Manim code for up to 5 concepts.
 3. **Render** (0.75 → 0.95) — render each visualization to MP4 and upload it, at most 3 concurrently (`asyncio.Semaphore(3)`). Each render task commits through its own DB session; a lock serializes progress updates.
 
+**Visual QA + self-repair** (`agents/visual_qa.py`, `temporal_app/activities.py`): after each render, a vision model samples 3 frames and judges layout defects (overlap / cutoff / collisions), scoring every verdict into Langfuse (`visual_qa_defect`). On the Temporal path, a `major` verdict triggers one **vision-grounded repair**: the video is read back through the storage backend (never the CDN — stable keys cache for a year), the defect frames plus the judge's issues go to a multimodal model, and the repaired code is re-rendered and re-judged. Every vision-failure mode falls back to a text-only repair; an unusable repair keeps the original video. Measured in production: text-only repair fixed 0/6 flagged videos; vision-grounded fixed 2/4 in its first run — the pixels carry information the text descriptions provably don't.
+
 **Terminal status is honest** (`resolve_terminal_job_status` in `jobs/worker.py`): a job is `completed` only if at least one visualization actually rendered. Zero generated or all-failed renders mark the job `failed` with an explanatory error, while the parsed paper text remains readable. Individual render failures are recorded per visualization and don't sink the job.
 
 ## Ingestion (`backend/ingestion/`)


### PR DESCRIPTION
Follow-ups from the first production benchmark of #59. **Result being documented: text-only repair 0/6 → vision-grounded 2/4 fixed (verified by re-judge: two videos went major→clean).** The 10-min repair timeout cost us a third fix — widened to 18 min (vision + 16k reasoning budget is measurably slower than the text path). CLAUDE.md + ARCHITECTURE.md now describe the full judge→repair→re-render→re-judge loop, its fallback ladder, and the CDN-staleness constraint. Note: the timeout change touches workflow code — in-flight workflows at deploy time may see a non-determinism error and retry; with minutes-long workflows the exposure window is tiny.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual quality checks after video rendering to detect layout issues such as overlaps, cutoffs, and collisions.
  * Added automated repair for major visual defects using sampled video frames.
  * Preserves the original video when an attempted repair is unusable.

* **Documentation**
  * Documented visual QA, repair behavior, fallback handling, configuration options, and measured repair outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->