### PR TITLE
fix: surface the real traceback in render failure messages

### DIFF
--- a/backend/rendering/local_runner.py
+++ b/backend/rendering/local_runner.py
@@ -15,6 +15,39 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+# Import-time chatter manim/manim-voiceover print to stderr before any real
+# error. Matched per line when no traceback is found.
+_WARNING_NOISE = ("UserWarning", "SyntaxWarning", "DeprecationWarning", "warnings.warn")
+
+# The DB error column and log pipelines surface the head of this string, so
+# keep it short enough to read but long enough to hold a full traceback box.
+_ERROR_MSG_LIMIT = 4000
+
+
+def _extract_render_error(stderr: str, stdout: str) -> str:
+    """Distill a failed render's output into the part that names the error.
+
+    Manim prints deprecation/syntax warnings at import time, BEFORE any
+    traceback — a raw ``stderr`` head is all warning and no error (a real
+    production failure was stored as just the pkg_resources deprecation
+    notice, hiding the actual ValueError). Prefer everything from the last
+    traceback onward; otherwise drop known warning lines; otherwise keep the
+    tail, where Python puts the exception.
+    """
+    text = (stderr or stdout or "").strip()
+    if not text:
+        return "Unknown error"
+    idx = text.rfind("Traceback (most recent call last)")
+    if idx != -1:
+        return text[idx:][:_ERROR_MSG_LIMIT]
+    lines = [
+        line for line in text.splitlines()
+        if not any(marker in line for marker in _WARNING_NOISE)
+    ]
+    cleaned = "\n".join(lines).strip() or text
+    return cleaned[-_ERROR_MSG_LIMIT:]
+
+
 def _tts_subprocess_env() -> dict[str, str]:
     """Environment for the render subprocess.
 
@@ -150,7 +183,7 @@ def _run_manim_subprocess(
             ) from None
 
         if result.returncode != 0:
-            error_msg = result.stderr or result.stdout or "Unknown error"
+            error_msg = _extract_render_error(result.stderr, result.stdout)
             logger.error(f"{tag} Manim render failed with return code {result.returncode}")
             logger.error(f"{tag} Error: {error_msg}")
             raise RuntimeError(f"Manim render failed: {error_msg}")

--- a/backend/tests/test_render_error_extraction.py
+++ b/backend/tests/test_render_error_extraction.py
@@ -1,0 +1,65 @@
+"""Unit tests for render-error distillation (pure function, no subprocess).
+
+Regression source: viz_1706_03762_1 in production failed with a numpy
+ValueError, but the stored error was only manim-voiceover's pkg_resources
+deprecation warning — the head of stderr — leaving the failure undiagnosable
+from the DB.
+"""
+
+from rendering.local_runner import _extract_render_error
+
+# The shape prod stderr actually had: import-time warnings first, then manim's
+# rich-boxed traceback with the real exception at the end.
+PROD_STDERR = """\
+/app/.venv/lib/python3.13/site-packages/manim_voiceover/__init__.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html.
+  import pkg_resources
+/app/.venv/lib/python3.13/site-packages/manim_voiceover/helper.py:21: SyntaxWarning: invalid escape sequence '\\s'
+╭───────────────────── Traceback (most recent call last) ──────────────────────╮
+│ /app/.venv/lib/python3.13/site-packages/manim/scene/scene.py:259 in render   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+ValueError: The truth value of an array with more than one element is ambiguous."""
+
+
+def test_traceback_wins_over_leading_warnings():
+    out = _extract_render_error(PROD_STDERR, "")
+    assert out.startswith("Traceback (most recent call last)")
+    assert "ValueError: The truth value of an array" in out
+    assert "pkg_resources is deprecated" not in out
+
+
+def test_last_traceback_is_used_when_several_appear():
+    text = (
+        "Traceback (most recent call last):\n  first\nKeyError: 'a'\n"
+        "retrying...\n"
+        "Traceback (most recent call last):\n  second\nValueError: real one"
+    )
+    out = _extract_render_error(text, "")
+    assert "ValueError: real one" in out
+    assert "KeyError" not in out
+
+
+def test_warning_only_stderr_is_filtered_to_remaining_lines():
+    text = (
+        "/x/manim_voiceover/__init__.py:4: UserWarning: pkg_resources is deprecated\n"
+        "Error: LaTeX compilation failed for MathTex"
+    )
+    out = _extract_render_error(text, "")
+    assert out == "Error: LaTeX compilation failed for MathTex"
+
+
+def test_all_noise_falls_back_to_full_text():
+    text = "/x/helper.py:21: SyntaxWarning: invalid escape sequence"
+    # Everything is noise — better the warning than an empty error message.
+    assert _extract_render_error(text, "") == text
+
+
+def test_stdout_fallback_and_empty():
+    assert _extract_render_error("", "some stdout failure") == "some stdout failure"
+    assert _extract_render_error("", "") == "Unknown error"
+
+
+def test_long_output_keeps_the_tail():
+    text = ("x" * 10000) + "\nRuntimeError: the actual error"
+    out = _extract_render_error(text, "")
+    assert out.endswith("RuntimeError: the actual error")
+    assert len(out) <= 4000


### PR DESCRIPTION
While investigating why job_cb7b7675eecb finished 4/5, the stored error for the failed viz was just manim-voiceover's pkg_resources deprecation warning — the real error (`ValueError: The truth value of an array with more than one element is ambiguous`, LLM-generated code comparing numpy arrays at animation time) was buried at the tail of stderr, past what the DB error column and log head show. This distills failed-render output to the last traceback (or de-noised tail) so failures are diagnosable from the DB again. Pure-function change + 6 hermetic tests including the exact production stderr shape.