### PR TITLE
feat: human feedback loop — per-video votes and site suggestions

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -76,7 +76,7 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
   `X-Render-Secret` header. The endpoint executes caller-supplied Python; keep it locked.
 - `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_GLOBAL` (30/h), `RATE_LIMIT_PROCESS_WINDOW_SECONDS`
   (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600) — cost fuse on `/api/process` (`api/throttle.py`).
-- `RATE_LIMIT_FEEDBACK_PER_IP` (30/h) — bounds `POST /api/feedback` (viewer 👍/👎 per video + site
+- `RATE_LIMIT_FEEDBACK_PER_IP` (30) / `RATE_LIMIT_FEEDBACK_WINDOW_SECONDS` (3600) — bounds `POST /api/feedback` (viewer 👍/👎 per video + site
   suggestions → `feedback` table). Video votes are labeled ground truth for calibrating the visual-QA judge;
   `paper_id` is denormalized from the viz row, never trusted from the client.
 - `TEMPORAL_ADDRESS` (`localhost:7233`), `TEMPORAL_NAMESPACE` (`default`), `TEMPORAL_TLS=1` (prod reaches

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -76,6 +76,9 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
   `X-Render-Secret` header. The endpoint executes caller-supplied Python; keep it locked.
 - `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_GLOBAL` (30/h), `RATE_LIMIT_PROCESS_WINDOW_SECONDS`
   (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600) — cost fuse on `/api/process` (`api/throttle.py`).
+- `RATE_LIMIT_FEEDBACK_PER_IP` (30/h) — bounds `POST /api/feedback` (viewer 👍/👎 per video + site
+  suggestions → `feedback` table). Video votes are labeled ground truth for calibrating the visual-QA judge;
+  `paper_id` is denormalized from the viz row, never trusted from the client.
 - `TEMPORAL_ADDRESS` (`localhost:7233`), `TEMPORAL_NAMESPACE` (`default`), `TEMPORAL_TLS=1` (prod reaches
   Temporal via HTTP/2 ingress behind TLS :443 — raw TCP ingress is unroutable on Container Apps).
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -463,7 +463,8 @@ async def submit_feedback(
         viz_id=request.viz_id if request.kind == "video" else None,
         paper_id=paper_id,
         vote=request.vote if request.kind == "video" else None,
-        reason=request.reason,
+        # reason is the downvote category — meaningless on site rows.
+        reason=request.reason if request.kind == "video" else None,
         comment=request.comment,
     )
     logger.info(

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -22,6 +22,8 @@ from jobs import process_paper_job
 from rendering import extract_scene_name, get_video_path, get_video_url, process_visualization
 
 from .schemas import (
+    FeedbackRequest,
+    FeedbackResponse,
     HealthResponse,
     JobStatus,
     PaperListResponse,
@@ -37,7 +39,7 @@ from .schemas import (
     VisualizationResponse,
     VisualizationStatus,
 )
-from .throttle import client_ip, global_limiter, per_ip_limiter, recent_jobs
+from .throttle import client_ip, feedback_limiter, global_limiter, per_ip_limiter, recent_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -414,6 +416,61 @@ async def render_manim(
             status_code=500,
             detail="Internal error while rendering. See server logs.",
         ) from None
+
+
+@router.post("/feedback", response_model=FeedbackResponse)
+async def submit_feedback(
+    request: FeedbackRequest,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Store viewer feedback.
+
+    kind=video: a verdict on one rendered visualization — this is labeled
+    ground truth the visual-QA judge can be calibrated against, so the viz
+    must exist and carry a vote. kind=site: a free-text suggestion.
+    """
+    ip = client_ip(http_request)
+    allowed, retry_after = feedback_limiter.allow(ip)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Too much feedback from this address. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    paper_id = None
+    if request.kind == "video":
+        if not request.viz_id or not request.vote:
+            raise HTTPException(
+                status_code=422,
+                detail="Video feedback requires viz_id and vote.",
+            )
+        viz = await queries.get_visualization(db, request.viz_id)
+        if viz is None:
+            raise HTTPException(status_code=404, detail="Visualization not found")
+        paper_id = viz.paper_id
+    elif not (request.comment and request.comment.strip()):
+        raise HTTPException(
+            status_code=422,
+            detail="Site feedback requires a comment.",
+        )
+
+    await queries.create_feedback(
+        db,
+        kind=request.kind,
+        viz_id=request.viz_id if request.kind == "video" else None,
+        paper_id=paper_id,
+        vote=request.vote if request.kind == "video" else None,
+        reason=request.reason,
+        comment=request.comment,
+    )
+    logger.info(
+        "Feedback stored: kind=%s viz=%s vote=%s",
+        request.kind, request.viz_id, request.vote,
+    )
+    return FeedbackResponse()
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -6,6 +6,7 @@ These schemas are THE CONTRACT - Team 4 builds their frontend against these resp
 
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -28,6 +29,20 @@ class VisualizationStatus(str, Enum):
 
 
 # === Request Schemas ===
+
+class FeedbackRequest(BaseModel):
+    """Request body for POST /api/feedback."""
+    kind: Literal["video", "site"] = Field(..., description="What the feedback is about")
+    viz_id: str | None = Field(None, max_length=64, description="Visualization id (required for kind=video)")
+    vote: Literal["up", "down"] | None = Field(None, description="Verdict on the video (required for kind=video)")
+    reason: str | None = Field(None, max_length=200, description="Short category, e.g. 'overlapping text'")
+    comment: str | None = Field(None, max_length=2000, description="Free-text detail or suggestion")
+
+
+class FeedbackResponse(BaseModel):
+    """Response for POST /api/feedback."""
+    status: str = "ok"
+
 
 class ProcessRequest(BaseModel):
     """Request body for POST /api/process."""

--- a/backend/api/throttle.py
+++ b/backend/api/throttle.py
@@ -41,6 +41,11 @@ class SlidingWindowLimiter:
         self._events: dict[str, deque[float]] = {}
         self._lock = threading.Lock()
 
+    def reset(self) -> None:
+        """Drop all recorded events (used by tests)."""
+        with self._lock:
+            self._events.clear()
+
     def allow(self, key: str, now: float | None = None) -> tuple[bool, int]:
         """Record-and-check. Returns (allowed, retry_after_seconds)."""
         if self.max_events == 0:
@@ -97,14 +102,6 @@ class RecentJobs:
             self._jobs.pop(arxiv_id, None)
 
 
-# Feedback is cheap to store but still abusable; own bucket, looser than
-# /api/process since it spends no money.
-feedback_limiter = SlidingWindowLimiter(
-    max_events=_int_env("RATE_LIMIT_FEEDBACK_PER_IP", 30),
-    window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
-)
-
-
 def client_ip(request: Request) -> str:
     """Client IP, honoring the ingress proxy's X-Forwarded-For (first hop)."""
     forwarded = request.headers.get("x-forwarded-for", "")
@@ -127,3 +124,10 @@ global_limiter = SlidingWindowLimiter(
     window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
 )
 recent_jobs = RecentJobs(ttl_seconds=_int_env("PROCESS_DEDUPE_TTL_SECONDS", 600))
+
+# Feedback is cheap to store but still abusable; own bucket AND own window —
+# tuning the /api/process cost fuse must not silently retune feedback.
+feedback_limiter = SlidingWindowLimiter(
+    max_events=_int_env("RATE_LIMIT_FEEDBACK_PER_IP", 30),
+    window_seconds=_int_env("RATE_LIMIT_FEEDBACK_WINDOW_SECONDS", 3600),
+)

--- a/backend/api/throttle.py
+++ b/backend/api/throttle.py
@@ -97,6 +97,14 @@ class RecentJobs:
             self._jobs.pop(arxiv_id, None)
 
 
+# Feedback is cheap to store but still abusable; own bucket, looser than
+# /api/process since it spends no money.
+feedback_limiter = SlidingWindowLimiter(
+    max_events=_int_env("RATE_LIMIT_FEEDBACK_PER_IP", 30),
+    window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
+)
+
+
 def client_ip(request: Request) -> str:
     """Client IP, honoring the ingress proxy's X-Forwarded-For (first hop)."""
     forwarded = request.headers.get("x-forwarded-for", "")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -73,6 +73,21 @@ class Visualization(Base):
     paper = relationship("Paper", back_populates="visualizations")
 
 
+class Feedback(Base):
+    """Viewer feedback: a per-video verdict (the labeled data the visual QA
+    loop can be calibrated against) or a site-level suggestion."""
+    __tablename__ = "feedback"
+
+    id = Column(String, primary_key=True)  # fb_<hex>
+    kind = Column(String, nullable=False)  # "video" | "site"
+    viz_id = Column(String, ForeignKey("visualizations.id"), nullable=True)
+    paper_id = Column(String, nullable=True)  # denormalized for easy grouping
+    vote = Column(String, nullable=True)  # "up" | "down" (video kind only)
+    reason = Column(String, nullable=True)  # short category, e.g. "overlapping text"
+    comment = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
 class ProcessingJob(Base):
     """Background processing job for paper pipeline."""
     __tablename__ = "processing_jobs"

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from .models import Paper, ProcessingJob, Section, Visualization
+from .models import Feedback, Paper, ProcessingJob, Section, Visualization
 
 # === Processing Jobs ===
 
@@ -132,6 +132,33 @@ async def update_job_status(
 
     await db.commit()
     return job
+
+
+# === Feedback ===
+
+async def create_feedback(
+    db: AsyncSession,
+    kind: str,
+    viz_id: str | None = None,
+    paper_id: str | None = None,
+    vote: str | None = None,
+    reason: str | None = None,
+    comment: str | None = None,
+) -> Feedback:
+    """Store one piece of viewer feedback."""
+    fb = Feedback(
+        id=f"fb_{uuid.uuid4().hex[:12]}",
+        kind=kind,
+        viz_id=viz_id,
+        paper_id=paper_id,
+        vote=vote,
+        reason=reason,
+        comment=comment,
+        created_at=_utcnow_naive(),
+    )
+    db.add(fb)
+    await db.commit()
+    return fb
 
 
 # === Papers ===

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -6,7 +6,6 @@ visualizations, the paper id is denormalized from the viz (never trusted from
 the client), and junk requests are rejected before they reach the table.
 """
 
-import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,123 @@
+"""Feedback endpoint + storage tests (in-memory SQLite, no network).
+
+Video feedback is labeled ground truth for the visual-QA loop, so the tests
+pin the invariants that keep the data trustworthy: votes attach only to real
+visualizations, the paper id is denormalized from the viz (never trusted from
+the client), and junk requests are rejected before they reach the table.
+"""
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api.routes import router
+from api.throttle import feedback_limiter
+from db import queries
+from db.connection import get_db
+from db.models import Base, Feedback, Paper, Visualization
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: db
+    feedback_limiter._events.clear()  # isolate rate-limit state between tests
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _seed_viz(db, viz_id="viz_1706_03762_1", paper_id="1706.03762"):
+    db.add(Paper(id=paper_id, title="Attention Is All You Need"))
+    db.add(Visualization(id=viz_id, paper_id=paper_id, concept="attention"))
+    await db.commit()
+
+
+async def test_video_feedback_is_stored_with_denormalized_paper(client, db):
+    await _seed_viz(db)
+    resp = await client.post("/api/feedback", json={
+        "kind": "video", "viz_id": "viz_1706_03762_1",
+        "vote": "down", "reason": "overlapping text",
+    })
+    assert resp.status_code == 200
+    rows = (await db.execute(select(Feedback))).scalars().all()
+    assert len(rows) == 1
+    fb = rows[0]
+    assert fb.vote == "down" and fb.reason == "overlapping text"
+    # paper_id comes from the viz row, not the client
+    assert fb.paper_id == "1706.03762"
+    assert fb.created_at.tzinfo is None  # naive-UTC convention (CLAUDE.md #6)
+
+
+async def test_video_feedback_rejects_unknown_viz(client):
+    resp = await client.post("/api/feedback", json={
+        "kind": "video", "viz_id": "viz_does_not_exist", "vote": "up",
+    })
+    assert resp.status_code == 404
+
+
+async def test_video_feedback_requires_vote(client, db):
+    await _seed_viz(db)
+    resp = await client.post("/api/feedback", json={
+        "kind": "video", "viz_id": "viz_1706_03762_1",
+    })
+    assert resp.status_code == 422
+
+
+async def test_site_feedback_requires_comment(client):
+    assert (await client.post("/api/feedback", json={"kind": "site"})).status_code == 422
+    assert (await client.post("/api/feedback", json={
+        "kind": "site", "comment": "   ",
+    })).status_code == 422
+    resp = await client.post("/api/feedback", json={
+        "kind": "site", "comment": "please add voice selection",
+    })
+    assert resp.status_code == 200
+
+
+async def test_site_feedback_never_stores_viz_or_vote(client, db):
+    await client.post("/api/feedback", json={
+        "kind": "site", "comment": "great tool",
+        "viz_id": "viz_smuggled", "vote": "up",
+    })
+    fb = (await db.execute(select(Feedback))).scalars().one()
+    assert fb.viz_id is None and fb.vote is None
+
+
+async def test_oversized_comment_is_rejected(client):
+    resp = await client.post("/api/feedback", json={
+        "kind": "site", "comment": "x" * 2001,
+    })
+    assert resp.status_code == 422
+
+
+async def test_rate_limit_kicks_in(client, db, monkeypatch):
+    await _seed_viz(db)
+    monkeypatch.setattr(feedback_limiter, "max_events", 2)
+    body = {"kind": "video", "viz_id": "viz_1706_03762_1", "vote": "up"}
+    assert (await client.post("/api/feedback", json=body)).status_code == 200
+    assert (await client.post("/api/feedback", json=body)).status_code == 200
+    resp = await client.post("/api/feedback", json=body)
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+
+
+async def test_create_feedback_query_defaults(db):
+    fb = await queries.create_feedback(db, kind="site", comment="hi")
+    assert fb.id.startswith("fb_")
+    assert fb.viz_id is None and fb.vote is None

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -35,7 +35,7 @@ async def client(db):
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_db] = lambda: db
-    feedback_limiter._events.clear()  # isolate rate-limit state between tests
+    feedback_limiter.reset()  # isolate rate-limit state between tests
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
@@ -92,10 +92,12 @@ async def test_site_feedback_requires_comment(client):
 async def test_site_feedback_never_stores_viz_or_vote(client, db):
     await client.post("/api/feedback", json={
         "kind": "site", "comment": "great tool",
-        "viz_id": "viz_smuggled", "vote": "up",
+        "viz_id": "viz_smuggled", "vote": "up", "reason": "smuggled category",
     })
     fb = (await db.execute(select(Feedback))).scalars().one()
     assert fb.viz_id is None and fb.vote is None
+    # reason is the downvote category — site rows must not carry one either
+    assert fb.reason is None
 
 
 async def test_oversized_comment_is_rejected(client):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,8 @@ You give the system an arXiv paper ID. It gives you back narrated, animated expl
 
 **Visual QA + self-repair** (`agents/visual_qa.py`, `temporal_app/activities.py`): after each render, a vision model samples 3 frames and judges layout defects (overlap / cutoff / collisions), scoring every verdict into Langfuse (`visual_qa_defect`). On the Temporal path, a `major` verdict triggers one **vision-grounded repair**: the video is read back through the storage backend (never the CDN — stable keys cache for a year), the defect frames plus the judge's issues go to a multimodal model, and the repaired code is re-rendered and re-judged. Every vision-failure mode falls back to a text-only repair; an unusable repair keeps the original video. Measured in production: text-only repair fixed 0/6 flagged videos; vision-grounded fixed 2/4 in its first run — the pixels carry information the text descriptions provably don't.
 
+**Human feedback loop** (`POST /api/feedback`): viewers vote 👍/👎 per video (optional reason chip) or leave site suggestions; rows land in the `feedback` table with `paper_id` denormalized from the visualization row. Video votes are human-labeled defect data — the ground truth the vision judge can be calibrated against, and seed material for the eval golden set.
+
 **Terminal status is honest** (`resolve_terminal_job_status` in `jobs/worker.py`): a job is `completed` only if at least one visualization actually rendered. Zero generated or all-failed renders mark the job `failed` with an explanatory error, while the parsed paper text remains readable. Individual render failures are recorded per visualization and don't sink the job.
 
 ## Ingestion (`backend/ingestion/`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,7 @@ self.set_speech_service(OpenAIService(voice="nova", model="gpt-4o-mini-tts", tra
 | GET | `/api/papers` | Explore gallery: all processed papers |
 | GET | `/api/video/{video_id}` | Serve or redirect to a rendered video |
 | POST | `/api/render` | Dev-only raw Manim render — in production, 404 unless `RENDER_API_SECRET` is configured and presented via `X-Render-Secret` (timing-safe compare) |
+| POST | `/api/feedback` | Store viewer feedback: per-video 👍/👎 (labeled QA ground truth) or site suggestion |
 | GET | `/api/health` | Database / Manim / storage health |
 
 CORS allows `arxivisual.org`, this project's Vercel preview deployments, and localhost dev.

--- a/frontend/app/abs/[...id]/page.tsx
+++ b/frontend/app/abs/[...id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState, useCallback, useMemo, useRef, use } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { CardStack } from "@/components/CardStack";
+import { SiteFeedback } from "@/components/SiteFeedback";
 import type { ScrollySectionModel } from "@/components/ScrollySection";
 import { GlassCard } from "@/components/ui/glass-card";
 import { MosaicBackground } from "@/components/ui/mosaic-background";
@@ -521,6 +522,7 @@ function ReadyState({
       level: clampLevel(s.level),
       equations: s.equations,
       videoUrl: s.video_url,
+      vizId: s.viz_id,
     }));
 
   const heroContent = (
@@ -604,6 +606,11 @@ function ReadyState({
           heroContent={heroContent}
           onProgressChange={onProgressChange}
         />
+
+        {/* Feature suggestions */}
+        <div className="mt-12 flex justify-center">
+          <SiteFeedback />
+        </div>
 
         {/* Footer links */}
         <div className="mt-8 mb-16 flex items-center justify-center gap-4 text-sm">

--- a/frontend/components/ScrollySection.tsx
+++ b/frontend/components/ScrollySection.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, useMotionValue, useMotionTemplate } from "framer-motion";
+import { VideoFeedback } from "@/components/VideoFeedback";
 import { VideoPlayer } from "@/components/VideoPlayer";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { cn } from "@/lib/utils";
@@ -13,6 +14,7 @@ export type ScrollySectionModel = {
   level?: 1 | 2 | 3;
   equations?: string[];
   videoUrl?: string;
+  vizId?: string;
 };
 
 function mergeContentWithEquations(content: string, equations?: string[]): string {
@@ -224,6 +226,7 @@ export function ScrollySection({
                     pauseWhenInactive={!isActive}
                   />
                 </div>
+                {section.vizId && <VideoFeedback vizId={section.vizId} />}
               </motion.div>
             )}
           </div>

--- a/frontend/components/SiteFeedback.tsx
+++ b/frontend/components/SiteFeedback.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { sendSiteFeedback } from "@/lib/api";
+
+/**
+ * Compact "suggest a feature / report a problem" box for the paper footer.
+ * Collapsed to one line of text until the reader opens it.
+ */
+export function SiteFeedback() {
+  const [open, setOpen] = useState(false);
+  const [comment, setComment] = useState("");
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+
+  async function submit() {
+    const trimmed = comment.trim();
+    if (!trimmed || state === "sending") return;
+    setState("sending");
+    try {
+      await sendSiteFeedback(trimmed.slice(0, 2000));
+      setState("sent");
+    } catch {
+      setState("error");
+    }
+  }
+
+  if (state === "sent") {
+    return (
+      <p className="text-sm text-white/30">
+        Thanks — your suggestion landed. It genuinely shapes what gets built next.
+      </p>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-sm text-white/30 underline decoration-white/20 underline-offset-4 transition hover:text-white/60"
+      >
+        Wish this did something it doesn&apos;t? Suggest a feature
+      </button>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-md space-y-2">
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        rows={3}
+        maxLength={2000}
+        placeholder="What should arXivisual do better? A feature, a paper type it struggles with, anything."
+        className="w-full resize-none rounded-lg border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-sm text-white/80 placeholder:text-white/25 focus:border-white/[0.2] focus:outline-none"
+      />
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!comment.trim() || state === "sending"}
+          className="rounded-lg border border-white/[0.1] bg-white/[0.06] px-3 py-1.5 text-sm text-white/70 transition hover:bg-white/[0.12] disabled:opacity-40"
+        >
+          {state === "sending" ? "Sending…" : "Send"}
+        </button>
+        {state === "error" && (
+          <span className="text-xs text-[#f27066]">
+            Couldn&apos;t send — try again in a moment.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/StackCard.tsx
+++ b/frontend/components/StackCard.tsx
@@ -198,8 +198,8 @@ export function StackCard({
             <div className="mt-8">
               <div className="rounded-xl overflow-hidden border border-white/[0.06] bg-black/30">
                 <VideoPlayer src={section.videoUrl} title="Visualization" />
-                {section.vizId && <VideoFeedback vizId={section.vizId} />}
               </div>
+              {section.vizId && <VideoFeedback vizId={section.vizId} />}
             </div>
           )}
         </motion.div>

--- a/frontend/components/StackCard.tsx
+++ b/frontend/components/StackCard.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useRef, useEffect, useCallback } from "react";
 import { motion, type MotionValue, useMotionValue, useMotionTemplate } from "framer-motion";
+import { VideoFeedback } from "@/components/VideoFeedback";
 import { VideoPlayer } from "@/components/VideoPlayer";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { cn } from "@/lib/utils";
@@ -56,6 +57,7 @@ interface StackCardProps {
     level?: 1 | 2 | 3;
     equations?: string[];
     videoUrl?: string;
+    vizId?: string;
   };
   index: number;
   totalSections: number;
@@ -196,6 +198,7 @@ export function StackCard({
             <div className="mt-8">
               <div className="rounded-xl overflow-hidden border border-white/[0.06] bg-black/30">
                 <VideoPlayer src={section.videoUrl} title="Visualization" />
+                {section.vizId && <VideoFeedback vizId={section.vizId} />}
               </div>
             </div>
           )}

--- a/frontend/components/VideoFeedback.tsx
+++ b/frontend/components/VideoFeedback.tsx
@@ -37,7 +37,12 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
     () => false
   );
 
-  function markDone() {
+  function submitVote(v: "up" | "down", reason?: string) {
+    // Exactly ONE row per user action: a bare 👎 only opens the reason stage,
+    // and the POST fires when that stage resolves (chip or Skip). Sending on
+    // the initial 👎 too would double-count downvotes in the labeled dataset.
+    // Fire-and-forget: a lost vote is not worth interrupting reading for.
+    sendVideoFeedback(vizId, v, reason).catch(() => {});
     try {
       localStorage.setItem(storageKey, "1");
     } catch {
@@ -45,16 +50,6 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
     }
     setThanked(true);
     setStage("done");
-  }
-
-  function vote(v: "up" | "down", reason?: string) {
-    // Fire-and-forget: a lost vote is not worth interrupting reading for.
-    sendVideoFeedback(vizId, v, reason).catch(() => {});
-    if (v === "down" && !reason) {
-      setStage("reason");
-    } else {
-      markDone();
-    }
   }
 
   if (alreadyVoted && stage === "vote") return null;
@@ -75,10 +70,7 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
           <button
             key={r}
             type="button"
-            onClick={() => {
-              sendVideoFeedback(vizId, "down", r).catch(() => {});
-              markDone();
-            }}
+            onClick={() => submitVote("down", r)}
             className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-[11px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
           >
             {r}
@@ -86,7 +78,7 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
         ))}
         <button
           type="button"
-          onClick={markDone}
+          onClick={() => submitVote("down")}
           className="px-1.5 py-1 text-[11px] text-white/25 transition hover:text-white/50"
         >
           Skip
@@ -101,7 +93,7 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
       <button
         type="button"
         aria-label="Yes, helpful"
-        onClick={() => vote("up")}
+        onClick={() => submitVote("up")}
         className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[12px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
       >
         👍
@@ -109,7 +101,7 @@ export function VideoFeedback({ vizId }: { vizId: string }) {
       <button
         type="button"
         aria-label="No, something is off"
-        onClick={() => vote("down")}
+        onClick={() => setStage("reason")}
         className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[12px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
       >
         👎

--- a/frontend/components/VideoFeedback.tsx
+++ b/frontend/components/VideoFeedback.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import { sendVideoFeedback } from "@/lib/api";
+
+const DOWN_REASONS = [
+  "Overlapping text",
+  "Elements cut off",
+  "Audio issue",
+  "Wrong concept",
+];
+
+type Stage = "vote" | "reason" | "done";
+
+/**
+ * Thumbs verdict on one rendered visualization. Every vote is labeled ground
+ * truth for the backend's visual-QA loop, so keep friction minimal: one tap
+ * for 👍, one tap + optional reason chip for 👎. A localStorage guard keeps
+ * repeat votes from the same browser out of the dataset.
+ */
+export function VideoFeedback({ vizId }: { vizId: string }) {
+  const storageKey = `arxivisual-fb-${vizId}`;
+  const [stage, setStage] = useState<Stage>("vote");
+  const [thanked, setThanked] = useState(false);
+  // SSR renders the buttons (server snapshot false); after hydration the
+  // client snapshot hides them if this browser already voted. localStorage
+  // never changes behind our back, so subscribe is a no-op.
+  const alreadyVoted = useSyncExternalStore(
+    () => () => {},
+    () => {
+      try {
+        return localStorage.getItem(storageKey) !== null;
+      } catch {
+        return false; // storage unavailable — backend rate limit caps abuse
+      }
+    },
+    () => false
+  );
+
+  function markDone() {
+    try {
+      localStorage.setItem(storageKey, "1");
+    } catch {
+      // Storage unavailable (private mode) — the vote still counted.
+    }
+    setThanked(true);
+    setStage("done");
+  }
+
+  function vote(v: "up" | "down", reason?: string) {
+    // Fire-and-forget: a lost vote is not worth interrupting reading for.
+    sendVideoFeedback(vizId, v, reason).catch(() => {});
+    if (v === "down" && !reason) {
+      setStage("reason");
+    } else {
+      markDone();
+    }
+  }
+
+  if (alreadyVoted && stage === "vote") return null;
+
+  if (stage === "done") {
+    return thanked ? (
+      <p className="mt-2 text-[11px] text-white/30">
+        Thanks — this helps improve future renders.
+      </p>
+    ) : null;
+  }
+
+  if (stage === "reason") {
+    return (
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <span className="text-[11px] text-white/30">What went wrong?</span>
+        {DOWN_REASONS.map((r) => (
+          <button
+            key={r}
+            type="button"
+            onClick={() => {
+              sendVideoFeedback(vizId, "down", r).catch(() => {});
+              markDone();
+            }}
+            className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-[11px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
+          >
+            {r}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={markDone}
+          className="px-1.5 py-1 text-[11px] text-white/25 transition hover:text-white/50"
+        >
+          Skip
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <span className="text-[11px] text-white/30">Was this visualization helpful?</span>
+      <button
+        type="button"
+        aria-label="Yes, helpful"
+        onClick={() => vote("up")}
+        className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[12px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
+      >
+        👍
+      </button>
+      <button
+        type="button"
+        aria-label="No, something is off"
+        onClick={() => vote("down")}
+        className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[12px] text-white/50 transition hover:bg-white/[0.08] hover:text-white/80"
+      >
+        👎
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/ui/mosaic-background.tsx
+++ b/frontend/components/ui/mosaic-background.tsx
@@ -252,9 +252,16 @@ export function MosaicBackground({
     };
 
     window.addEventListener("resize", handleResize);
+    // A parent that was zero-sized at mount (hidden tab, unsettled layout)
+    // fires no window resize when it gains size — observe the parent itself
+    // so the guard's skipped draw happens once layout exists.
+    const parent = canvasRef.current?.parentElement;
+    const observer = parent ? new ResizeObserver(handleResize) : null;
+    if (parent && observer) observer.observe(parent);
     return () => {
       clearTimeout(timeout);
       window.removeEventListener("resize", handleResize);
+      observer?.disconnect();
     };
   }, [render]);
 

--- a/frontend/components/ui/mosaic-background.tsx
+++ b/frontend/components/ui/mosaic-background.tsx
@@ -52,6 +52,10 @@ export function MosaicBackground({
     const dpr = window.devicePixelRatio || 1;
     const w = parent.clientWidth;
     const h = parent.clientHeight;
+    // A zero-sized parent (layout not settled yet, hidden tab) would make
+    // getImageData below throw IndexSizeError and crash the whole React tree
+    // to a black page. Skip drawing — this is decoration, not content.
+    if (w < 1 || h < 1) return;
 
     canvas.width = w * dpr;
     canvas.height = h * dpr;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -223,6 +223,7 @@ export async function getPaper(arxivId: string): Promise<Paper | null> {
       order_index: s.order_index,
       equations: s.equations,
       video_url: resolveVideoUrl(viz?.video_url),
+      viz_id: viz?.id,
     };
   });
 
@@ -324,4 +325,31 @@ export function toProcessingStatus(response: StatusResponse): ProcessingStatus {
     current_step: response.current_step,
     error: response.error,
   };
+}
+
+/**
+ * Send viewer feedback. Video votes are labeled ground truth for the
+ * backend's visual-QA loop; site comments are feature requests.
+ * Fire-and-forget friendly: callers may ignore the promise.
+ */
+export async function sendVideoFeedback(
+  vizId: string,
+  vote: "up" | "down",
+  reason?: string
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind: "video", viz_id: vizId, vote, reason }),
+  });
+  if (!res.ok) throw new Error(`Feedback failed: ${res.status}`);
+}
+
+export async function sendSiteFeedback(comment: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind: "site", comment }),
+  });
+  if (!res.ok) throw new Error(`Feedback failed: ${res.status}`);
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -332,24 +332,23 @@ export function toProcessingStatus(response: StatusResponse): ProcessingStatus {
  * backend's visual-QA loop; site comments are feature requests.
  * Fire-and-forget friendly: callers may ignore the promise.
  */
-export async function sendVideoFeedback(
-  vizId: string,
-  vote: "up" | "down",
-  reason?: string
-): Promise<void> {
+async function postFeedback(body: Record<string, unknown>): Promise<void> {
   const res = await fetch(`${API_BASE}/api/feedback`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ kind: "video", viz_id: vizId, vote, reason }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`Feedback failed: ${res.status}`);
 }
 
-export async function sendSiteFeedback(comment: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/feedback`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ kind: "site", comment }),
-  });
-  if (!res.ok) throw new Error(`Feedback failed: ${res.status}`);
+export function sendVideoFeedback(
+  vizId: string,
+  vote: "up" | "down",
+  reason?: string
+): Promise<void> {
+  return postFeedback({ kind: "video", viz_id: vizId, vote, reason });
+}
+
+export function sendSiteFeedback(comment: string): Promise<void> {
+  return postFeedback({ kind: "site", comment });
 }

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -35,5 +35,6 @@ export type Section = {
   order_index: number;
   equations: string[];
   video_url?: string;
+  viz_id?: string;
 };
 


### PR DESCRIPTION
Turns organic traffic into labeled data: every rendered video gets a one-tap 👍/👎 (optional reason chip on 👎) stored via a new `POST /api/feedback` into a `feedback` table. **Video votes are human-labeled defect data — ground truth the visual-QA judge can be calibrated against, and seed material for the eval golden set.** `paper_id` is denormalized from the viz row server-side, never trusted from the client. A collapsed suggest-a-feature box joins the paper footer.

- Rate-limited per IP on its own bucket (`RATE_LIMIT_FEEDBACK_PER_IP`, 30/h)
- Fire-and-forget votes — reading is never interrupted; localStorage guards repeat votes (via `useSyncExternalStore`, no hydration mismatch)
- viz id threaded through `Section`/`ScrollySectionModel` to both reading views
- 8 hermetic backend tests (storage, validation, smuggled-field rejection, rate limit)

**Separate called-out commit:** `MosaicBackground` crashed the entire page to black (`getImageData` IndexSizeError) when its parent had zero size — reproduced against production. Three-line guard: skip drawing decoration on zero-size layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 👍/👎 feedback controls beneath videos, with optional reasons for negative ratings.
  * Added a feature-suggestion form at the bottom of paper pages.
  * Feedback submissions display confirmation or retry messages and prevent duplicate browser submissions.
  * Added safeguards against excessive submissions.

* **Bug Fixes**
  * Prevented mosaic backgrounds from crashing when their container has no size.

* **Documentation**
  * Documented the new feedback workflow and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->