### PR TITLE
fix: never ingest the abstract page; honest failure instead of raw-text fallback

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -126,5 +126,9 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
    and reaper queries compare naive values.
 7. **All LLM calls route through `agents/base.py`** (`call_llm` / `BaseAgent._call_llm`) — provider switching
    and Langfuse tracing live there.
-8. **Keep `pytest` hermetic.** `testpaths=["tests"]` exists because scripts under `tools/` fire real API calls
+8. **Ingestion never stores an abstract page or raw parser output.** HTML availability requires a 200 from
+   a LaTeXML host (`arxiv.org/html`, then `ar5iv`) with redirects NOT followed — ar5iv redirects unconverted
+   ids to the arXiv abstract page, and ~31% of the library was once ingested that way; fetched bodies must
+   contain `ltx_document`. Summarization is retried once, then the job fails with a truthful error.
+9. **Keep `pytest` hermetic.** `testpaths=["tests"]` exists because scripts under `tools/` fire real API calls
    on collection; new tests must not need network or real keys.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -126,9 +126,12 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
    and reaper queries compare naive values.
 7. **All LLM calls route through `agents/base.py`** (`call_llm` / `BaseAgent._call_llm`) — provider switching
    and Langfuse tracing live there.
-8. **Ingestion never stores an abstract page or raw parser output.** HTML availability requires a 200 from
-   a LaTeXML host (`arxiv.org/html`, then `ar5iv`) with redirects NOT followed — ar5iv redirects unconverted
-   ids to the arXiv abstract page, and ~31% of the library was once ingested that way; fetched bodies must
-   contain `ltx_document`. Summarization is retried once, then the job fails with a truthful error.
+8. **Ingestion never stores an abstract page or raw parser output.** `find_latexml_html_url` probes the
+   LaTeXML pages themselves (`arxiv.org/html/{id}`, then `ar5iv.labs.arxiv.org/html/{id}`) with redirects
+   NOT followed; a 3xx counts only if it resolves to another `/html/` URL on those hosts that itself answers
+   200 — ar5iv sends unconverted ids to the arXiv abstract page, and ~31% of the library was once ingested
+   that way. Fetched bodies must contain `ltx_document`. Sources under 400 words raise
+   `SourceTooShortError` (never retried); other formatting failures are retried once in-function and the
+   Temporal ingest activity then fails the job with the real message (`ApplicationError`, non-retryable).
 9. **Keep `pytest` hermetic.** `testpaths=["tests"]` exists because scripts under `tools/` fire real API calls
    on collection; new tests must not need network or real keys.

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,7 @@ frontend, and builds the backend Docker image. A blocking secret scan and a nigh
 
 ## How a paper becomes videos
 
-1. **Ingest** (`ingestion/`) — fetch metadata + ar5iv HTML (PDF fallback), parse into sections, store in the DB.
+1. **Ingest** (`ingestion/`) — fetch metadata + LaTeXML HTML from arxiv.org/html or ar5iv (PDF fallback); sources under 400 words are refused, and a formatting failure fails the job instead of storing raw text, parse into sections, store in the DB.
 2. **Analyze & plan** (`agents/section_analyzer.py`, `agents/visualization_planner.py`) — find up to 5
    visualization-worthy concepts and storyboard each one.
 3. **Generate** (`agents/manim_generator.py`) — write complete Manim `VoiceoverScene` code, narration included,

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -360,17 +360,16 @@ class BaseAgent:
         content containing curly braces (like LaTeX's \\begin{pmatrix}).
         Also handles {{ and }} escape sequences like str.format() does.
         """
-        result = self.prompt_template
+        # Mark the TEMPLATE's escaped braces before substitution: doing the
+        # unescape afterwards rewrote substituted content too (LaTeX like
+        # \\frac{{a}} inside a section became \\frac{a}).
+        result = self.prompt_template.replace("{{", "\x00LB\x00").replace("}}", "\x00RB\x00")
 
-        # Replace all placeholders first
         for key, value in kwargs.items():
             placeholder = "{" + key + "}"
             result = result.replace(placeholder, str(value))
 
-        # Convert escaped braces ({{ -> {, }} -> }) like str.format() does
-        result = result.replace("{{", "{").replace("}}", "}")
-
-        return result
+        return result.replace("\x00LB\x00", "{").replace("\x00RB\x00", "}")
 
     def _parse_json_response(self, content: str) -> dict:
         """

--- a/backend/ingestion/__init__.py
+++ b/backend/ingestion/__init__.py
@@ -103,18 +103,26 @@ async def ingest_paper(
     total_chars = sum(len(s.content) for s in sections)
     logger.info(f"Extracted {raw_count} raw sections ({total_chars:,} chars total)")
 
-    # Step 4: Summarize + organize into <=5 sections (two-phase LLM pipeline)
-    try:
-        sections = await format_sections(sections, meta)
-        logger.info(
-            f"Section formatting succeeded: {raw_count} raw → {len(sections)} summarized sections"
-        )
-    except Exception as e:
-        logger.error(
-            f"Section formatting FAILED ({type(e).__name__}: {e}). "
-            f"Falling back to {raw_count} raw sections. "
-            f"This usually means the LLM call timed out or the API key is invalid."
-        )
+    # Step 4: Summarize + organize into <=5 sections (two-phase LLM pipeline).
+    # No raw-text fallback: raw parser sections carry header/footnote/table
+    # debris and shipped to the site with videos attached (2507.15866). A
+    # paper we cannot format is a failed job with a truthful error, not a
+    # degraded page.
+    last_exc: Exception | None = None
+    for attempt in (1, 2):
+        try:
+            sections = await format_sections(sections, meta)
+            logger.info(
+                f"Section formatting succeeded: {raw_count} raw → {len(sections)} summarized sections"
+            )
+            break
+        except Exception as e:
+            last_exc = e
+            logger.warning(f"Section formatting attempt {attempt} failed ({type(e).__name__}: {e})")
+    else:
+        raise RuntimeError(
+            f"Section formatting failed twice for {arxiv_id}: {last_exc}"
+        ) from last_exc
 
     # Step 5: Build final structure
     paper = StructuredPaper(

--- a/backend/ingestion/__init__.py
+++ b/backend/ingestion/__init__.py
@@ -5,7 +5,7 @@ Main entry point: ingest_paper(arxiv_id) -> StructuredPaper
 
 Pipeline:
 1. Fetch metadata from arXiv API
-2. Check for ar5iv HTML availability
+2. Locate a LaTeXML HTML rendering (arxiv.org/html, then ar5iv)
 3. Parse HTML (preferred) or PDF (fallback)
 4. Extract sections with hierarchy
 5. Cache and return StructuredPaper
@@ -32,7 +32,7 @@ from .arxiv_fetcher import (
 from .html_parser import fetch_and_parse_html, parse_html
 from .pdf_parser import parse_pdf
 from .section_extractor import extract_sections
-from .section_formatter import format_sections
+from .section_formatter import SourceTooShortError, format_sections
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ async def ingest_paper(
 
     if meta.html_url and not prefer_pdf:
         # Try HTML first (cleaner structure)
-        logger.info(f"Parsing ar5iv HTML: {meta.html_url}")
+        logger.info(f"Parsing LaTeXML HTML: {meta.html_url}")
         try:
             content = await fetch_and_parse_html(meta.html_url)
             logger.info("Successfully parsed HTML content")
@@ -116,12 +116,14 @@ async def ingest_paper(
                 f"Section formatting succeeded: {raw_count} raw → {len(sections)} summarized sections"
             )
             break
+        except SourceTooShortError:
+            raise  # deterministic — retrying an LLM call cannot grow the source
         except Exception as e:
             last_exc = e
             logger.warning(f"Section formatting attempt {attempt} failed ({type(e).__name__}: {e})")
     else:
         raise RuntimeError(
-            f"Section formatting failed twice for {arxiv_id}: {last_exc}"
+            f"Section formatting failed after 2 attempts for {arxiv_id}: {last_exc}"
         ) from last_exc
 
     # Step 5: Build final structure

--- a/backend/ingestion/arxiv_fetcher.py
+++ b/backend/ingestion/arxiv_fetcher.py
@@ -2,7 +2,7 @@
 ArXiv paper fetcher for the ingestion pipeline.
 
 Fetches paper metadata from the arXiv API and downloads PDFs.
-Also checks for ar5iv HTML availability.
+Also locates a LaTeXML HTML rendering (arxiv.org/html, then ar5iv).
 """
 
 import asyncio
@@ -138,7 +138,7 @@ async def fetch_paper_meta(arxiv_id: str) -> ArxivPaperMeta:
     pdf_url = f"https://arxiv.org/pdf/{base_id}.pdf"
     
     # Check for ar5iv HTML availability
-    html_url = await check_ar5iv_available(base_id)
+    html_url = await find_latexml_html_url(base_id)
     
     return ArxivPaperMeta(
         arxiv_id=base_id,
@@ -153,36 +153,52 @@ async def fetch_paper_meta(arxiv_id: str) -> ArxivPaperMeta:
     )
 
 
-async def check_ar5iv_available(arxiv_id: str) -> str | None:
+_LATEXML_HOSTS = {"arxiv.org", "ar5iv.labs.arxiv.org"}
+
+
+def _is_latexml_html_url(url: str) -> bool:
+    parsed = httpx.URL(url)
+    return parsed.host in _LATEXML_HOSTS and parsed.path.startswith("/html/")
+
+
+async def find_latexml_html_url(arxiv_id: str) -> str | None:
     """
     Find a LaTeXML HTML rendering of the paper, or None.
 
-    Tries arxiv.org's own HTML first, then ar5iv. Redirects are NOT followed:
-    ar5iv answers ids it hasn't converted with a redirect to the arxiv.org
-    ABSTRACT page, and following it made ~31% of the library ingest a
-    300-word inflation of the abstract as "the paper". A redirect is accepted
-    only when it points at another /html/ rendering.
+    Probes the LaTeXML pages themselves — arxiv.org/html first, then
+    ar5iv.labs.arxiv.org/html — with redirects NOT followed. The old check
+    HEAD'd ar5iv.org/abs with redirects on; for ids ar5iv hasn't converted
+    that chain ends at the arxiv.org ABSTRACT page with a 200, and ~31% of
+    the library was ingested as a 300-word inflation of the abstract. A 3xx
+    is honoured only when it resolves to another /html/ URL on a LaTeXML host
+    AND that target itself answers 200 (unconverted ids redirect to /abs/).
     """
     candidates = [
         f"https://arxiv.org/html/{arxiv_id}",
-        f"https://ar5iv.org/abs/{arxiv_id}",
+        f"https://ar5iv.labs.arxiv.org/html/{arxiv_id}",
     ]
-    try:
-        async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
-            for url in candidates:
-                try:
-                    response = await client.head(url)
-                except httpx.RequestError:
-                    continue
+    async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
+        for url in candidates:
+            try:
+                response = await client.head(url)
                 if response.status_code == 200:
                     return url
                 if 300 <= response.status_code < 400:
                     location = response.headers.get("location", "")
-                    if "/html/" in location:
-                        return location
-    except httpx.RequestError:
-        pass
+                    if not location:
+                        continue
+                    target = str(httpx.URL(url).join(location))
+                    if _is_latexml_html_url(target):
+                        resolved = await client.head(target)
+                        if resolved.status_code == 200:
+                            return target
+            except httpx.RequestError:
+                continue
     return None
+
+
+# Backwards-compatible name (callers/tests written against the old check).
+check_ar5iv_available = find_latexml_html_url
 
 
 async def download_pdf(pdf_url: str) -> bytes:

--- a/backend/ingestion/arxiv_fetcher.py
+++ b/backend/ingestion/arxiv_fetcher.py
@@ -155,27 +155,33 @@ async def fetch_paper_meta(arxiv_id: str) -> ArxivPaperMeta:
 
 async def check_ar5iv_available(arxiv_id: str) -> str | None:
     """
-    Check if ar5iv HTML version is available for this paper.
-    
-    Args:
-        arxiv_id: Normalized arXiv ID (without version)
-        
-    Returns:
-        ar5iv URL if available, None otherwise
+    Find a LaTeXML HTML rendering of the paper, or None.
+
+    Tries arxiv.org's own HTML first, then ar5iv. Redirects are NOT followed:
+    ar5iv answers ids it hasn't converted with a redirect to the arxiv.org
+    ABSTRACT page, and following it made ~31% of the library ingest a
+    300-word inflation of the abstract as "the paper". A redirect is accepted
+    only when it points at another /html/ rendering.
     """
-    url = f"https://ar5iv.org/abs/{arxiv_id}"
-    
+    candidates = [
+        f"https://arxiv.org/html/{arxiv_id}",
+        f"https://ar5iv.org/abs/{arxiv_id}",
+    ]
     try:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=10.0) as client:
-            response = await client.head(url)
-            
-            if response.status_code == 200:
-                return url
-            
+        async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
+            for url in candidates:
+                try:
+                    response = await client.head(url)
+                except httpx.RequestError:
+                    continue
+                if response.status_code == 200:
+                    return url
+                if 300 <= response.status_code < 400:
+                    location = response.headers.get("location", "")
+                    if "/html/" in location:
+                        return location
     except httpx.RequestError:
-        # Network error, ar5iv might be down
         pass
-    
     return None
 
 

--- a/backend/ingestion/html_parser.py
+++ b/backend/ingestion/html_parser.py
@@ -29,8 +29,20 @@ async def fetch_and_parse_html(html_url: str) -> ParsedContent:
         response = await client.get(html_url)
         response.raise_for_status()
         html_content = response.text
-    
+        final_url = str(response.url)
+
+    if not looks_like_latexml_paper(html_content):
+        raise ValueError(
+            f"{final_url} is not a LaTeXML paper page (an abstract or landing page?) — "
+            "refusing to parse it as the paper"
+        )
     return parse_html(html_content)
+
+
+def looks_like_latexml_paper(html_content: str) -> bool:
+    """LaTeXML output (arxiv.org/html, ar5iv) always carries these markers;
+    the arXiv abstract page — where ar5iv redirects unconverted ids — never does."""
+    return "ltx_document" in html_content or "ltx_page_main" in html_content
 
 
 def parse_html(html_content: str) -> ParsedContent:
@@ -46,7 +58,12 @@ def parse_html(html_content: str) -> ParsedContent:
     soup = BeautifulSoup(html_content, 'lxml')
     
     # Find the main article content
-    article = soup.find('article') or soup.find('main') or soup.find('body')
+    article = (
+        soup.find('article', class_='ltx_document')
+        or soup.find('article')
+        or soup.find('main')
+        or soup.find('body')
+    )
     
     if not article:
         raise ValueError("Could not find article content in HTML")

--- a/backend/ingestion/section_formatter.py
+++ b/backend/ingestion/section_formatter.py
@@ -20,6 +20,12 @@ from models.paper import ArxivPaperMeta, Equation, Section
 logger = logging.getLogger(__name__)
 
 MIN_SOURCE_WORDS = 400  # below this the 'paper' is an abstract, not a paper
+
+
+class SourceTooShortError(ValueError):
+    """The fetched text is an abstract/landing page, not a paper. Deterministic:
+    retrying the LLM call cannot fix it, so callers must not retry."""
+
 MAX_SECTIONS = 5
 
 
@@ -56,8 +62,7 @@ def _prepare_paper_content(
 # Phase 1: Holistic summarization
 # ---------------------------------------------------------------------------
 
-SUMMARIZE_SYSTEM_PROMPT = r"""\
-You are an expert science communicator who makes academic papers accessible to newcomers.
+SUMMARIZE_SYSTEM_PROMPT = r"""You are an expert science communicator who makes academic papers accessible to newcomers.
 
 Your task: Read the entire paper below and write a clear, approachable summary.
 
@@ -110,13 +115,13 @@ async def _summarize_paper(
     Returns plain markdown text at 30-40% of original length.
     """
     if total_words < MIN_SOURCE_WORDS:
-        raise ValueError(
+        raise SourceTooShortError(
             f"Paper text is only {total_words} words — that is an abstract or landing "
             "page, not the paper; refusing to summarize it into a fake full text"
         )
     target_pct = 35  # aim for middle of 30-40% range
-    # The old max(300, ...) floor forced INFLATION of short sources.
-    target_words = max(150, int(total_words * target_pct / 100))
+    # No floor: the old max(300, ...) forced INFLATION of short sources.
+    target_words = int(total_words * target_pct / 100)
 
     system_prompt = (
         SUMMARIZE_SYSTEM_PROMPT
@@ -285,39 +290,59 @@ def _fallback_split(text: str, max_sections: int = MAX_SECTIONS) -> list[dict]:
     return sections
 
 
-_SCAFFOLD_RE = re.compile(
-    r"^\s*(?:Paper:\s*\".*?\"\s*\n+)?(?:Summarized text to organize into sections:\s*\n+)"
-    r"|</?summary>\s*",
+_SCAFFOLD_LEAD_RE = re.compile(
+    r"^\s*(?:Paper:\s*\".*?\"\s*\n+)?"
+    r"(?:(?:Summarized text to organize into sections:|"
+    r"The text to organize is between the <summary> tags\.[^\n]*)\s*\n+)?"
+    r"(?:<summary>\s*)?",
     re.IGNORECASE,
 )
+_SCAFFOLD_TAIL_RE = re.compile(r"\s*</summary>\s*$", re.IGNORECASE)
 
 
 def strip_prompt_scaffold(text: str) -> str:
-    """Remove the organizer prompt's own header/delimiters if the model echoed them."""
-    return _SCAFFOLD_RE.sub("", text or "").strip()
+    """Remove the organizer prompt's own header/delimiters if the model echoed
+    them — anchored to the edges only, so a '<summary>' in body prose survives."""
+    t = _SCAFFOLD_LEAD_RE.sub("", text or "", count=1)
+    return _SCAFFOLD_TAIL_RE.sub("", t).strip()
 
 
 _DISPLAY_MATH_RE = re.compile(r"\$\$(.+?)\$\$", re.S)
 _INLINE_MATH_RE = re.compile(r"(?<!\$)\$(?!\$)([^$\n]{2,200}?)\$(?!\$)")
 
 
-def extract_equations(text: str) -> list[Equation]:
-    """Carry the summary's equations through as structured data.
+_MONEY_LEAD_RE = re.compile(r"^\d[\d,.]*\s*[KMBkmb]?\b\s+[a-z]")
+_PROSE_RUN_RE = re.compile(r"(?:\b[a-z]{2,}\s+){3,}")
+
+
+def _equations_from_summary(text: str) -> list[Equation]:
+    """Carry the summary's equations through as structured data (distinct from
+    pdf_parser.extract_equations, which works on raw PDF text with context).
 
     Sections used to ship equations=[] unconditionally, so the analyzer
-    always saw 'No equations in this section.' and the planner storyboarded
-    from prose alone. Inline spans must contain a TeX command, sub/superscript
-    or operator so currency ('$5 and $10') is not mistaken for math.
+    always saw 'No equations in this section.' Inline spans must contain a
+    TeX command, sub/superscript or operator, and must not read as money or
+    prose ('$5 < $10 today' is not an equation).
     """
     equations: list[Equation] = []
+    seen: set[str] = set()
+
+    def add(latex: str, inline: bool) -> None:
+        if latex and latex not in seen:
+            seen.add(latex)
+            equations.append(Equation(latex=latex, is_inline=inline))
+
     for m in _DISPLAY_MATH_RE.finditer(text or ""):
-        latex = m.group(1).strip()
-        if latex:
-            equations.append(Equation(latex=latex, is_inline=False))
+        add(m.group(1).strip(), False)
     for m in _INLINE_MATH_RE.finditer(text or ""):
         latex = m.group(1).strip()
-        if re.search(r"\\[A-Za-z]+|[_^=<>]", latex):
-            equations.append(Equation(latex=latex, is_inline=True))
+        if not re.search(r"\\[A-Za-z]+|[_^=<>]", latex):
+            continue
+        if _MONEY_LEAD_RE.match(latex) or _PROSE_RUN_RE.search(latex):
+            continue
+        if latex[0].isdigit() and not re.search(r"[A-Za-z\\]", latex):
+            continue  # "$5 < $10" — numbers and an operator, no variables
+        add(latex, True)
     return equations
 
 
@@ -401,12 +426,12 @@ async def format_sections(
     # --- Phase 1: Holistic summarization ---
     try:
         summary_text = await _summarize_paper(full_content, meta.title, total_words, model)
+    except SourceTooShortError:
+        raise
     except Exception as e:
         logger.error(f"Phase 1 (summarization) failed: {e}")
         print(f"[FORMATTER] Phase 1 FAILED ({type(e).__name__}: {e}), aborting pipeline")
-        raise RuntimeError(
-            "Section summarization failed. No paper content was stored to avoid raw-text fallback."
-        ) from e
+        raise RuntimeError(f"Section summarization failed: {type(e).__name__}: {e}") from e
 
     # --- Phase 2: Section organization ---
     try:
@@ -426,7 +451,7 @@ async def format_sections(
             level=1,
             content=cleaned_content,
             summary=cleaned_content,
-            equations=extract_equations(cleaned_content),
+            equations=_equations_from_summary(cleaned_content),
             figures=[],
             tables=[],
             parent_id=None,

--- a/backend/ingestion/section_formatter.py
+++ b/backend/ingestion/section_formatter.py
@@ -15,10 +15,11 @@ import logging
 import re
 
 from agents.base import call_llm
-from models.paper import ArxivPaperMeta, Section
+from models.paper import ArxivPaperMeta, Equation, Section
 
 logger = logging.getLogger(__name__)
 
+MIN_SOURCE_WORDS = 400  # below this the 'paper' is an abstract, not a paper
 MAX_SECTIONS = 5
 
 
@@ -55,7 +56,7 @@ def _prepare_paper_content(
 # Phase 1: Holistic summarization
 # ---------------------------------------------------------------------------
 
-SUMMARIZE_SYSTEM_PROMPT = """\
+SUMMARIZE_SYSTEM_PROMPT = r"""\
 You are an expert science communicator who makes academic papers accessible to newcomers.
 
 Your task: Read the entire paper below and write a clear, approachable summary.
@@ -88,6 +89,8 @@ FORMATTING:
 - Use bullet points sparingly for lists of results or contributions
 - Preserve LaTeX notation for important equations
 - Do NOT use TeX text styling commands like \textsc, \textbf, \mathrm for prose
+- Every LaTeX command must be inside $...$ or $$...$$; never write \alpha or \mathcal{X} in prose
+- Write currency as "USD 391M", never "$391M" (a bare $ starts a formula)
 - Write model names in plain text (e.g., "BERT Base", "BERT Large"), not split letters
 - Do NOT invent information not in the source paper
 - Do NOT start with "This paper..." or any preamble -- just begin explaining
@@ -106,8 +109,14 @@ async def _summarize_paper(
 
     Returns plain markdown text at 30-40% of original length.
     """
+    if total_words < MIN_SOURCE_WORDS:
+        raise ValueError(
+            f"Paper text is only {total_words} words — that is an abstract or landing "
+            "page, not the paper; refusing to summarize it into a fake full text"
+        )
     target_pct = 35  # aim for middle of 30-40% range
-    target_words = max(300, int(total_words * target_pct / 100))
+    # The old max(300, ...) floor forced INFLATION of short sources.
+    target_words = max(150, int(total_words * target_pct / 100))
 
     system_prompt = (
         SUMMARIZE_SYSTEM_PROMPT
@@ -187,11 +196,16 @@ async def _organize_into_sections(
         "{max_sections}", str(MAX_SECTIONS)
     )
 
+    # Delimited so rule 5 ("every piece of the input must appear in a
+    # section") cannot make the model copy this header into section 1 —
+    # 21 live papers started with 'Summarized text to organize into sections:'.
     user_prompt = f"""Paper: "{paper_title}"
 
-Summarized text to organize into sections:
+The text to organize is between the <summary> tags. The tags and this header are NOT content.
 
-{summary_text}"""
+<summary>
+{summary_text}
+</summary>"""
 
     summary_words = len(summary_text.split())
     print(f"[FORMATTER] Phase 2: Organizing {summary_words} words into <={MAX_SECTIONS} sections...")
@@ -213,6 +227,8 @@ Summarized text to organize into sections:
 
     parsed = json.loads(raw_response)
     organized_sections = parsed["sections"]
+    for sec in organized_sections:
+        sec["content"] = strip_prompt_scaffold(sec.get("content", ""))
 
     # Validate
     if not organized_sections:
@@ -267,6 +283,42 @@ def _fallback_split(text: str, max_sections: int = MAX_SECTIONS) -> list[dict]:
         idx += size
 
     return sections
+
+
+_SCAFFOLD_RE = re.compile(
+    r"^\s*(?:Paper:\s*\".*?\"\s*\n+)?(?:Summarized text to organize into sections:\s*\n+)"
+    r"|</?summary>\s*",
+    re.IGNORECASE,
+)
+
+
+def strip_prompt_scaffold(text: str) -> str:
+    """Remove the organizer prompt's own header/delimiters if the model echoed them."""
+    return _SCAFFOLD_RE.sub("", text or "").strip()
+
+
+_DISPLAY_MATH_RE = re.compile(r"\$\$(.+?)\$\$", re.S)
+_INLINE_MATH_RE = re.compile(r"(?<!\$)\$(?!\$)([^$\n]{2,200}?)\$(?!\$)")
+
+
+def extract_equations(text: str) -> list[Equation]:
+    """Carry the summary's equations through as structured data.
+
+    Sections used to ship equations=[] unconditionally, so the analyzer
+    always saw 'No equations in this section.' and the planner storyboarded
+    from prose alone. Inline spans must contain a TeX command, sub/superscript
+    or operator so currency ('$5 and $10') is not mistaken for math.
+    """
+    equations: list[Equation] = []
+    for m in _DISPLAY_MATH_RE.finditer(text or ""):
+        latex = m.group(1).strip()
+        if latex:
+            equations.append(Equation(latex=latex, is_inline=False))
+    for m in _INLINE_MATH_RE.finditer(text or ""):
+        latex = m.group(1).strip()
+        if re.search(r"\\[A-Za-z]+|[_^=<>]", latex):
+            equations.append(Equation(latex=latex, is_inline=True))
+    return equations
 
 
 def _clean_display_text(text: str) -> str:
@@ -374,7 +426,7 @@ async def format_sections(
             level=1,
             content=cleaned_content,
             summary=cleaned_content,
-            equations=[],
+            equations=extract_equations(cleaned_content),
             figures=[],
             tables=[],
             parent_id=None,

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -96,7 +96,21 @@ async def ingest_paper(params: PipelineInput) -> None:
                 progress=0.30,
             )
             return
-        await _ingest_and_store_paper(db, params.job_id, params.arxiv_id)
+        try:
+            await _ingest_and_store_paper(db, params.job_id, params.arxiv_id)
+        except Exception as exc:
+            # Deterministic ingestion failures (abstract-only source, formatting
+            # failed after its own attempts) must reach the job row verbatim and
+            # must NOT be multiplied by the activity retry policy.
+            from temporalio.exceptions import ApplicationError
+
+            from ingestion.section_formatter import SourceTooShortError
+
+            deterministic = isinstance(exc, SourceTooShortError) or "Section formatting failed" in str(exc)
+            if deterministic:
+                await queries.update_job_status(db, params.job_id, status="failed", error=str(exc))
+                raise ApplicationError(str(exc), non_retryable=True) from exc
+            raise
 
 
 @activity.defn

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,3 +8,36 @@ socket-blocking fixture is tracked in the backlog under Testing & CI.)
 import os
 
 os.environ["LANGFUSE_TRACING_ENABLED"] = "false"
+
+
+def make_fake_http_client(responses: dict):
+    """Factory for a stand-in ``httpx.AsyncClient`` (monkeypatch it onto the
+    module under test). ``responses`` maps URL -> (status, headers) for HEAD
+    and URL -> (status, json) for POST; unknown URLs raise RequestError."""
+    import httpx
+
+    class _Resp:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self.headers = payload if isinstance(payload, dict) and "location" in payload else {}
+            self._json = payload
+
+        def json(self):
+            return self._json
+
+    class _Client:
+        def __init__(self, *a, **k): ...
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+        async def head(self, url):
+            if url not in responses:
+                raise httpx.RequestError(f"no fake for {url}")
+            return _Resp(*responses[url])
+
+        async def post(self, url, **k):
+            if url not in responses:
+                raise httpx.RequestError(f"no fake for {url}")
+            return _Resp(*responses[url])
+
+    return _Client

--- a/backend/tests/test_ingestion_guards.py
+++ b/backend/tests/test_ingestion_guards.py
@@ -10,7 +10,6 @@ on substituted LaTeX.
 
 import asyncio
 
-import httpx
 import pytest
 
 from agents.base import BaseAgent
@@ -18,49 +17,54 @@ from ingestion import arxiv_fetcher, section_formatter
 from ingestion.html_parser import looks_like_latexml_paper
 from ingestion.section_formatter import (
     SUMMARIZE_SYSTEM_PROMPT,
-    extract_equations,
+    SourceTooShortError,
+    _equations_from_summary,
     strip_prompt_scaffold,
 )
+from tests.conftest import make_fake_http_client
 
 ABSTRACT_PAGE = "<html><body><main><h1>Title</h1><blockquote class='abstract'>..</blockquote></main></body></html>"
 LATEXML_PAGE = "<html><body><article class='ltx_document'><section class='ltx_section'>..</section></article></body></html>"
 
 
 class TestHtmlAvailability:
-    def _client(self, responses):
-        """Fake httpx client: url -> (status, headers)."""
-        class Resp:
-            def __init__(self, status, headers):
-                self.status_code, self.headers = status, headers
+    """Redirect shapes pinned to what the real hosts emit: arxiv.org/html
+    answers 200 or 404; ar5iv.labs.arxiv.org/html answers 200 when converted
+    and 307 -> arxiv.org/abs/{id} when not."""
 
-        class Client:
-            def __init__(self, *a, **k): ...
-            async def __aenter__(self): return self
-            async def __aexit__(self, *a): return False
-            async def head(self, url):
-                if url not in responses:
-                    raise httpx.RequestError("boom")
-                return Resp(*responses[url])
-        return Client
-
-    def test_ar5iv_redirect_to_abstract_is_not_html(self, monkeypatch):
-        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
+    def test_unconverted_id_yields_none_not_the_abstract_page(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", make_fake_http_client({
             "https://arxiv.org/html/2608.13717": (404, {}),
-            "https://ar5iv.org/abs/2608.13717": (302, {"location": "https://arxiv.org/abs/2608.13717"}),
+            "https://ar5iv.labs.arxiv.org/html/2608.13717": (307, {"location": "https://arxiv.org/abs/2608.13717"}),
         }))
-        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("2608.13717")) is None
+        assert asyncio.run(arxiv_fetcher.find_latexml_html_url("2608.13717")) is None
 
     def test_arxiv_html_preferred_when_present(self, monkeypatch):
-        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", make_fake_http_client({
             "https://arxiv.org/html/2608.13717": (200, {}),
         }))
-        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("2608.13717")) == "https://arxiv.org/html/2608.13717"
+        assert asyncio.run(arxiv_fetcher.find_latexml_html_url("2608.13717")) == "https://arxiv.org/html/2608.13717"
 
-    def test_redirect_to_versioned_html_is_accepted(self, monkeypatch):
-        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
-            "https://arxiv.org/html/1706.03762": (301, {"location": "https://arxiv.org/html/1706.03762v7"}),
+    def test_ar5iv_labs_fallback_when_converted(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", make_fake_http_client({
+            "https://arxiv.org/html/1706.03762": (404, {}),
+            "https://ar5iv.labs.arxiv.org/html/1706.03762": (200, {}),
         }))
-        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("1706.03762")) == "https://arxiv.org/html/1706.03762v7"
+        assert asyncio.run(arxiv_fetcher.find_latexml_html_url("1706.03762")) == "https://ar5iv.labs.arxiv.org/html/1706.03762"
+
+    def test_relative_redirect_to_versioned_html_is_resolved_and_verified(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", make_fake_http_client({
+            "https://arxiv.org/html/1706.03762": (301, {"location": "/html/1706.03762v7"}),
+            "https://arxiv.org/html/1706.03762v7": (200, {}),
+        }))
+        assert asyncio.run(arxiv_fetcher.find_latexml_html_url("1706.03762")) == "https://arxiv.org/html/1706.03762v7"
+
+    def test_redirect_off_latexml_hosts_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", make_fake_http_client({
+            "https://arxiv.org/html/1.2": (302, {"location": "https://evil.example/html/1.2"}),
+            "https://ar5iv.labs.arxiv.org/html/1.2": (404, {}),
+        }))
+        assert asyncio.run(arxiv_fetcher.find_latexml_html_url("1.2")) is None
 
     def test_body_validation(self):
         assert looks_like_latexml_paper(LATEXML_PAGE)
@@ -71,9 +75,11 @@ class TestSummarizer:
     def test_prompt_is_raw_so_tex_commands_survive(self):
         assert "\\textsc" in SUMMARIZE_SYSTEM_PROMPT
         assert "\t" not in SUMMARIZE_SYSTEM_PROMPT
+        # The raw-string change must not turn the old line-continuation into content.
+        assert SUMMARIZE_SYSTEM_PROMPT.startswith("You are")
 
     def test_short_source_is_refused(self):
-        with pytest.raises(ValueError, match="abstract"):
+        with pytest.raises(SourceTooShortError, match="abstract"):
             asyncio.run(section_formatter._summarize_paper("word " * 120, "T", 120, "gpt-5-mini"))
 
     def test_target_does_not_inflate(self, monkeypatch):
@@ -84,9 +90,9 @@ class TestSummarizer:
             return "summary text"
 
         monkeypatch.setattr(section_formatter, "call_llm", fake_llm)
-        asyncio.run(section_formatter._summarize_paper("w " * 500, "T", 500, "m"))
-        # 35% of 500 = 175, well under the old hard floor of 300
-        assert "~175 words" in captured["system"]
+        asyncio.run(section_formatter._summarize_paper("w " * 400, "T", 400, "m"))
+        # 35% of 400 = 140: no floor of any kind (the old max(300, ...) inflated)
+        assert "~140 words" in captured["system"]
 
 
 class TestOrganizerScaffold:
@@ -96,6 +102,12 @@ class TestOrganizerScaffold:
         assert strip_prompt_scaffold("<summary>\nBody\n</summary>") == "Body"
         assert strip_prompt_scaffold("Plain body") == "Plain body"
 
+    def test_new_header_sentence_stripped_but_inline_tag_kept(self):
+        text = 'Paper: "X"\n\nThe text to organize is between the <summary> tags. The tags and this header are NOT content.\n\nBody here.'
+        assert strip_prompt_scaffold(text) == "Body here."
+        # A <summary> element mentioned in prose (HTML papers) is content.
+        assert strip_prompt_scaffold("We use a <summary> token to mark boundaries.") == "We use a <summary> token to mark boundaries."
+
 
 class TestEquationCarryThrough:
     def test_display_and_inline_math_extracted_currency_ignored(self):
@@ -103,12 +115,17 @@ class TestEquationCarryThrough:
             "Attention is\n$$\n\\mathrm{softmax}(QK^T/\\sqrt{d})V\n$$\nwith $d_k = 64$ heads. "
             "Prices were $5 and $10 per unit."
         )
-        eqs = extract_equations(text)
+        eqs = _equations_from_summary(text)
         latex = [e.latex for e in eqs]
         assert "\\mathrm{softmax}(QK^T/\\sqrt{d})V" in latex
         assert "d_k = 64" in latex
         assert not any("5 and" in item for item in latex)
         assert [e.is_inline for e in eqs] == [False, True]
+
+    def test_money_and_prose_spans_rejected_and_deduped(self):
+        text = "It costs $5 < $10 today. Also $x = y$ and again $x = y$ and $the model then uses the same trick$."
+        latex = [e.latex for e in _equations_from_summary(text)]
+        assert latex == ["x = y"]
 
 
 class TestPromptBraces:

--- a/backend/tests/test_ingestion_guards.py
+++ b/backend/tests/test_ingestion_guards.py
@@ -1,0 +1,119 @@
+"""Ingestion correctness guards (no network).
+
+Reviewer-confirmed defects pinned here: ar5iv redirected unconverted ids to
+the arXiv ABSTRACT page and ~31% of the library was ingested as a 300-word
+inflation of the abstract; the organizer echoed its own prompt header into
+section 1; equations were hard-coded to []; the summarizer prompt was a
+non-raw string whose \\t corrupted its own instructions; brace-unescaping ran
+on substituted LaTeX.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from agents.base import BaseAgent
+from ingestion import arxiv_fetcher, section_formatter
+from ingestion.html_parser import looks_like_latexml_paper
+from ingestion.section_formatter import (
+    SUMMARIZE_SYSTEM_PROMPT,
+    extract_equations,
+    strip_prompt_scaffold,
+)
+
+ABSTRACT_PAGE = "<html><body><main><h1>Title</h1><blockquote class='abstract'>..</blockquote></main></body></html>"
+LATEXML_PAGE = "<html><body><article class='ltx_document'><section class='ltx_section'>..</section></article></body></html>"
+
+
+class TestHtmlAvailability:
+    def _client(self, responses):
+        """Fake httpx client: url -> (status, headers)."""
+        class Resp:
+            def __init__(self, status, headers):
+                self.status_code, self.headers = status, headers
+
+        class Client:
+            def __init__(self, *a, **k): ...
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def head(self, url):
+                if url not in responses:
+                    raise httpx.RequestError("boom")
+                return Resp(*responses[url])
+        return Client
+
+    def test_ar5iv_redirect_to_abstract_is_not_html(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
+            "https://arxiv.org/html/2608.13717": (404, {}),
+            "https://ar5iv.org/abs/2608.13717": (302, {"location": "https://arxiv.org/abs/2608.13717"}),
+        }))
+        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("2608.13717")) is None
+
+    def test_arxiv_html_preferred_when_present(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
+            "https://arxiv.org/html/2608.13717": (200, {}),
+        }))
+        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("2608.13717")) == "https://arxiv.org/html/2608.13717"
+
+    def test_redirect_to_versioned_html_is_accepted(self, monkeypatch):
+        monkeypatch.setattr(arxiv_fetcher.httpx, "AsyncClient", self._client({
+            "https://arxiv.org/html/1706.03762": (301, {"location": "https://arxiv.org/html/1706.03762v7"}),
+        }))
+        assert asyncio.run(arxiv_fetcher.check_ar5iv_available("1706.03762")) == "https://arxiv.org/html/1706.03762v7"
+
+    def test_body_validation(self):
+        assert looks_like_latexml_paper(LATEXML_PAGE)
+        assert not looks_like_latexml_paper(ABSTRACT_PAGE)
+
+
+class TestSummarizer:
+    def test_prompt_is_raw_so_tex_commands_survive(self):
+        assert "\\textsc" in SUMMARIZE_SYSTEM_PROMPT
+        assert "\t" not in SUMMARIZE_SYSTEM_PROMPT
+
+    def test_short_source_is_refused(self):
+        with pytest.raises(ValueError, match="abstract"):
+            asyncio.run(section_formatter._summarize_paper("word " * 120, "T", 120, "gpt-5-mini"))
+
+    def test_target_does_not_inflate(self, monkeypatch):
+        captured = {}
+
+        async def fake_llm(prompt, model, system_prompt, max_tokens):
+            captured["system"] = system_prompt
+            return "summary text"
+
+        monkeypatch.setattr(section_formatter, "call_llm", fake_llm)
+        asyncio.run(section_formatter._summarize_paper("w " * 500, "T", 500, "m"))
+        # 35% of 500 = 175, well under the old hard floor of 300
+        assert "~175 words" in captured["system"]
+
+
+class TestOrganizerScaffold:
+    def test_header_and_delimiters_stripped(self):
+        text = 'Paper: "Cognitive computational neuroscience"\n\nSummarized text to organize into sections:\n\nThe goal is X.'
+        assert strip_prompt_scaffold(text) == "The goal is X."
+        assert strip_prompt_scaffold("<summary>\nBody\n</summary>") == "Body"
+        assert strip_prompt_scaffold("Plain body") == "Plain body"
+
+
+class TestEquationCarryThrough:
+    def test_display_and_inline_math_extracted_currency_ignored(self):
+        text = (
+            "Attention is\n$$\n\\mathrm{softmax}(QK^T/\\sqrt{d})V\n$$\nwith $d_k = 64$ heads. "
+            "Prices were $5 and $10 per unit."
+        )
+        eqs = extract_equations(text)
+        latex = [e.latex for e in eqs]
+        assert "\\mathrm{softmax}(QK^T/\\sqrt{d})V" in latex
+        assert "d_k = 64" in latex
+        assert not any("5 and" in item for item in latex)
+        assert [e.is_inline for e in eqs] == [False, True]
+
+
+class TestPromptBraces:
+    def test_template_escapes_unescaped_but_content_preserved(self, tmp_path, monkeypatch):
+        agent = BaseAgent.__new__(BaseAgent)
+        agent.prompt_template = "Example: {{x}} -> Section: {section}"
+        out = agent._format_prompt(section="\\frac{{a}}{{b}}")
+        assert out == "Example: {x} -> Section: \\frac{{a}}{{b}}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ You give the system an arXiv paper ID. It gives you back narrated, animated expl
 
 ## Ingestion (`backend/ingestion/`)
 
-`ingest_paper(arxiv_id)` fetches metadata from the arXiv API, then parses content — ar5iv HTML when available (clean headings, equations, figure captions), PDF via pymupdf4llm otherwise. Sections are extracted with heading levels and per-section equations/figures/tables, noise sections (references, acknowledgments, etc.) are dropped, and an LLM summarization pass produces per-section summaries. Output is a `StructuredPaper` (Pydantic), persisted to the `papers` and `sections` tables.
+`ingest_paper(arxiv_id)` fetches metadata from the arXiv API, then parses content — LaTeXML HTML when available (probed at `arxiv.org/html`, then `ar5iv.labs.arxiv.org/html`, redirects not followed and bodies must carry `ltx_document`, so an abstract page is never mistaken for the paper) (clean headings, equations, figure captions), PDF via pymupdf4llm otherwise. Sections are extracted with heading levels and per-section equations/figures/tables, noise sections (references, acknowledgments, etc.) are dropped, and an LLM summarization pass produces per-section summaries. Output is a `StructuredPaper` (Pydantic), persisted to the `papers` and `sections` tables.
 
 ## The Agent Pipeline (`backend/agents/pipeline.py`)
 


### PR DESCRIPTION
Step 3a of the reliability plan — the biggest content defect found by the investigation.

**~31% of the library was not the paper.** For ids ar5iv hasn't converted, `check_ar5iv_available` followed the redirect to the arXiv *abstract page*, parsed it as the paper, and the summarizer's `max(300, …)` floor inflated it into a 300-word 'full text' (e.g. 2608.13717: 793-char abstract → 2,408-char 'paper').

- HTML availability: `arxiv.org/html` first, then ar5iv, **redirects not followed** (accepted only toward another `/html/` rendering); fetched bodies must carry LaTeXML markers or the PDF path is used.
- Summarizer refuses sources < 400 words; no inflation floor.
- Formatting retried once, then the job **fails honestly** — raw parser sections are never stored as a page again (2507.15866 shipped header/footnote debris with videos attached).
- `SUMMARIZE_SYSTEM_PROMPT` is now a raw string (its `\textsc`/`\textbf` were literally TAB characters); adds 'no bare TeX in prose' and 'no bare $ currency' rules.
- Organizer input delimited + scaffold stripped (21 papers started with the prompt header).
- Sections carry extracted equations (analyzer always saw 'No equations').
- `_format_prompt` brace-unescape no longer rewrites substituted LaTeX.

10 hermetic tests. Behavior change to note: papers whose summarization fails twice now fail the job instead of shipping raw text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved paper ingestion by prioritizing valid LaTeX-rendered HTML pages, with PDF fallback when needed.
  * Preserved equations as structured content in generated sections.
  * Improved summaries with cleaner formatting, more accurate LaTeX handling, and better treatment of currency values.

* **Bug Fixes**
  * Prevented abstract or landing pages from being processed as full papers.
  * Short or invalid sources now fail clearly instead of producing unreliable results.
  * Formatting failures no longer alter LaTeX content and receive a controlled retry.

* **Tests**
  * Added regression coverage for ingestion, redirects, formatting, summaries, and equation extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->