### PR TITLE
feat: resumable generation, isolated render failures, JSON mode + dedupe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ manim-mcp-server/
 
 # Claude Code local state (agent worktrees, local launch config)
 .claude/
+.playwright-mcp/

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -40,6 +40,12 @@ POST /api/process  (api/routes.py: rate-limit + dedupe [api/throttle.py] + stale
 | 6 | VoiceoverScriptValidator | `agents/voiceover_script_validator.py` | gate: narration quality, heuristics + LLM judge |
 | 7 | RenderTester | `agents/render_tester.py` | gate: dry-run construct() execution in a stubbed subprocess (auto-skipped when `RENDER_MODE=modal`) |
 
+SectionAnalyzer and VisualizationPlanner run in JSON mode (`response_format=json_object`) with a short
+analyst persona (`prompts/system/json_analyst.md`, not the 17KB Manim reference), lenient JSON repair and
+one retry (`BaseAgent._call_llm_json`); candidates are de-duplicated by concept before the cap of 5. On the
+Temporal path each finished visualization is checkpointed (upserted + heartbeat) as it completes; a retried
+generation skips checkpointed concepts, and a paper's prior viz rows are cleared at the start of a run.
+
 Gate failure → regenerate with combined feedback (`MAX_RETRIES=3` + `VOICE_QUALITY_RETRIES=2` attempts); all
 attempts failing → `VOICE_FAIL_BEHAVIOR="return_silent"`. Gates report to the eval harness through the
 `agents.pipeline.metrics_hook` seam (None in production). After rendering, a vision judge samples frames for

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -40,11 +40,15 @@ POST /api/process  (api/routes.py: rate-limit + dedupe [api/throttle.py] + stale
 | 6 | VoiceoverScriptValidator | `agents/voiceover_script_validator.py` | gate: narration quality, heuristics + LLM judge |
 | 7 | RenderTester | `agents/render_tester.py` | gate: dry-run construct() execution in a stubbed subprocess (auto-skipped when `RENDER_MODE=modal`) |
 
-SectionAnalyzer and VisualizationPlanner run in JSON mode (`response_format=json_object`) with a short
-analyst persona (`prompts/system/json_analyst.md`, not the 17KB Manim reference), lenient JSON repair and
-one retry (`BaseAgent._call_llm_json`); candidates are de-duplicated by concept before the cap of 5. On the
-Temporal path each finished visualization is checkpointed (upserted + heartbeat) as it completes; a retried
-generation skips checkpointed concepts, and a paper's prior viz rows are cleared at the start of a run.
+SectionAnalyzer and VisualizationPlanner run in JSON mode on Azure (`response_format=json_object`; the
+Dedalus fallback can only be prompted) with a short analyst persona (`prompts/system/json_analyst.md`, not
+the 17KB Manim reference), lenient JSON repair and one retry (`agents.base.call_llm_json`, shared with the
+ingestion organizer); candidates are de-duplicated by concept before the cap of 5. On the Temporal path each
+finished visualization is checkpointed (upserted + heartbeat, plus a 30s heartbeat timer) as it completes; a
+retried generation resumes from this run's checkpoints (rows created since the job began) and only fills
+the remaining slots. Previous runs' rows are never deleted (feedback references them): `finalize_job`
+marks them `superseded` once the new run produced videos, and superseded rows never reach the API. The
+legacy in-process path (`jobs/worker.py`) still writes rows the old way — no checkpointing or superseding.
 
 Gate failure → regenerate with combined feedback (`MAX_RETRIES=3` + `VOICE_QUALITY_RETRIES=2` attempts); all
 attempts failing → `VOICE_FAIL_BEHAVIOR="return_silent"`. Gates report to the eval harness through the

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -257,6 +257,8 @@ async def call_llm(
             raise
 
     dedalus_model = _dedalus_model(model or DEFAULT_DEDALUS_MODEL)
+    if json_mode:
+        logger.warning("[LLM] json_mode requested but the Dedalus provider cannot enforce it; relying on the prompt")
     logger.info(f"[LLM] Calling {dedalus_model} ({input_words} input words, max_tokens={max_tokens})")
     try:
         runner = _get_dedalus_runner()
@@ -282,6 +284,7 @@ def call_llm_sync(
     system_prompt: str = "",
     max_tokens: int = 4096,
     name: str | None = None,
+    json_mode: bool = False,
 ) -> str:
     """Synchronous LLM call routed through the configured provider."""
     provider = get_provider()
@@ -291,11 +294,13 @@ def call_llm_sync(
         client = _get_azure_sync_client()
         resp = client.chat.completions.create(
             **_with_trace_name(
-                _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens),
+                _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens, json_mode),
                 name,
             )
         )
         return resp.choices[0].message.content or ""
+    if json_mode:
+        logger.warning("[LLM] json_mode requested but the Dedalus provider cannot enforce it; relying on the prompt")
 
     import asyncio
 
@@ -309,15 +314,72 @@ def call_llm_sync(
     return result.final_output or ""
 
 
-_LONE_BACKSLASH_RE = re.compile(r'\\(?!["\\/bfnrtu])')
+# An escaped pair is consumed whole (first alternative) so its second
+# backslash is never mistaken for a lone one — the old lookahead-only pattern
+# turned a correctly escaped \\alpha into \\\alpha and could never salvage a
+# compliant reply that also had a trailing comma. \u counts as an escape only
+# when four hex digits follow.
+_BACKSLASH_RE = re.compile(r'\\\\|\\(?!["\\/bfnrt]|u[0-9a-fA-F]{4})')
 _TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
 
 
 def repair_json_text(text: str) -> str:
-    """Best-effort repair of LLM JSON: escape lone backslashes (LaTeX inside
-    strings: \\alpha -> \\\\alpha) and drop trailing commas."""
-    repaired = _LONE_BACKSLASH_RE.sub(r"\\\\", text)
+    """Best-effort repair of LLM JSON: escape LONE backslashes (LaTeX inside
+    strings: \\alpha -> \\\\alpha; already-escaped pairs untouched) and drop
+    trailing commas. Idempotent on valid JSON."""
+    # Both cases map to an escaped pair: a matched pair stays a pair, a lone
+    # backslash becomes one.
+    repaired = _BACKSLASH_RE.sub("\\\\\\\\", text)
     return _TRAILING_COMMA_RE.sub(r"\1", repaired)
+
+
+_JSON_RETRY_SUFFIX = (
+    "\n\nYour previous reply was not valid JSON. Return ONLY a valid JSON object. "
+    "Escape every backslash inside strings as \\\\ and every double quote as \\\"."
+)
+
+
+def parse_json_response(content: str) -> dict:
+    """JSON from a model reply: fenced or bare, with lenient repair as the
+    last resort. Raises ValueError with the reply head on failure."""
+    candidates = []
+    for pattern in (r"```json\s*([\s\S]*?)\s*```", r"```\s*([\s\S]*?)\s*```"):
+        m = re.search(pattern, content)
+        if m:
+            candidates.append(m.group(1).strip())
+    candidates.append(content.strip())
+    for cand in candidates:
+        for text in (cand, repair_json_text(cand)):
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError(f"Failed to parse JSON from response: {content[:500]}")
+
+
+async def call_llm_json(
+    prompt: str,
+    *,
+    model: str | None = None,
+    system_prompt: str = "",
+    max_tokens: int = 4096,
+    name: str | None = None,
+) -> dict:
+    """JSON-mode call with one repair retry — the single implementation the
+    agents and the ingestion organizer share (two copies had already drifted:
+    one retry suffix forgot the double-quote rule)."""
+    text = await call_llm(prompt, model=model, system_prompt=system_prompt,
+                          max_tokens=max_tokens, name=name, json_mode=True)
+    try:
+        return parse_json_response(text)
+    except ValueError as first:
+        logger.warning("%s returned unparseable JSON; retrying once", name or "llm")
+        text = await call_llm(prompt + _JSON_RETRY_SUFFIX, model=model, system_prompt=system_prompt,
+                              max_tokens=max_tokens, name=name, json_mode=True)
+        try:
+            return parse_json_response(text)
+        except ValueError as second:
+            raise second from first
 
 
 class BaseAgent:
@@ -418,23 +480,16 @@ class BaseAgent:
         ) from last_error
 
     async def _call_llm_json(self, prompt: str, **kwargs: Any) -> dict:
-        """JSON-mode call with one repair retry: a malformed reply used to drop
-        a section's candidates or a planned visualization permanently."""
-        text = await self._call_llm(prompt, json_mode=True, **kwargs)
-        try:
-            return self._parse_json_response(text)
-        except ValueError as first:
-            logger.warning("%s returned unparseable JSON; retrying once", self._trace_name)
-            retry_prompt = (
-                prompt + "\n\nYour previous reply was not valid JSON. Return ONLY a valid JSON "
-                "object. Escape every backslash inside strings as \\\\ and every double "
-                "quote as \\\"."
-            )
-            text = await self._call_llm(retry_prompt, json_mode=True, **kwargs)
-            try:
-                return self._parse_json_response(text)
-            except ValueError as second:
-                raise second from first
+        """JSON-mode call with one repair retry (see module-level call_llm_json):
+        a malformed reply used to drop a section's candidates or a planned
+        visualization permanently."""
+        return await call_llm_json(
+            prompt,
+            model=kwargs.get("model", self.model),
+            system_prompt=kwargs.get("system_prompt") or self.system_prompt,
+            max_tokens=kwargs.get("max_tokens", self.max_tokens),
+            name=self._trace_name,
+        )
 
     def _extract_code_block(self, content: str, language: str = "python") -> str:
         """

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -150,7 +150,7 @@ def _azure_model(model: str | None) -> str:
 
 
 def _azure_request_kwargs(
-    model: str, prompt: str, system_prompt: str, max_tokens: int
+    model: str, prompt: str, system_prompt: str, max_tokens: int, json_mode: bool = False
 ) -> dict:
     messages = []
     if system_prompt:
@@ -161,6 +161,11 @@ def _azure_request_kwargs(
         "messages": messages,
         "max_completion_tokens": max_tokens + _AZURE_REASONING_HEADROOM,
     }
+    if json_mode:
+        # The API then guarantees a parseable JSON object — ~4% of papers lost
+        # a section's candidates and ~6% a planned visualization to unparseable
+        # output (unescaped backslashes, stray quotes) before this.
+        kwargs["response_format"] = {"type": "json_object"}
     # minimal | low | medium | high — low keeps the pipeline fast/cheap
     kwargs["reasoning_effort"] = os.environ.get("AZURE_OPENAI_REASONING_EFFORT", "low")
     return kwargs
@@ -224,6 +229,7 @@ async def call_llm(
     system_prompt: str = "",
     max_tokens: int = 4096,
     name: str | None = None,
+    json_mode: bool = False,
 ) -> str:
     """Async LLM call routed through the configured provider."""
     provider = get_provider()
@@ -237,7 +243,7 @@ async def call_llm(
             client = _get_azure_client()
             resp = await client.chat.completions.create(
                 **_with_trace_name(
-                    _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens),
+                    _azure_request_kwargs(resolved, prompt, system_prompt, max_tokens, json_mode),
                     name,
                 )
             )
@@ -303,6 +309,17 @@ def call_llm_sync(
     return result.final_output or ""
 
 
+_LONE_BACKSLASH_RE = re.compile(r'\\(?!["\\/bfnrtu])')
+_TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
+
+
+def repair_json_text(text: str) -> str:
+    """Best-effort repair of LLM JSON: escape lone backslashes (LaTeX inside
+    strings: \\alpha -> \\\\alpha) and drop trailing commas."""
+    repaired = _LONE_BACKSLASH_RE.sub(r"\\\\", text)
+    return _TRAILING_COMMA_RE.sub(r"\1", repaired)
+
+
 class BaseAgent:
     """
     Base class for all AI agents in the pipeline.
@@ -316,11 +333,14 @@ class BaseAgent:
         prompt_file: str,
         model: str | None = None,
         max_tokens: int = 4096,
+        system_prompt_file: str = "system/manim_reference.md",
     ):
         self._provider = get_provider()
         self.model = get_model_name(model)
         self.max_tokens = max_tokens
-        self.system_prompt = self._load_system_prompt()
+        # Only the code generator needs the 17KB Manim reference; the JSON
+        # agents (analyzer, planner) get a short analyst persona instead.
+        self.system_prompt = self._load_system_prompt(system_prompt_file)
         self.prompt_template = self._load_prompt(prompt_file)
         # Readable Langfuse generation name, e.g. "manim_generator"
         self._trace_name = Path(prompt_file).stem
@@ -338,9 +358,9 @@ class BaseAgent:
         """Get the prompts directory path."""
         return Path(__file__).parent.parent / "prompts"
 
-    def _load_system_prompt(self) -> str:
-        """Load the curated Manim reference as system prompt."""
-        path = self._get_prompts_dir() / "system" / "manim_reference.md"
+    def _load_system_prompt(self, relative: str = "system/manim_reference.md") -> str:
+        """Load a system prompt file from the prompts directory ('' if absent)."""
+        path = self._get_prompts_dir() / relative
         if path.exists():
             return path.read_text()
         return ""
@@ -375,27 +395,46 @@ class BaseAgent:
         """
         Extract and parse JSON from the response.
 
-        Handles both raw JSON and JSON wrapped in markdown code blocks.
+        Handles raw JSON, JSON wrapped in markdown code blocks, and the two
+        LaTeX-induced breakages production actually produces (a lone
+        backslash before a non-escape character, a trailing comma).
         """
-        # Try to extract JSON from markdown code blocks
-        json_patterns = [
-            r"```json\s*([\s\S]*?)\s*```",  # ```json ... ```
-            r"```\s*([\s\S]*?)\s*```",       # ``` ... ```
-        ]
-
-        for pattern in json_patterns:
+        candidates = []
+        for pattern in (r"```json\s*([\s\S]*?)\s*```", r"```\s*([\s\S]*?)\s*```"):
             match = re.search(pattern, content)
             if match:
-                try:
-                    return json.loads(match.group(1).strip())
-                except json.JSONDecodeError:
-                    continue
+                candidates.append(match.group(1).strip())
+        candidates.append(content.strip())
 
-        # Try parsing the whole content as JSON
+        last_error: Exception | None = None
+        for text in candidates:
+            for attempt in (text, repair_json_text(text)):
+                try:
+                    return json.loads(attempt)
+                except json.JSONDecodeError as e:
+                    last_error = e
+        raise ValueError(
+            f"Failed to parse JSON from response: {last_error}\nContent: {content[:500]}"
+        ) from last_error
+
+    async def _call_llm_json(self, prompt: str, **kwargs: Any) -> dict:
+        """JSON-mode call with one repair retry: a malformed reply used to drop
+        a section's candidates or a planned visualization permanently."""
+        text = await self._call_llm(prompt, json_mode=True, **kwargs)
         try:
-            return json.loads(content.strip())
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse JSON from response: {e}\nContent: {content[:500]}") from e
+            return self._parse_json_response(text)
+        except ValueError as first:
+            logger.warning("%s returned unparseable JSON; retrying once", self._trace_name)
+            retry_prompt = (
+                prompt + "\n\nYour previous reply was not valid JSON. Return ONLY a valid JSON "
+                "object. Escape every backslash inside strings as \\\\ and every double "
+                "quote as \\\"."
+            )
+            text = await self._call_llm(retry_prompt, json_mode=True, **kwargs)
+            try:
+                return self._parse_json_response(text)
+            except ValueError as second:
+                raise second from first
 
     def _extract_code_block(self, content: str, language: str = "python") -> str:
         """
@@ -432,6 +471,7 @@ class BaseAgent:
         prompt: str,
         system_prompt: str | None = None,
         max_tokens: int | None = None,
+        json_mode: bool = False,
     ) -> str:
         """Call the LLM via the configured provider (async)."""
         return await call_llm(
@@ -440,6 +480,7 @@ class BaseAgent:
             system_prompt=system_prompt or self.system_prompt,
             max_tokens=max_tokens or self.max_tokens,
             name=self._trace_name,
+            json_mode=json_mode,
         )
 
     def _call_llm_sync(

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -320,17 +320,19 @@ def call_llm_sync(
 # compliant reply that also had a trailing comma. \u counts as an escape only
 # when four hex digits follow.
 _BACKSLASH_RE = re.compile(r'\\\\|\\(?!["\\/bfnrt]|u[0-9a-fA-F]{4})')
-_TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
+# String literals are matched (and kept) by the first alternative so a comma
+# INSIDE a string value ("a, ]") is never mistaken for a trailing comma.
+_STRING_OR_TRAILING_COMMA_RE = re.compile(r'("(?:[^"\\]|\\.)*")|,\s*([}\]])')
 
 
 def repair_json_text(text: str) -> str:
     """Best-effort repair of LLM JSON: escape LONE backslashes (LaTeX inside
     strings: \\alpha -> \\\\alpha; already-escaped pairs untouched) and drop
-    trailing commas. Idempotent on valid JSON."""
+    trailing commas outside string literals. Idempotent on valid JSON."""
     # Both cases map to an escaped pair: a matched pair stays a pair, a lone
     # backslash becomes one.
     repaired = _BACKSLASH_RE.sub("\\\\\\\\", text)
-    return _TRAILING_COMMA_RE.sub(r"\1", repaired)
+    return _STRING_OR_TRAILING_COMMA_RE.sub(lambda m: m.group(1) if m.group(1) is not None else m.group(2), repaired)
 
 
 _JSON_RETRY_SUFFIX = (
@@ -454,30 +456,8 @@ class BaseAgent:
         return result.replace("\x00LB\x00", "{").replace("\x00RB\x00", "}")
 
     def _parse_json_response(self, content: str) -> dict:
-        """
-        Extract and parse JSON from the response.
-
-        Handles raw JSON, JSON wrapped in markdown code blocks, and the two
-        LaTeX-induced breakages production actually produces (a lone
-        backslash before a non-escape character, a trailing comma).
-        """
-        candidates = []
-        for pattern in (r"```json\s*([\s\S]*?)\s*```", r"```\s*([\s\S]*?)\s*```"):
-            match = re.search(pattern, content)
-            if match:
-                candidates.append(match.group(1).strip())
-        candidates.append(content.strip())
-
-        last_error: Exception | None = None
-        for text in candidates:
-            for attempt in (text, repair_json_text(text)):
-                try:
-                    return json.loads(attempt)
-                except json.JSONDecodeError as e:
-                    last_error = e
-        raise ValueError(
-            f"Failed to parse JSON from response: {last_error}\nContent: {content[:500]}"
-        ) from last_error
+        """See module-level parse_json_response (single implementation)."""
+        return parse_json_response(content)
 
     async def _call_llm_json(self, prompt: str, **kwargs: Any) -> dict:
         """JSON-mode call with one repair retry (see module-level call_llm_json):

--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -12,7 +12,7 @@ import os
 import re
 import sys
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 try:
@@ -129,12 +129,76 @@ def _extract_voiceover_metadata(code: str) -> tuple[list[str], list[str]]:
     return [n.strip() for n in narrations if n.strip()], beats
 
 
+_CONCEPT_STOPWORDS = {"the", "and", "for", "with", "via", "from", "into", "over", "vs"}
+
+
+def normalize_concept(name: str) -> str:
+    """Comparable token string for concept names: lowercase, alphanumeric,
+    crude singularization, short/stop words dropped ('Pseudo-labels' and
+    'Pseudo-label', 'Re-alignment' and 'realignment' should agree)."""
+    tokens = re.sub(r"[^a-z0-9]+", " ", (name or "").lower()).split()
+    kept = []
+    for raw in tokens:
+        if len(raw) < 3 or raw in _CONCEPT_STOPWORDS:
+            continue
+        kept.append(raw[:-1] if len(raw) > 3 and raw.endswith("s") else raw)
+    return " ".join(kept)
+
+
+def _dedupe_candidates(candidates: list[VisualizationCandidate]) -> list[VisualizationCandidate]:
+    """Drop near-duplicate concepts, keeping the first (highest priority).
+
+    The <=5 organized sections overlap, so the analyzer proposed the same
+    concept from several of them and a paper got 'Teacher -> Pseudo-label ->
+    Student' animated three times while other concepts never got a slot.
+    """
+    kept: list[VisualizationCandidate] = []
+    seen: list[set[str]] = []
+    for cand in candidates:
+        tokens = set(normalize_concept(cand.concept_name).split())
+        duplicate = False
+        for other in seen:
+            if not tokens or not other:
+                continue
+            if tokens == other or len(tokens & other) / len(tokens | other) >= 0.6:
+                duplicate = True
+                break
+        if duplicate:
+            logger.info("  Skipping near-duplicate concept: %s", cand.concept_name)
+            continue
+        kept.append(cand)
+        seen.append(tokens)
+    return kept
+
+
+VisualizationCallback = Callable[[Visualization], Awaitable[None]]
+
+
+async def _with_callback(
+    coro: Awaitable[Visualization | None], callback: VisualizationCallback | None
+) -> Visualization | None:
+    """Deliver each finished visualization immediately (checkpointing)."""
+    result = await coro
+    if result is not None and callback is not None:
+        await callback(result)
+    return result
+
+
 @observe(name="generate-visualizations", capture_input=False)
 async def generate_visualizations(
     paper: StructuredPaper,
     max_visualizations: int = MAX_VISUALIZATIONS,
+    on_visualization: VisualizationCallback | None = None,
+    skip_concepts: set[str] | None = None,
 ) -> list[Visualization]:
-    """Generate validated visualizations from a structured paper."""
+    """Generate validated visualizations from a structured paper.
+
+    ``on_visualization`` is awaited as soon as each visualization is ready, so
+    a caller can persist it (a worker restart used to lose every finished
+    visualization because rows were written only after ALL candidates
+    finished). ``skip_concepts`` (normalized names) lets a retried run skip
+    concepts it already checkpointed instead of paying for them again.
+    """
     logger.info("Starting visualization generation for paper: %s", paper.meta.title)
     logger.info(
         "Pipeline config: max_viz=%s, spatial=%s, render=%s, voice=%s",
@@ -172,6 +236,11 @@ async def generate_visualizations(
         return []
 
     candidates.sort(key=lambda x: x.priority, reverse=True)
+    candidates = _dedupe_candidates(candidates)
+    if skip_concepts:
+        before = len(candidates)
+        candidates = [c for c in candidates if normalize_concept(c.concept_name) not in skip_concepts]
+        logger.info("Skipping %d already-checkpointed concept(s)", before - len(candidates))
     candidates = candidates[:max_visualizations]
 
     logger.info("Found %s visualization candidates", len(candidates))
@@ -183,15 +252,18 @@ async def generate_visualizations(
 
     if CONCURRENT_GENERATION:
         tasks = [
-            generate_single_visualization(
-                candidate=candidate,
-                paper=paper,
-                planner=planner,
-                generator=generator,
-                validator=validator,
-                spatial_validator=spatial_validator,
-                voiceover_script_validator=voiceover_script_validator,
-                render_tester=render_tester,
+            _with_callback(
+                generate_single_visualization(
+                    candidate=candidate,
+                    paper=paper,
+                    planner=planner,
+                    generator=generator,
+                    validator=validator,
+                    spatial_validator=spatial_validator,
+                    voiceover_script_validator=voiceover_script_validator,
+                    render_tester=render_tester,
+                ),
+                on_visualization,
             )
             for candidate in candidates
         ]
@@ -205,15 +277,18 @@ async def generate_visualizations(
     else:
         visualizations = []
         for candidate in candidates:
-            viz = await generate_single_visualization(
-                candidate=candidate,
-                paper=paper,
-                planner=planner,
-                generator=generator,
-                validator=validator,
-                spatial_validator=spatial_validator,
-                voiceover_script_validator=voiceover_script_validator,
-                render_tester=render_tester,
+            viz = await _with_callback(
+                generate_single_visualization(
+                    candidate=candidate,
+                    paper=paper,
+                    planner=planner,
+                    generator=generator,
+                    validator=validator,
+                    spatial_validator=spatial_validator,
+                    voiceover_script_validator=voiceover_script_validator,
+                    render_tester=render_tester,
+                ),
+                on_visualization,
             )
             if viz is not None:
                 visualizations.append(viz)

--- a/backend/agents/pipeline.py
+++ b/backend/agents/pipeline.py
@@ -145,15 +145,22 @@ def normalize_concept(name: str) -> str:
     return " ".join(kept)
 
 
-def _dedupe_candidates(candidates: list[VisualizationCandidate]) -> list[VisualizationCandidate]:
+def _dedupe_candidates(
+    candidates: list[VisualizationCandidate], already_have: set[str] | None = None
+) -> list[VisualizationCandidate]:
     """Drop near-duplicate concepts, keeping the first (highest priority).
 
     The <=5 organized sections overlap, so the analyzer proposed the same
     concept from several of them and a paper got 'Teacher -> Pseudo-label ->
     Student' animated three times while other concepts never got a slot.
+    ``already_have`` (raw concept names of checkpointed visualizations) seeds
+    the comparison so a retried run doesn't regenerate near-duplicates of
+    what it already has.
     """
     kept: list[VisualizationCandidate] = []
-    seen: list[set[str]] = []
+    seen: list[set[str]] = [
+        set(normalize_concept(n).split()) for n in (already_have or set())
+    ]
     for cand in candidates:
         tokens = set(normalize_concept(cand.concept_name).split())
         duplicate = False
@@ -174,13 +181,21 @@ def _dedupe_candidates(candidates: list[VisualizationCandidate]) -> list[Visuali
 VisualizationCallback = Callable[[Visualization], Awaitable[None]]
 
 
+class CheckpointError(RuntimeError):
+    """The caller's on_visualization callback failed: a finished (paid)
+    visualization could not be persisted. Surfaced, never swallowed."""
+
+
 async def _with_callback(
     coro: Awaitable[Visualization | None], callback: VisualizationCallback | None
 ) -> Visualization | None:
     """Deliver each finished visualization immediately (checkpointing)."""
     result = await coro
     if result is not None and callback is not None:
-        await callback(result)
+        try:
+            await callback(result)
+        except Exception as exc:
+            raise CheckpointError(f"checkpoint failed for {result.concept}: {exc}") from exc
     return result
 
 
@@ -196,8 +211,9 @@ async def generate_visualizations(
     ``on_visualization`` is awaited as soon as each visualization is ready, so
     a caller can persist it (a worker restart used to lose every finished
     visualization because rows were written only after ALL candidates
-    finished). ``skip_concepts`` (normalized names) lets a retried run skip
-    concepts it already checkpointed instead of paying for them again.
+    finished); if it raises, the whole call raises CheckpointError rather than
+    silently dropping paid work. ``skip_concepts`` (raw concept names) lets a
+    retried run skip concepts it already checkpointed instead of paying again.
     """
     logger.info("Starting visualization generation for paper: %s", paper.meta.title)
     logger.info(
@@ -236,11 +252,12 @@ async def generate_visualizations(
         return []
 
     candidates.sort(key=lambda x: x.priority, reverse=True)
-    candidates = _dedupe_candidates(candidates)
+    before = len(candidates)
+    # skip_concepts are RAW names; normalization happens here on both sides,
+    # and the dedupe is seeded with them so near-duplicates are skipped too.
+    candidates = _dedupe_candidates(candidates, already_have=skip_concepts)
     if skip_concepts:
-        before = len(candidates)
-        candidates = [c for c in candidates if normalize_concept(c.concept_name) not in skip_concepts]
-        logger.info("Skipping %d already-checkpointed concept(s)", before - len(candidates))
+        logger.info("Skipped %d checkpointed/duplicate concept(s)", before - len(candidates))
     candidates = candidates[:max_visualizations]
 
     logger.info("Found %s visualization candidates", len(candidates))
@@ -270,6 +287,8 @@ async def generate_visualizations(
         results = await asyncio.gather(*tasks, return_exceptions=True)
         visualizations: list[Visualization] = []
         for result in results:
+            if isinstance(result, CheckpointError):
+                raise result
             if isinstance(result, Exception):
                 logger.error("Visualization generation failed: %s", result)
             elif result is not None:

--- a/backend/agents/section_analyzer.py
+++ b/backend/agents/section_analyzer.py
@@ -28,7 +28,7 @@ class SectionAnalyzer(BaseAgent):
     """
     
     def __init__(self, model: str | None = None):
-        super().__init__("section_analyzer.md", model=model)
+        super().__init__("section_analyzer.md", model=model, system_prompt_file="system/json_analyst.md")
     
     def _format_equations(self, section: Section) -> str:
         """Format equations for the prompt."""
@@ -70,9 +70,7 @@ class SectionAnalyzer(BaseAgent):
             equations=self._format_equations(section),
         )
         
-        text = await self._call_llm(prompt)
-
-        result = self._parse_json_response(text)
+        result = await self._call_llm_json(prompt)
         return self._parse_result(result, section.id)
 
     def _parse_result(self, result: dict, section_id: str) -> AnalyzerOutput:

--- a/backend/agents/visualization_planner.py
+++ b/backend/agents/visualization_planner.py
@@ -36,7 +36,7 @@ class VisualizationPlanner(BaseAgent):
     """
     
     def __init__(self, model: str | None = None):
-        super().__init__("visualization_planner.md", model=model)
+        super().__init__("visualization_planner.md", model=model, system_prompt_file="system/json_analyst.md")
     
     async def run(
         self,
@@ -64,9 +64,7 @@ class VisualizationPlanner(BaseAgent):
             paper_context=paper_context,
         )
         
-        text = await self._call_llm(prompt)
-
-        result = self._parse_json_response(text)
+        result = await self._call_llm_json(prompt)
         return self._parse_result(result, candidate.visualization_type)
 
     def _parse_result(

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -307,11 +307,13 @@ async def get_paper(arxiv_id: str, db: AsyncSession = Depends(get_db)):
         # Convert database models to response schemas
         sections = sorted(paper.sections, key=lambda s: s.order_index)
 
+        # Previous runs' rows are kept for feedback integrity but never shown.
+        visible_viz = [v for v in paper.visualizations if v.status != "superseded"]
         # Build section_id -> video_url lookup from visualizations
         # Prioritize complete videos and take the first complete one for each section
         section_video_map = {}
         section_status_map = {}  # Track status of mapped videos
-        for v in paper.visualizations:
+        for v in visible_viz:
             if v.video_url and v.section_id:
                 existing_status = section_status_map.get(v.section_id)
                 # Only update if:
@@ -353,7 +355,7 @@ async def get_paper(arxiv_id: str, db: AsyncSession = Depends(get_db)):
                     video_url=v.video_url,
                     status=VisualizationStatus(v.status),
                 )
-                for v in paper.visualizations
+                for v in visible_viz
             ],
             processed_at=paper.updated_at or paper.created_at or _utcnow_naive(),
         )

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -377,6 +377,42 @@ def next_viz_index(rows: list[Visualization]) -> int:
     return highest + 1
 
 
+async def insert_visualization_with_next_index(
+    *,
+    paper_suffix: str,
+    paper_id: str,
+    section_id: str | None,
+    concept: str,
+    storyboard: dict | None,
+    manim_code: str | None,
+    session_maker,
+    attempts: int = 5,
+) -> str:
+    """INSERT a checkpoint row under the first unused ``viz_{suffix}_{N}`` id.
+
+    Read-then-insert in its own session, retried on IntegrityError, so two
+    overlapping generation attempts can never write the same id (an upsert
+    would silently overwrite the other attempt's row).
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        async with session_maker() as db:
+            rows = await get_visualizations_for_paper(db, paper_id, include_superseded=True)
+            viz_id = f"viz_{paper_suffix}_{next_viz_index(rows)}"
+            try:
+                await create_visualization(
+                    db, viz_id=viz_id, paper_id=paper_id, section_id=section_id,
+                    concept=concept, status="pending", storyboard=storyboard, manim_code=manim_code,
+                )
+                return viz_id
+            except IntegrityError as exc:
+                last_exc = exc
+                await db.rollback()
+    raise RuntimeError(f"Could not allocate a visualization id for {paper_id}") from last_exc
+
+
 async def supersede_visualizations_before(
     db: AsyncSession, paper_id: str, before: datetime
 ) -> int:

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -343,6 +343,43 @@ async def create_visualization(
     return viz
 
 
+async def get_visualizations_for_paper(db: AsyncSession, paper_id: str) -> list[Visualization]:
+    """All visualization rows for a paper, oldest first."""
+    result = await db.execute(
+        select(Visualization)
+        .where(Visualization.paper_id == paper_id)
+        .order_by(Visualization.created_at.asc(), Visualization.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def delete_visualizations_for_paper(db: AsyncSession, paper_id: str) -> int:
+    """Remove a paper's visualization rows so a new run's rows are the only
+    rows. Upsert-by-id left stale/orphan rows behind (old truncated-id rows
+    from before the viz-id fix, rows pointing at another paper's sections,
+    previous runs' videos shadowing new ones)."""
+    rows = await get_visualizations_for_paper(db, paper_id)
+    for row in rows:
+        await db.delete(row)
+    if rows:
+        await db.commit()
+    return len(rows)
+
+
+async def fail_pending_visualizations(db: AsyncSession, paper_id: str, error: str) -> int:
+    """Mark a paper's still-pending rows failed (a job that died mid-render
+    used to strand them at 'pending' forever, where the gallery counted them
+    as visuals)."""
+    rows = await get_visualizations_for_paper(db, paper_id)
+    stranded = [r for r in rows if r.status in ("pending", "rendering")]
+    for r in stranded:
+        r.status = "failed"
+        r.error = error
+    if stranded:
+        await db.commit()
+    return len(stranded)
+
+
 async def get_visualization(db: AsyncSession, viz_id: str) -> Visualization | None:
     """Get a single visualization by id."""
     result = await db.execute(

--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -4,6 +4,7 @@ Database queries for ArXiviz.
 CRUD operations for papers, sections, visualizations, and processing jobs.
 """
 
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -343,34 +344,62 @@ async def create_visualization(
     return viz
 
 
-async def get_visualizations_for_paper(db: AsyncSession, paper_id: str) -> list[Visualization]:
-    """All visualization rows for a paper, oldest first."""
-    result = await db.execute(
-        select(Visualization)
-        .where(Visualization.paper_id == paper_id)
-        .order_by(Visualization.created_at.asc(), Visualization.id.asc())
-    )
+async def get_visualizations_for_paper(
+    db: AsyncSession,
+    paper_id: str,
+    since: datetime | None = None,
+    include_superseded: bool = False,
+) -> list[Visualization]:
+    """A paper's visualization rows, oldest first.
+
+    ``since`` scopes to rows created by a particular run (a job's created_at);
+    superseded rows — previous runs' rows, hidden once a newer run succeeded —
+    are excluded unless asked for.
+    """
+    stmt = select(Visualization).where(Visualization.paper_id == paper_id)
+    if since is not None:
+        stmt = stmt.where(Visualization.created_at >= since)
+    if not include_superseded:
+        stmt = stmt.where(Visualization.status != "superseded")
+    result = await db.execute(stmt.order_by(Visualization.created_at.asc(), Visualization.id.asc()))
     return list(result.scalars().all())
 
 
-async def delete_visualizations_for_paper(db: AsyncSession, paper_id: str) -> int:
-    """Remove a paper's visualization rows so a new run's rows are the only
-    rows. Upsert-by-id left stale/orphan rows behind (old truncated-id rows
-    from before the viz-id fix, rows pointing at another paper's sections,
-    previous runs' videos shadowing new ones)."""
-    rows = await get_visualizations_for_paper(db, paper_id)
+def next_viz_index(rows: list[Visualization]) -> int:
+    """First unused ``_N`` suffix across ALL of a paper's rows (superseded
+    included): ids are never reused, so feedback votes keep pointing at the
+    video they were cast on."""
+    highest = 0
     for row in rows:
-        await db.delete(row)
-    if rows:
-        await db.commit()
-    return len(rows)
+        m = re.search(r"_(\d+)$", row.id)
+        if m:
+            highest = max(highest, int(m.group(1)))
+    return highest + 1
 
 
-async def fail_pending_visualizations(db: AsyncSession, paper_id: str, error: str) -> int:
-    """Mark a paper's still-pending rows failed (a job that died mid-render
-    used to strand them at 'pending' forever, where the gallery counted them
-    as visuals)."""
+async def supersede_visualizations_before(
+    db: AsyncSession, paper_id: str, before: datetime
+) -> int:
+    """Hide a paper's rows from previous runs once a newer run has produced
+    videos. Rows are NOT deleted: feedback.viz_id references them (a hard
+    delete violated that foreign key and, worse, would have discarded the
+    labeled ground truth the feedback loop exists to collect)."""
     rows = await get_visualizations_for_paper(db, paper_id)
+    older = [r for r in rows if r.created_at is not None and r.created_at < before]
+    for r in older:
+        r.status = "superseded"
+    if older:
+        await db.commit()
+    return len(older)
+
+
+async def fail_pending_visualizations(
+    db: AsyncSession, paper_id: str, error: str, since: datetime | None = None
+) -> int:
+    """Mark still-pending rows failed (a job that died mid-render used to
+    strand them at 'pending' forever, where the gallery counted them as
+    visuals). ``since`` limits it to the failed run's own rows."""
+    rows = await get_visualizations_for_paper(db, paper_id, since=since)
     stranded = [r for r in rows if r.status in ("pending", "rendering")]
     for r in stranded:
         r.status = "failed"

--- a/backend/ingestion/section_formatter.py
+++ b/backend/ingestion/section_formatter.py
@@ -10,11 +10,10 @@ Two-phase LLM pipeline:
 Output populates both .content and .summary on each Section.
 """
 
-import json
 import logging
 import re
 
-from agents.base import call_llm, repair_json_text
+from agents.base import call_llm, call_llm_json
 from models.paper import ArxivPaperMeta, Equation, Section
 
 logger = logging.getLogger(__name__)
@@ -215,34 +214,9 @@ The text to organize is between the <summary> tags. The tags and this header are
     summary_words = len(summary_text.split())
     print(f"[FORMATTER] Phase 2: Organizing {summary_words} words into <={MAX_SECTIONS} sections...")
 
-    parsed = None
-    for attempt in (1, 2):
-        raw_response = await call_llm(
-            prompt=user_prompt if attempt == 1 else (
-                user_prompt + "\n\nYour previous reply was not valid JSON. Return ONLY a valid "
-                "JSON object; escape every backslash inside strings as \\\\."
-            ),
-            model=model,
-            system_prompt=system_prompt,
-            max_tokens=16000,
-            json_mode=True,
-        )
-        raw_response = raw_response.strip()
-        if raw_response.startswith("```"):
-            raw_response = "\n".join(
-                line for line in raw_response.split("\n") if not line.strip().startswith("```")
-            )
-        try:
-            parsed = json.loads(raw_response)
-            break
-        except json.JSONDecodeError:
-            try:
-                parsed = json.loads(repair_json_text(raw_response))
-                break
-            except json.JSONDecodeError as e:
-                logger.warning("Phase 2 JSON parse failed (attempt %d): %s", attempt, e)
-    if parsed is None:
-        raise ValueError("Phase 2 organizer returned unparseable JSON twice")
+    parsed = await call_llm_json(
+        user_prompt, model=model, system_prompt=system_prompt, max_tokens=16000, name="section_organizer"
+    )
     organized_sections = parsed["sections"]
     for sec in organized_sections:
         sec["content"] = strip_prompt_scaffold(sec.get("content", ""))

--- a/backend/ingestion/section_formatter.py
+++ b/backend/ingestion/section_formatter.py
@@ -14,7 +14,7 @@ import json
 import logging
 import re
 
-from agents.base import call_llm
+from agents.base import call_llm, repair_json_text
 from models.paper import ArxivPaperMeta, Equation, Section
 
 logger = logging.getLogger(__name__)
@@ -215,22 +215,34 @@ The text to organize is between the <summary> tags. The tags and this header are
     summary_words = len(summary_text.split())
     print(f"[FORMATTER] Phase 2: Organizing {summary_words} words into <={MAX_SECTIONS} sections...")
 
-    raw_response = await call_llm(
-        prompt=user_prompt,
-        model=model,
-        system_prompt=system_prompt,
-        max_tokens=16000,
-    )
-    raw_response = raw_response.strip()
-
-    # Strip markdown code fences if present
-    if raw_response.startswith("```"):
-        lines = raw_response.split("\n")
-        raw_response = "\n".join(
-            line for line in lines if not line.strip().startswith("```")
+    parsed = None
+    for attempt in (1, 2):
+        raw_response = await call_llm(
+            prompt=user_prompt if attempt == 1 else (
+                user_prompt + "\n\nYour previous reply was not valid JSON. Return ONLY a valid "
+                "JSON object; escape every backslash inside strings as \\\\."
+            ),
+            model=model,
+            system_prompt=system_prompt,
+            max_tokens=16000,
+            json_mode=True,
         )
-
-    parsed = json.loads(raw_response)
+        raw_response = raw_response.strip()
+        if raw_response.startswith("```"):
+            raw_response = "\n".join(
+                line for line in raw_response.split("\n") if not line.strip().startswith("```")
+            )
+        try:
+            parsed = json.loads(raw_response)
+            break
+        except json.JSONDecodeError:
+            try:
+                parsed = json.loads(repair_json_text(raw_response))
+                break
+            except json.JSONDecodeError as e:
+                logger.warning("Phase 2 JSON parse failed (attempt %d): %s", attempt, e)
+    if parsed is None:
+        raise ValueError("Phase 2 organizer returned unparseable JSON twice")
     organized_sections = parsed["sections"]
     for sec in organized_sections:
         sec["content"] = strip_prompt_scaffold(sec.get("content", ""))

--- a/backend/prompts/system/json_analyst.md
+++ b/backend/prompts/system/json_analyst.md
@@ -1,0 +1,6 @@
+You are a precise research analyst. You read sections of academic papers and answer with a single JSON object that exactly matches the schema requested in the user message.
+
+Rules:
+- Output ONLY the JSON object — no prose, no markdown fences.
+- Inside JSON strings, escape every backslash (write \\alpha for \alpha) and every double quote.
+- Never invent content that is not supported by the section text.

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -127,7 +127,9 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
     The returned list is checkpointed in workflow history (~8KB of Manim code
     per viz, well under Temporal's payload limits).
     """
-    from agents.pipeline import generate_visualizations, normalize_concept
+    import asyncio
+
+    from agents.pipeline import MAX_VISUALIZATIONS, generate_visualizations
     from db import queries
     from db.connection import async_session_maker
     from jobs.worker import _build_structured_paper_from_db
@@ -152,13 +154,18 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
             current_step="Analyzing concepts for visualization",
             progress=0.50,
         )
-        if attempt == 1:
-            # A run's rows are the only rows: clears stale previous-run and
-            # orphan rows that shadowed new videos in the gallery and reader.
-            removed = await queries.delete_visualizations_for_paper(db, params.arxiv_id)
-            if removed:
-                logger.info("Cleared %d prior visualization row(s) for %s", removed, params.arxiv_id)
-        existing = [r for r in await queries.get_visualizations_for_paper(db, params.arxiv_id) if r.manim_code]
+        job = await queries.get_job(db, params.job_id)
+        run_started = job.created_at if job else None
+        # This run's checkpoints only (rows created since the job began): a
+        # retried attempt resumes from them. Previous runs' rows stay visible
+        # to readers until finalize_job supersedes them — a re-run no longer
+        # blanks an already-visualized paper for 10-25 minutes.
+        existing = [
+            r for r in await queries.get_visualizations_for_paper(db, params.arxiv_id, since=run_started)
+            if r.manim_code
+        ]
+        all_rows = await queries.get_visualizations_for_paper(db, params.arxiv_id, include_superseded=True)
+        counter = queries.next_viz_index(all_rows) - 1
         db_paper = await queries.get_paper(db, params.arxiv_id)
         db_sections = sorted(db_paper.sections, key=lambda s: s.order_index)
         structured_paper = _build_structured_paper_from_db(db_paper, db_sections)
@@ -168,7 +175,7 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
     ]
     if existing:
         logger.info("Attempt %d: resuming with %d checkpointed visualization(s)", attempt, len(existing))
-    counter = len(existing)
+    remaining = max(0, MAX_VISUALIZATIONS - len(existing))
 
     async def checkpoint(viz) -> None:
         nonlocal counter
@@ -186,19 +193,35 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
                 status="pending",
             )
         render_inputs.append(RenderInput(job_id=params.job_id, viz_id=viz_id, manim_code=viz.manim_code))
-        activity.heartbeat(f"{counter} visualization(s) checkpointed")
+        activity.heartbeat(f"{len(render_inputs)} visualization(s) checkpointed")
 
-    with propagate_attributes(
-        session_id=params.job_id,
-        trace_name="process-paper",
-        tags=["pipeline", "temporal"],
-        metadata={"arxiv_id": params.arxiv_id},
-    ):
-        await generate_visualizations(
-            structured_paper,
-            on_visualization=checkpoint,
-            skip_concepts={normalize_concept(r.concept) for r in existing},
-        )
+    async def heartbeat_loop() -> None:
+        # A heartbeat only on checkpoints let a live-but-slow worker exceed the
+        # heartbeat timeout before its first viz finished, spawning a second
+        # attempt that double-spent and collided on ids. Beat on a timer.
+        while True:
+            await asyncio.sleep(30)
+            activity.heartbeat(f"{len(render_inputs)} visualization(s) checkpointed")
+
+    if remaining == 0:
+        logger.info("All %d visualization slots already checkpointed; skipping generation", len(existing))
+    else:
+        beat = asyncio.create_task(heartbeat_loop())
+        try:
+            with propagate_attributes(
+                session_id=params.job_id,
+                trace_name="process-paper",
+                tags=["pipeline", "temporal"],
+                metadata={"arxiv_id": params.arxiv_id},
+            ):
+                await generate_visualizations(
+                    structured_paper,
+                    max_visualizations=remaining,
+                    on_visualization=checkpoint,
+                    skip_concepts={r.concept for r in existing},
+                )
+        finally:
+            beat.cancel()
 
     if render_inputs:
         async with async_session_maker() as db:
@@ -410,6 +433,13 @@ async def finalize_job(params: ProgressUpdate) -> None:
             progress=1.0,
             error=error,
         )
+        # Only a run that actually produced videos retires the previous run's
+        # rows; a failed re-run leaves the old videos serving.
+        job = await queries.get_job(db, params.job_id)
+        if params.completed > 0 and job and job.paper_id and job.created_at:
+            retired = await queries.supersede_visualizations_before(db, job.paper_id, job.created_at)
+            if retired:
+                logger.info("Superseded %d previous-run visualization(s) for %s", retired, job.paper_id)
 
 
 @activity.defn
@@ -441,8 +471,11 @@ async def mark_job_failed(params: PipelineInput) -> None:
         )
         # Rows the dead run never got to render would otherwise sit at
         # 'pending' forever and count as visuals in the gallery.
+        job = await queries.get_job(db, params.job_id)
         stranded = await queries.fail_pending_visualizations(
-            db, params.arxiv_id, error="Pipeline failed before this visualization rendered."
+            db, params.arxiv_id,
+            error="Pipeline failed before this visualization rendered.",
+            since=job.created_at if job else None,
         )
         if stranded:
             logger.info("Marked %d stranded visualization(s) failed for %s", stranded, params.arxiv_id)

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -16,6 +16,7 @@ so only the interrupted render re-runs.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from dataclasses import dataclass
 
@@ -164,8 +165,6 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
             r for r in await queries.get_visualizations_for_paper(db, params.arxiv_id, since=run_started)
             if r.manim_code
         ]
-        all_rows = await queries.get_visualizations_for_paper(db, params.arxiv_id, include_superseded=True)
-        counter = queries.next_viz_index(all_rows) - 1
         db_paper = await queries.get_paper(db, params.arxiv_id)
         db_sections = sorted(db_paper.sections, key=lambda s: s.order_index)
         structured_paper = _build_structured_paper_from_db(db_paper, db_sections)
@@ -178,20 +177,19 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
     remaining = max(0, MAX_VISUALIZATIONS - len(existing))
 
     async def checkpoint(viz) -> None:
-        nonlocal counter
-        counter += 1
-        viz_id = f"viz_{paper_suffix}_{counter}"
-        async with async_session_maker() as db:
-            await queries.upsert_visualization(
-                db,
-                viz_id=viz_id,
-                paper_id=params.arxiv_id,
-                section_id=viz.section_id,
-                concept=viz.concept,
-                storyboard={"raw": viz.storyboard},
-                manim_code=viz.manim_code,
-                status="pending",
-            )
+        # The id is minted from the table at write time and INSERTed (never
+        # upserted): if a second attempt ever overlaps the first — the 40-min
+        # start-to-close timeout can fire while attempt 1 is still running —
+        # neither can overwrite the other's row.
+        viz_id = await queries.insert_visualization_with_next_index(
+            paper_suffix=paper_suffix,
+            paper_id=params.arxiv_id,
+            section_id=viz.section_id,
+            concept=viz.concept,
+            storyboard={"raw": viz.storyboard},
+            manim_code=viz.manim_code,
+            session_maker=async_session_maker,
+        )
         render_inputs.append(RenderInput(job_id=params.job_id, viz_id=viz_id, manim_code=viz.manim_code))
         activity.heartbeat(f"{len(render_inputs)} visualization(s) checkpointed")
 
@@ -222,6 +220,8 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
                 )
         finally:
             beat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await beat
 
     if render_inputs:
         async with async_session_maker() as db:
@@ -436,10 +436,20 @@ async def finalize_job(params: ProgressUpdate) -> None:
         # Only a run that actually produced videos retires the previous run's
         # rows; a failed re-run leaves the old videos serving.
         job = await queries.get_job(db, params.job_id)
-        if params.completed > 0 and job and job.paper_id and job.created_at:
-            retired = await queries.supersede_visualizations_before(db, job.paper_id, job.created_at)
-            if retired:
-                logger.info("Superseded %d previous-run visualization(s) for %s", retired, job.paper_id)
+        if job and job.paper_id and job.created_at:
+            # Every render input has written a terminal status by now; a row
+            # still pending is one whose failure recorder itself failed.
+            leftover = await queries.fail_pending_visualizations(
+                db, job.paper_id,
+                error="Render did not complete before the job finished.",
+                since=job.created_at,
+            )
+            if leftover:
+                logger.warning("Failed %d leftover pending visualization(s) for %s", leftover, job.paper_id)
+            if params.completed > 0:
+                retired = await queries.supersede_visualizations_before(db, job.paper_id, job.created_at)
+                if retired:
+                    logger.info("Superseded %d previous-run visualization(s) for %s", retired, job.paper_id)
 
 
 @activity.defn

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -115,13 +115,19 @@ async def ingest_paper(params: PipelineInput) -> None:
 
 @activity.defn
 async def generate_visualizations_for_paper(params: PipelineInput) -> list[RenderInput]:
-    """Run the agent pipeline; upsert viz records; return render inputs.
+    """Run the agent pipeline; upsert viz rows; return render inputs.
+
+    Checkpointed per visualization: each finished viz is upserted (and the
+    activity heartbeats) the moment it is ready. Before this, rows were
+    written only after ALL candidates finished, so a worker restart
+    mid-generation lost every finished visualization and left '0 visuals'.
+    On a retry attempt the already-checkpointed concepts are skipped, so a
+    restart costs the unfinished work only — never a second full generation.
 
     The returned list is checkpointed in workflow history (~8KB of Manim code
-    per viz, well under Temporal's payload limits) — this is what makes
-    resume-without-re-paying-generation possible.
+    per viz, well under Temporal's payload limits).
     """
-    from agents.pipeline import generate_visualizations
+    from agents.pipeline import generate_visualizations, normalize_concept
     from db import queries
     from db.connection import async_session_maker
     from jobs.worker import _build_structured_paper_from_db
@@ -134,32 +140,41 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
         def propagate_attributes(**_kw):  # type: ignore
             return nullcontext()
 
+    # Full sanitized arXiv id — a truncated prefix collided across sibling
+    # ids (e.g. 2608.23551 vs 2608.23553 both mapped to "26082355"), making
+    # papers overwrite each other's visualization rows via upsert.
+    paper_suffix = params.arxiv_id.replace(".", "_").replace("/", "_")
+    attempt = activity.info().attempt
+
     async with async_session_maker() as db:
         await queries.update_job_status(
             db, params.job_id,
             current_step="Analyzing concepts for visualization",
             progress=0.50,
         )
+        if attempt == 1:
+            # A run's rows are the only rows: clears stale previous-run and
+            # orphan rows that shadowed new videos in the gallery and reader.
+            removed = await queries.delete_visualizations_for_paper(db, params.arxiv_id)
+            if removed:
+                logger.info("Cleared %d prior visualization row(s) for %s", removed, params.arxiv_id)
+        existing = [r for r in await queries.get_visualizations_for_paper(db, params.arxiv_id) if r.manim_code]
         db_paper = await queries.get_paper(db, params.arxiv_id)
         db_sections = sorted(db_paper.sections, key=lambda s: s.order_index)
         structured_paper = _build_structured_paper_from_db(db_paper, db_sections)
 
-    with propagate_attributes(
-        session_id=params.job_id,
-        trace_name="process-paper",
-        tags=["pipeline", "temporal"],
-        metadata={"arxiv_id": params.arxiv_id},
-    ):
-        generated = await generate_visualizations(structured_paper)
+    render_inputs: list[RenderInput] = [
+        RenderInput(job_id=params.job_id, viz_id=r.id, manim_code=r.manim_code) for r in existing
+    ]
+    if existing:
+        logger.info("Attempt %d: resuming with %d checkpointed visualization(s)", attempt, len(existing))
+    counter = len(existing)
 
-    render_inputs: list[RenderInput] = []
-    # Full sanitized arXiv id — a truncated prefix collided across sibling
-    # ids (e.g. 2608.23551 vs 2608.23553 both mapped to "26082355"), making
-    # papers overwrite each other's visualization rows via upsert.
-    paper_suffix = params.arxiv_id.replace(".", "_").replace("/", "_")
-    async with async_session_maker() as db:
-        for i, viz in enumerate(generated):
-            viz_id = f"viz_{paper_suffix}_{i + 1}"
+    async def checkpoint(viz) -> None:
+        nonlocal counter
+        counter += 1
+        viz_id = f"viz_{paper_suffix}_{counter}"
+        async with async_session_maker() as db:
             await queries.upsert_visualization(
                 db,
                 viz_id=viz_id,
@@ -170,10 +185,23 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
                 manim_code=viz.manim_code,
                 status="pending",
             )
-            render_inputs.append(
-                RenderInput(job_id=params.job_id, viz_id=viz_id, manim_code=viz.manim_code)
-            )
-        if render_inputs:
+        render_inputs.append(RenderInput(job_id=params.job_id, viz_id=viz_id, manim_code=viz.manim_code))
+        activity.heartbeat(f"{counter} visualization(s) checkpointed")
+
+    with propagate_attributes(
+        session_id=params.job_id,
+        trace_name="process-paper",
+        tags=["pipeline", "temporal"],
+        metadata={"arxiv_id": params.arxiv_id},
+    ):
+        await generate_visualizations(
+            structured_paper,
+            on_visualization=checkpoint,
+            skip_concepts={normalize_concept(r.concept) for r in existing},
+        )
+
+    if render_inputs:
+        async with async_session_maker() as db:
             await queries.update_job_status(
                 db, params.job_id,
                 current_step="Rendering videos",
@@ -385,6 +413,21 @@ async def finalize_job(params: ProgressUpdate) -> None:
 
 
 @activity.defn
+async def record_render_failure(params: RenderInput) -> None:
+    """A render activity that failed at the Temporal level (timeout, worker
+    death after retries) never ran the status write inside
+    render_visualization — record it so the row doesn't strand at pending."""
+    from db import queries
+    from db.connection import async_session_maker
+
+    async with async_session_maker() as db:
+        await queries.update_visualization_status(
+            db, params.viz_id, status="failed",
+            error="Render did not complete (worker interrupted or timed out).",
+        )
+
+
+@activity.defn
 async def mark_job_failed(params: PipelineInput) -> None:
     """Terminal failure marker for unrecoverable workflow errors."""
     from db import queries
@@ -396,3 +439,10 @@ async def mark_job_failed(params: PipelineInput) -> None:
             status="failed",
             error="Pipeline failed after retries. See worker logs for details.",
         )
+        # Rows the dead run never got to render would otherwise sit at
+        # 'pending' forever and count as visuals in the gallery.
+        stranded = await queries.fail_pending_visualizations(
+            db, params.arxiv_id, error="Pipeline failed before this visualization rendered."
+        )
+        if stranded:
+            logger.info("Marked %d stranded visualization(s) failed for %s", stranded, params.arxiv_id)

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -35,11 +35,26 @@ from temporal_app.activities import (
     generate_visualizations_for_paper,
     ingest_paper,
     mark_job_failed,
+    record_render_failure,
     render_visualization,
     repair_visualization_code,
     update_render_progress,
 )
 from temporal_app.workflows import RENDER_TASK_QUEUE, TASK_QUEUE, PaperPipelineWorkflow
+
+# Module-level so a test can assert every activity the workflow references is
+# registered: an activity invoked but not registered fails with NotFoundError
+# at runtime, and once that sank whole jobs in the render-failure fallback.
+PIPELINE_ACTIVITIES = [
+    ingest_paper,
+    generate_visualizations_for_paper,
+    update_render_progress,
+    finalize_job,
+    mark_job_failed,
+    repair_visualization_code,
+    record_render_failure,
+]
+RENDER_ACTIVITIES = [render_visualization]
 
 logging.basicConfig(
     level=logging.INFO,
@@ -72,20 +87,13 @@ async def main() -> None:
         client,
         task_queue=TASK_QUEUE,
         workflows=[PaperPipelineWorkflow],
-        activities=[
-            ingest_paper,
-            generate_visualizations_for_paper,
-            update_render_progress,
-            finalize_job,
-            mark_job_failed,
-            repair_visualization_code,
-        ],
+        activities=PIPELINE_ACTIVITIES,
         max_concurrent_activities=pipeline_concurrency,
     )
     render_worker = Worker(
         client,
         task_queue=RENDER_TASK_QUEUE,
-        activities=[render_visualization],
+        activities=RENDER_ACTIVITIES,
         max_concurrent_activities=render_concurrency,
     )
 

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -53,13 +53,14 @@ RENDER_TASK_QUEUE = "paper-render"
 
 # Transient infra faults (network, DB hiccup) get one automatic retry.
 _INFRA_RETRY = RetryPolicy(maximum_attempts=2)
-# Generation is real money (~$0.07/paper of LLM spend) — never auto-retry.
+# A repair (or a repair re-render) is a single paid LLM/render step whose
+# failure keeps the original video — never worth a second attempt.
 _NO_RETRY = RetryPolicy(maximum_attempts=1)
-# Generation retries once, but only a worker death can trigger it: the
-# activity swallows per-candidate errors itself, and heartbeats every
-# checkpointed visualization so a dead worker is noticed within the heartbeat
-# timeout. The retry skips checkpointed concepts, so it costs the unfinished
-# work only.
+# Generation retries once, and only a dead worker can trigger it: the
+# activity swallows per-candidate errors itself and heartbeats on a 30s timer
+# (not just per finished viz), so a heartbeat timeout genuinely means the
+# worker died. The retry skips this run's checkpointed concepts, so it costs
+# the unfinished work only.
 _GENERATION_RETRY = RetryPolicy(maximum_attempts=2)
 
 
@@ -158,12 +159,17 @@ class PaperPipelineWorkflow:
             )
         except Exception as exc:
             workflow.logger.warning("Render activity failed for %s: %s", ri.viz_id, exc)
-            await workflow.execute_activity(
-                record_render_failure,
-                ri,
-                start_to_close_timeout=timedelta(minutes=1),
-                retry_policy=_INFRA_RETRY,
-            )
+            # Best effort: the recorder keeps the row from stranding at
+            # 'pending', but a recorder failure must never abort the job.
+            try:
+                await workflow.execute_activity(
+                    record_render_failure,
+                    ri,
+                    start_to_close_timeout=timedelta(minutes=1),
+                    retry_policy=_INFRA_RETRY,
+                )
+            except Exception as rec_exc:
+                workflow.logger.warning("Could not record render failure for %s: %s", ri.viz_id, rec_exc)
             return RenderResult(viz_id=ri.viz_id, succeeded=False)
 
     async def _repair_one(self, job_id: str, result: RenderResult, code: str) -> bool:

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -11,8 +11,10 @@ actually had, not to technology enthusiasm):
   impossible at the orchestrator (the API's in-memory/DB dedupe remains as a
   cheap first line, but this is the guarantee).
 - Per-activity retry policies: transient render failures (LaTeX/CPU
-  contention) retry once automatically; generation never auto-retries, because
-  a retry doubles real LLM spend and deserves a deliberate decision.
+  contention) retry once automatically; generation retries only for a dead
+  worker (heartbeat timeout) and resumes from per-visualization checkpoints,
+  so a retry never pays for finished work twice. A single failed render is a
+  failed visualization, not a failed job.
 - Orchestration state (completion counters) lives in the workflow, not in
   shared mutable state between concurrent tasks — progress writes are issued
   by the workflow as render results arrive.
@@ -40,6 +42,7 @@ with workflow.unsafe.imports_passed_through():
         generate_visualizations_for_paper,
         ingest_paper,
         mark_job_failed,
+        record_render_failure,
         render_visualization,
         repair_visualization_code,
         update_render_progress,
@@ -52,6 +55,12 @@ RENDER_TASK_QUEUE = "paper-render"
 _INFRA_RETRY = RetryPolicy(maximum_attempts=2)
 # Generation is real money (~$0.07/paper of LLM spend) — never auto-retry.
 _NO_RETRY = RetryPolicy(maximum_attempts=1)
+# Generation retries once, but only a worker death can trigger it: the
+# activity swallows per-candidate errors itself, and heartbeats every
+# checkpointed visualization so a dead worker is noticed within the heartbeat
+# timeout. The retry skips checkpointed concepts, so it costs the unfinished
+# work only.
+_GENERATION_RETRY = RetryPolicy(maximum_attempts=2)
 
 
 @workflow.defn
@@ -76,7 +85,8 @@ class PaperPipelineWorkflow:
                 generate_visualizations_for_paper,
                 params,
                 start_to_close_timeout=timedelta(minutes=40),
-                retry_policy=_NO_RETRY,
+                heartbeat_timeout=timedelta(minutes=8),
+                retry_policy=_GENERATION_RETRY,
             )
 
             total = len(render_inputs)
@@ -86,16 +96,11 @@ class PaperPipelineWorkflow:
 
             # Start all renders; the render worker's concurrency cap does the
             # throttling (Temporal queues the surplus — no semaphore needed).
-            render_tasks = [
-                workflow.execute_activity(
-                    render_visualization,
-                    ri,
-                    task_queue=RENDER_TASK_QUEUE,
-                    start_to_close_timeout=timedelta(minutes=15),
-                    retry_policy=_INFRA_RETRY,
-                )
-                for ri in render_inputs
-            ]
+            # Each render is wrapped so ONE failed activity (timeout, worker
+            # death past its retry) becomes a failed RenderResult instead of
+            # aborting the workflow — which used to fail the whole job and
+            # strand every unfinished visualization at 'pending'.
+            render_tasks = [self._render_one(ri) for ri in render_inputs]
 
             succeeded = 0
             results: list[RenderResult] = []
@@ -141,6 +146,25 @@ class PaperPipelineWorkflow:
                 retry_policy=_INFRA_RETRY,
             )
             raise
+
+    async def _render_one(self, ri: RenderInput) -> RenderResult:
+        try:
+            return await workflow.execute_activity(
+                render_visualization,
+                ri,
+                task_queue=RENDER_TASK_QUEUE,
+                start_to_close_timeout=timedelta(minutes=15),
+                retry_policy=_INFRA_RETRY,
+            )
+        except Exception as exc:
+            workflow.logger.warning("Render activity failed for %s: %s", ri.viz_id, exc)
+            await workflow.execute_activity(
+                record_render_failure,
+                ri,
+                start_to_close_timeout=timedelta(minutes=1),
+                retry_policy=_INFRA_RETRY,
+            )
+            return RenderResult(viz_id=ri.viz_id, succeeded=False)
 
     async def _repair_one(self, job_id: str, result: RenderResult, code: str) -> bool:
         """Repair one defective visualization; returns True if the re-render

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -56,11 +56,11 @@ _INFRA_RETRY = RetryPolicy(maximum_attempts=2)
 # A repair (or a repair re-render) is a single paid LLM/render step whose
 # failure keeps the original video — never worth a second attempt.
 _NO_RETRY = RetryPolicy(maximum_attempts=1)
-# Generation retries once, and only a dead worker can trigger it: the
-# activity swallows per-candidate errors itself and heartbeats on a 30s timer
-# (not just per finished viz), so a heartbeat timeout genuinely means the
-# worker died. The retry skips this run's checkpointed concepts, so it costs
-# the unfinished work only.
+# Generation retries once. A heartbeat timeout (dead worker) or the 40-min
+# start-to-close timeout can trigger it; in the latter case attempt 1 may
+# still be running, which is why checkpoint ids are INSERTed under a freshly
+# read index (no overwrite possible) and why the retry only fills the slots
+# this run has not checkpointed — it never pays for finished work twice.
 _GENERATION_RETRY = RetryPolicy(maximum_attempts=2)
 
 

--- a/backend/tests/test_generation_robustness.py
+++ b/backend/tests/test_generation_robustness.py
@@ -44,6 +44,14 @@ class TestJsonRepair:
         assert repair_json_text(valid) == valid
         assert json.loads(repair_json_text(valid)) == json.loads(valid)
 
+    def test_commas_inside_strings_survive_repair(self):
+        # Reviewer repro: the trailing-comma strip was not string-aware and
+        # deleted the comma in "a, ]" — corrupting concept text.
+        raw = '{"c": "x, ]", "d": "y, }", "items": [1,],}'
+        assert parse_json_response(raw) == {"c": "x, ]", "d": "y, }", "items": [1]}
+        valid = '{"c": "x, ]"}'
+        assert repair_json_text(valid) == valid
+
     def test_bogus_unicode_escape_is_repaired(self):
         # \u not followed by 4 hex digits is a lone backslash, not an escape.
         assert json.loads(repair_json_text('{"c": "\\underline"}')) == {"c": "\\underline"}
@@ -247,3 +255,21 @@ def test_every_workflow_activity_is_registered_on_a_worker():
     assert referenced, "no activities detected in workflows.py — test is broken"
     missing = referenced - registered
     assert not missing, f"activities invoked by the workflow but not registered: {missing}"
+
+
+async def test_checkpoint_ids_are_minted_at_write_time_and_never_collide(db):
+    await _seed(db)  # rows _1 and _2 (new format) + an old-format row
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    maker = async_sessionmaker(db.bind, expire_on_commit=False)
+    a = await queries.insert_visualization_with_next_index(
+        paper_suffix="1706_03762", paper_id="1706.03762", section_id="s", concept="c1",
+        storyboard=None, manim_code="code", session_maker=maker,
+    )
+    b = await queries.insert_visualization_with_next_index(
+        paper_suffix="1706_03762", paper_id="1706.03762", section_id="s", concept="c2",
+        storyboard=None, manim_code="code", session_maker=maker,
+    )
+    assert (a, b) == ("viz_1706_03762_3", "viz_1706_03762_4")
+    rows = await queries.get_visualizations_for_paper(db, "1706.03762", include_superseded=True)
+    assert {r.id for r in rows} >= {"viz_1706_03762_3", "viz_1706_03762_4"}

--- a/backend/tests/test_generation_robustness.py
+++ b/backend/tests/test_generation_robustness.py
@@ -8,16 +8,19 @@ every finished visualization; rows stranded at 'pending' counted as visuals.
 """
 
 import asyncio
+import json
 from datetime import datetime
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+import agents.base as base
 import agents.pipeline as pipeline
-from agents.base import BaseAgent, repair_json_text
+from agents.base import BaseAgent, call_llm_json, parse_json_response, repair_json_text
 from db import queries
-from db.models import Base, Paper, Visualization
+from db.models import Base, Feedback, Paper, Visualization
 from models.generation import Visualization as VizModel
 from models.generation import VisualizationCandidate, VisualizationStatus, VisualizationType
 
@@ -26,43 +29,64 @@ from models.generation import VisualizationCandidate, VisualizationStatus, Visua
 class TestJsonRepair:
     def test_lone_backslashes_and_trailing_commas(self):
         raw = '{"concept": "uses \\alpha and \\mathcal{X}", "items": [1, 2,],}'
-        agent = BaseAgent.__new__(BaseAgent)
-        out = agent._parse_json_response(raw)
+        out = parse_json_response(raw)
         assert out["concept"] == "uses \\alpha and \\mathcal{X}"
         assert out["items"] == [1, 2]
+
+    def test_escaped_pairs_survive_repair(self):
+        # Reviewer repro: a correctly escaped \\alpha plus a trailing comma was
+        # turned into \\\\alpha (invalid) by the old lookahead-only regex.
+        raw = '{"c": "\\\\alpha", "items": [1,],}'
+        assert parse_json_response(raw) == {"c": "\\alpha", "items": [1]}
+
+    def test_repair_is_idempotent_on_valid_json(self):
+        valid = '{"c": "\\\\alpha \\u00e9 \\n"}'
+        assert repair_json_text(valid) == valid
+        assert json.loads(repair_json_text(valid)) == json.loads(valid)
+
+    def test_bogus_unicode_escape_is_repaired(self):
+        # \u not followed by 4 hex digits is a lone backslash, not an escape.
+        assert json.loads(repair_json_text('{"c": "\\underline"}')) == {"c": "\\underline"}
 
     def test_valid_escapes_untouched(self):
         assert repair_json_text('{"a": "line\\nbreak \\"q\\""}') == '{"a": "line\\nbreak \\"q\\""}'
 
     def test_fenced_json_still_parses(self):
-        agent = BaseAgent.__new__(BaseAgent)
-        assert agent._parse_json_response('```json\n{"x": 1}\n```') == {"x": 1}
+        assert parse_json_response('```json\n{"x": 1}\n```') == {"x": 1}
 
     def test_call_llm_json_retries_once(self, monkeypatch):
-        agent = BaseAgent.__new__(BaseAgent)
-        agent._trace_name = "t"
         replies = iter(["not json at all", '{"ok": true}'])
-        seen_prompts = []
+        seen = []
 
-        async def fake_call(prompt, json_mode=False, **kw):
-            seen_prompts.append((prompt, json_mode))
+        async def fake_call(prompt, **kw):
+            seen.append((prompt, kw.get("json_mode")))
             return next(replies)
 
-        monkeypatch.setattr(agent, "_call_llm", fake_call)
-        assert asyncio.run(agent._call_llm_json("do it")) == {"ok": True}
-        assert len(seen_prompts) == 2 and all(j for _, j in seen_prompts)
-        assert "not valid JSON" in seen_prompts[1][0]
+        monkeypatch.setattr(base, "call_llm", fake_call)
+        assert asyncio.run(call_llm_json("do it", name="t")) == {"ok": True}
+        assert len(seen) == 2 and all(j for _, j in seen)
+        assert "not valid JSON" in seen[1][0] and "double quote" in seen[1][0]
 
     def test_call_llm_json_gives_up_after_retry(self, monkeypatch):
-        agent = BaseAgent.__new__(BaseAgent)
-        agent._trace_name = "t"
-
-        async def fake_call(prompt, json_mode=False, **kw):
+        async def fake_call(prompt, **kw):
             return "still not json"
 
-        monkeypatch.setattr(agent, "_call_llm", fake_call)
+        monkeypatch.setattr(base, "call_llm", fake_call)
         with pytest.raises(ValueError):
-            asyncio.run(agent._call_llm_json("do it"))
+            asyncio.run(call_llm_json("do it", name="t"))
+
+    def test_agent_wrapper_delegates_to_shared_caller(self, monkeypatch):
+        agent = BaseAgent.__new__(BaseAgent)
+        agent._trace_name, agent.model, agent.max_tokens, agent.system_prompt = "t", "m", 10, "sys"
+        captured = {}
+
+        async def fake(prompt, **kw):
+            captured.update(kw)
+            return {"ok": 1}
+
+        monkeypatch.setattr(base, "call_llm_json", fake)
+        assert asyncio.run(agent._call_llm_json("p")) == {"ok": 1}
+        assert captured["system_prompt"] == "sys" and captured["name"] == "t"
 
 
 # --- candidate dedupe --------------------------------------------------------
@@ -119,11 +143,35 @@ async def test_callback_fires_per_visualization_and_skips_checkpointed(monkeypat
     async def on_viz(v):
         delivered.append(v.concept)
 
+    # skip_concepts takes RAW names (normalized inside) — a checkpointed
+    # 'Beta Concepts' must skip the analyzer's 'Beta concept'.
     out = await pipeline.generate_visualizations(
-        _Paper(), on_visualization=on_viz, skip_concepts={"beta concept"}
+        _Paper(), on_visualization=on_viz, skip_concepts={"Beta Concepts"}
     )
     assert sorted(delivered) == ["Alpha concept", "Gamma concept"]
     assert len(out) == 2
+
+
+async def test_failing_checkpoint_surfaces_instead_of_dropping_paid_work(monkeypatch):
+    for name in ("SectionAnalyzer", "VisualizationPlanner", "ManimGenerator", "CodeValidator",
+                 "SpatialValidator", "VoiceoverScriptValidator", "RenderTester"):
+        monkeypatch.setattr(pipeline, name, lambda *a, **k: object())
+
+    async def fake_analyze(analyzer, paper):
+        return [_cand("Alpha concept", 5)]
+
+    async def fake_generate(candidate, **kw):
+        return VizModel(id="tmp", section_id="s1", concept=candidate.concept_name,
+                        storyboard="{}", manim_code="from manim import *",
+                        video_url=None, status=VisualizationStatus.PENDING)
+
+    async def broken_checkpoint(v):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(pipeline, "_analyze_all_sections", fake_analyze)
+    monkeypatch.setattr(pipeline, "generate_single_visualization", fake_generate)
+    with pytest.raises(pipeline.CheckpointError):
+        await pipeline.generate_visualizations(_Paper(), on_visualization=broken_checkpoint)
 
 
 # --- DB helpers for resumable runs -------------------------------------------
@@ -150,16 +198,52 @@ async def _seed(db):
     await db.commit()
 
 
-async def test_delete_clears_stale_rows_for_a_run(db):
+async def test_supersede_hides_previous_runs_but_keeps_rows_and_feedback(db):
     await _seed(db)
-    assert await queries.delete_visualizations_for_paper(db, "1706.03762") == 3
-    assert await queries.get_visualizations_for_paper(db, "1706.03762") == []
+    db.add(Feedback(id="fb_1", kind="video", viz_id="viz_17060376_1", paper_id="1706.03762", vote="down"))
+    await db.commit()
+    # The 2026-09-07 run succeeded: everything created before it is retired.
+    assert await queries.supersede_visualizations_before(db, "1706.03762", datetime(2026, 9, 7)) == 1
+    visible = {r.id for r in await queries.get_visualizations_for_paper(db, "1706.03762")}
+    assert visible == {"viz_1706_03762_1", "viz_1706_03762_2"}
+    everything = await queries.get_visualizations_for_paper(db, "1706.03762", include_superseded=True)
+    assert {r.id: r.status for r in everything}["viz_17060376_1"] == "superseded"
+    # The vote still points at the row it was cast on (no FK violation, no data loss).
+    fb = (await db.execute(select(Feedback))).scalars().one()
+    assert fb.viz_id == "viz_17060376_1"
+
+
+async def test_run_scoped_checkpoints_and_next_index(db):
+    await _seed(db)
+    this_run = await queries.get_visualizations_for_paper(db, "1706.03762", since=datetime(2026, 9, 7))
+    assert {r.id for r in this_run} == {"viz_1706_03762_1", "viz_1706_03762_2"}
+    everything = await queries.get_visualizations_for_paper(db, "1706.03762", include_superseded=True)
+    # Ids are never reused: the next new row is _3 even though _1 belongs to an old run.
+    assert queries.next_viz_index(everything) == 3
 
 
 async def test_fail_pending_marks_only_stranded_rows(db):
     await _seed(db)
-    assert await queries.fail_pending_visualizations(db, "1706.03762", "died") == 1
+    assert await queries.fail_pending_visualizations(db, "1706.03762", "died", since=datetime(2026, 9, 7)) == 1
     rows = {r.id: r for r in await queries.get_visualizations_for_paper(db, "1706.03762")}
     assert rows["viz_1706_03762_1"].status == "failed"
     assert rows["viz_1706_03762_2"].status == "complete"
     assert rows["viz_17060376_1"].status == "complete"
+
+
+# --- every activity the workflow calls must be registered on a worker ---------
+
+def test_every_workflow_activity_is_registered_on_a_worker():
+    import inspect
+
+    from temporal_app import activities, worker, workflows
+
+    registered = {fn.__name__ for fn in worker.PIPELINE_ACTIVITIES + worker.RENDER_ACTIVITIES}
+    source = inspect.getsource(workflows)
+    referenced = {
+        name for name, obj in vars(activities).items()
+        if callable(obj) and hasattr(obj, "__temporal_activity_definition") and name in source
+    }
+    assert referenced, "no activities detected in workflows.py — test is broken"
+    missing = referenced - registered
+    assert not missing, f"activities invoked by the workflow but not registered: {missing}"

--- a/backend/tests/test_generation_robustness.py
+++ b/backend/tests/test_generation_robustness.py
@@ -1,0 +1,165 @@
+"""Generation robustness: JSON repair/retry, candidate dedupe, per-viz
+checkpoint callbacks, and the DB helpers behind resumable runs (no network).
+
+Reviewer-confirmed defects pinned here: unparseable JSON silently dropped
+concepts (~4% of papers lost a section's candidates, ~6% a planned viz);
+the same concept was animated 2-3 times per paper; a worker restart lost
+every finished visualization; rows stranded at 'pending' counted as visuals.
+"""
+
+import asyncio
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import agents.pipeline as pipeline
+from agents.base import BaseAgent, repair_json_text
+from db import queries
+from db.models import Base, Paper, Visualization
+from models.generation import Visualization as VizModel
+from models.generation import VisualizationCandidate, VisualizationStatus, VisualizationType
+
+# --- JSON repair -------------------------------------------------------------
+
+class TestJsonRepair:
+    def test_lone_backslashes_and_trailing_commas(self):
+        raw = '{"concept": "uses \\alpha and \\mathcal{X}", "items": [1, 2,],}'
+        agent = BaseAgent.__new__(BaseAgent)
+        out = agent._parse_json_response(raw)
+        assert out["concept"] == "uses \\alpha and \\mathcal{X}"
+        assert out["items"] == [1, 2]
+
+    def test_valid_escapes_untouched(self):
+        assert repair_json_text('{"a": "line\\nbreak \\"q\\""}') == '{"a": "line\\nbreak \\"q\\""}'
+
+    def test_fenced_json_still_parses(self):
+        agent = BaseAgent.__new__(BaseAgent)
+        assert agent._parse_json_response('```json\n{"x": 1}\n```') == {"x": 1}
+
+    def test_call_llm_json_retries_once(self, monkeypatch):
+        agent = BaseAgent.__new__(BaseAgent)
+        agent._trace_name = "t"
+        replies = iter(["not json at all", '{"ok": true}'])
+        seen_prompts = []
+
+        async def fake_call(prompt, json_mode=False, **kw):
+            seen_prompts.append((prompt, json_mode))
+            return next(replies)
+
+        monkeypatch.setattr(agent, "_call_llm", fake_call)
+        assert asyncio.run(agent._call_llm_json("do it")) == {"ok": True}
+        assert len(seen_prompts) == 2 and all(j for _, j in seen_prompts)
+        assert "not valid JSON" in seen_prompts[1][0]
+
+    def test_call_llm_json_gives_up_after_retry(self, monkeypatch):
+        agent = BaseAgent.__new__(BaseAgent)
+        agent._trace_name = "t"
+
+        async def fake_call(prompt, json_mode=False, **kw):
+            return "still not json"
+
+        monkeypatch.setattr(agent, "_call_llm", fake_call)
+        with pytest.raises(ValueError):
+            asyncio.run(agent._call_llm_json("do it"))
+
+
+# --- candidate dedupe --------------------------------------------------------
+
+def _cand(name, priority, section="s1"):
+    return VisualizationCandidate(
+        section_id=section, concept_name=name, concept_description="d", context="c",
+        visualization_type=VisualizationType.DATA_FLOW, priority=priority,
+    )
+
+
+class TestDedupe:
+    def test_near_duplicates_collapse_keeping_first(self):
+        cands = [
+            _cand("StreamHear pipeline (teacher -> pseudo-labels -> student)", 5),
+            _cand("Teacher -> Pseudo-label -> Student Adaptation Pipeline", 4),
+            _cand("Prior-regularized dynamic-programming realignment", 4),
+            _cand("Prior-regularized Dynamic Programming Re-alignment", 3),
+            _cand("Beam search decoding", 2),
+        ]
+        kept = pipeline._dedupe_candidates(cands)
+        assert [c.priority for c in kept] == [5, 4, 2]
+
+    def test_distinct_concepts_all_kept(self):
+        cands = [_cand("Attention heads", 5), _cand("Positional encoding", 4), _cand("Beam search", 3)]
+        assert len(pipeline._dedupe_candidates(cands)) == 3
+
+
+# --- per-viz callbacks + skip ------------------------------------------------
+
+class _Paper:
+    class meta:
+        title = "T"
+    sections = []
+
+
+async def test_callback_fires_per_visualization_and_skips_checkpointed(monkeypatch):
+    for name in ("SectionAnalyzer", "VisualizationPlanner", "ManimGenerator", "CodeValidator",
+                 "SpatialValidator", "VoiceoverScriptValidator", "RenderTester"):
+        monkeypatch.setattr(pipeline, name, lambda *a, **k: object())
+
+    async def fake_analyze(analyzer, paper):
+        return [_cand("Alpha concept", 5), _cand("Beta concept", 4), _cand("Gamma concept", 3)]
+
+    async def fake_generate(candidate, **kw):
+        return VizModel(id="tmp", section_id="s1", concept=candidate.concept_name,
+                        storyboard="{}", manim_code="from manim import *",
+                        video_url=None, status=VisualizationStatus.PENDING)
+
+    monkeypatch.setattr(pipeline, "_analyze_all_sections", fake_analyze)
+    monkeypatch.setattr(pipeline, "generate_single_visualization", fake_generate)
+    delivered = []
+
+    async def on_viz(v):
+        delivered.append(v.concept)
+
+    out = await pipeline.generate_visualizations(
+        _Paper(), on_visualization=on_viz, skip_concepts={"beta concept"}
+    )
+    assert sorted(delivered) == ["Alpha concept", "Gamma concept"]
+    assert len(out) == 2
+
+
+# --- DB helpers for resumable runs -------------------------------------------
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db):
+    db.add(Paper(id="1706.03762", title="A"))
+    db.add(Visualization(id="viz_17060376_1", paper_id="1706.03762", section_id="s", concept="old",
+                         status="complete", video_url="https://x/old.mp4", created_at=datetime(2026, 8, 24)))
+    db.add(Visualization(id="viz_1706_03762_1", paper_id="1706.03762", section_id="s", concept="new",
+                         status="pending", manim_code="code", created_at=datetime(2026, 9, 7)))
+    db.add(Visualization(id="viz_1706_03762_2", paper_id="1706.03762", section_id="s", concept="new2",
+                         status="complete", video_url="https://x/new.mp4", created_at=datetime(2026, 9, 7)))
+    await db.commit()
+
+
+async def test_delete_clears_stale_rows_for_a_run(db):
+    await _seed(db)
+    assert await queries.delete_visualizations_for_paper(db, "1706.03762") == 3
+    assert await queries.get_visualizations_for_paper(db, "1706.03762") == []
+
+
+async def test_fail_pending_marks_only_stranded_rows(db):
+    await _seed(db)
+    assert await queries.fail_pending_visualizations(db, "1706.03762", "died") == 1
+    rows = {r.id: r for r in await queries.get_visualizations_for_paper(db, "1706.03762")}
+    assert rows["viz_1706_03762_1"].status == "failed"
+    assert rows["viz_1706_03762_2"].status == "complete"
+    assert rows["viz_17060376_1"].status == "complete"


### PR DESCRIPTION
Step 3b (stacked on #69 — retarget to main after it merges).

Two Temporal-path defects behind today's '0 visuals' cards and the 317 stranded `pending` rows:
- generation upserted rows only after **all** candidates finished, with no heartbeat and no retry → a worker restart lost everything finished;
- one failed render activity aborted the workflow → job failed, remaining rows stranded at `pending` (and counted as visuals).

Fixes: per-visualization checkpoint + heartbeat; generation retries once, only on worker death, resuming from checkpoints (never re-paying finished work); a run clears the paper's prior rows first (kills stale/orphan-row shadowing); one failed render = one failed viz (`record_render_failure`), job finalizes honestly; `mark_job_failed` fails stranded rows. Plus JSON mode + lenient repair + one retry for analyzer/planner/organizer, analyst persona instead of the 17KB Manim reference, and concept de-duplication before the cap. 10 tests; suite 167 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Visualization generation now saves completed results incrementally, allowing interrupted runs to resume without repeating completed concepts.
  - Duplicate concepts are filtered, and generation respects the remaining visualization limit.
  - Failed rendering is recorded per visualization instead of stopping the entire workflow.

- **Bug Fixes**
  - Older visualization results are excluded from paper responses after a successful newer run.
  - Stalled visualizations are marked as failed for clearer job status.
  - Malformed JSON responses are repaired and retried automatically.

- **Reliability**
  - Generation can retry after worker interruptions, with improved heartbeat handling for longer-running jobs.
  - Visualization identifiers are allocated safely to prevent collisions during resumed or concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->