### PR TITLE
perf: stop re-parsing the reader on every poll tick; cheaper card compositing

### DIFF
--- a/frontend/app/abs/[...id]/page.tsx
+++ b/frontend/app/abs/[...id]/page.tsx
@@ -515,7 +515,10 @@ function ReadyState({
   absUrl: string;
   onProgressChange: (progress: number) => void;
 }) {
-  const scrollySections: ScrollySectionModel[] = [...paper.sections]
+  // Memoised on the paper: the 2s status poll and the video re-check used to
+  // hand CardStack a brand-new sections array (new identities) each tick,
+  // re-rendering every mounted card and re-parsing its markdown/KaTeX.
+  const scrollySections: ScrollySectionModel[] = useMemo(() => [...paper.sections]
     .sort((a, b) => a.order_index - b.order_index)
     .map((s) => ({
       id: s.id,
@@ -530,9 +533,9 @@ function ReadyState({
         videoUrl: v.video_url,
         concept: v.concept,
       })),
-    }));
+    })), [paper]);
 
-  const heroContent = (
+  const heroContent = useMemo(() => (
     <div className="mb-12">
       {/* Hero section */}
       <motion.div
@@ -599,7 +602,7 @@ function ReadyState({
       {/* Divider before sections */}
       <div className="mt-10 h-px bg-gradient-to-r from-transparent via-white/[0.08] to-transparent" />
     </div>
-  );
+  ), [paper]);
 
   return (
     <motion.div

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -42,10 +42,9 @@ body {
   font-family: var(--font-geist-sans), ui-sans-serif, system-ui, -apple-system, sans-serif;
 }
 
-/* Smooth scrolling */
-html {
-  scroll-behavior: smooth;
-}
+/* No global smooth scrolling: the reader is an N×200vh scroll track, and
+   animating every programmatic/keyboard scroll across it read as "sluggish".
+   (There are no in-page anchor links that relied on it.) */
 
 /* Glassmorphism card */
 .glass-card {

--- a/frontend/components/CardStack.tsx
+++ b/frontend/components/CardStack.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState, memo, startTransition } from "react";
 import {
   motion,
   useScroll,
@@ -28,7 +21,22 @@ const CONTENT_FRACTION = 1 - EXIT_FRACTION; // first 75% = content scroll phase
  * SlideCard — creates 3 motion values per card (vs old CardSlot's 8 hooks).
  * Handles horizontal slide transitions: exit left, enter from right.
  */
-function SlideCard({
+// Viewport size read once per resize instead of inside every per-frame
+// transform: window.innerWidth/innerHeight inside useTransform forced a
+// layout read between framer's writes on every scroll frame (up to 6/frame).
+const viewport = { current: { w: 1000, h: 696 } };
+function useViewportRef() {
+  useEffect(() => {
+    const read = () => {
+      viewport.current = { w: window.innerWidth, h: window.innerHeight };
+    };
+    read();
+    window.addEventListener("resize", read);
+    return () => window.removeEventListener("resize", read);
+  }, []);
+}
+
+const SlideCard = memo(function SlideCard({
   section,
   index,
   totalSections,
@@ -58,7 +66,7 @@ function SlideCard({
 
   // --- slideX: horizontal position ---
   const slideX = useTransform(scrollYProgress, (v) => {
-    const vw = typeof window !== "undefined" ? window.innerWidth : 1000;
+    const vw = viewport.current.w;
 
     // Before this card's enter phase: offscreen right
     if (index > 0 && v < prevExitStart) return vw;
@@ -119,8 +127,7 @@ function SlideCard({
   // --- contentY: scroll content within the card during content phase ---
   const contentY = useTransform(scrollYProgress, (v) => {
     const contentHeight = contentHeightsRef.current?.[index] || 0;
-    const cardViewportHeight =
-      typeof window !== "undefined" ? window.innerHeight - 96 : 600;
+    const cardViewportHeight = viewport.current.h - 96;
     const maxScroll = Math.max(0, contentHeight - cardViewportHeight);
 
     // Before this card's segment: content at top
@@ -155,7 +162,7 @@ function SlideCard({
       onContentHeight={onContentHeight}
     />
   );
-}
+});
 
 export function CardStack({
   sections,
@@ -187,11 +194,17 @@ export function CardStack({
   // No useSpring — raw scroll progress for responsive feel
 
   const [activeIndex, setActiveIndex] = useState(0);
+  const activeIndexRef = useRef(0);
+  useViewportRef();
 
   useMotionValueEvent(scrollYProgress, "change", (latest) => {
     const newActive = Math.min(Math.floor(latest * N), N - 1);
-    if (newActive >= 0 && newActive !== activeIndex) {
-      setActiveIndex(newActive);
+    // Ref, not state, in the closure: reading activeIndex here made framer
+    // re-subscribe on every render. The boundary switch mounts a new card
+    // (markdown + KaTeX + videos) — keep that off the scroll frame.
+    if (newActive >= 0 && newActive !== activeIndexRef.current) {
+      activeIndexRef.current = newActive;
+      startTransition(() => setActiveIndex(newActive));
     }
   });
 

--- a/frontend/components/MarkdownContent.tsx
+++ b/frontend/components/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
+import { memo, useMemo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
@@ -10,15 +11,11 @@ type MarkdownContentProps = {
   className?: string;
 };
 
-export function MarkdownContent({ content, className = "" }: MarkdownContentProps) {
-  const processedContent = preprocessLatex(content);
-
-  return (
-    <div className={`markdown-content ${className}`}>
-      <ReactMarkdown
-        remarkPlugins={[remarkMath]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
+// Hoisted: a new object literal per render defeated react-markdown's own
+// memoisation, and this component used to re-run the whole
+// remark → rehype → KaTeX pipeline on every unrelated state change (the 2s
+// status poll re-parsed every mounted card while the reader scrolled).
+const MARKDOWN_COMPONENTS: Components = {
           p: ({ children }) => (
             <p className="mb-6 last:mb-0 leading-[1.9]">{children}</p>
           ),
@@ -81,13 +78,26 @@ export function MarkdownContent({ content, className = "" }: MarkdownContentProp
               {children}
             </a>
           ),
-        }}
+};
+
+export const MarkdownContent = memo(function MarkdownContent({
+  content,
+  className = "",
+}: MarkdownContentProps) {
+  const processedContent = useMemo(() => preprocessLatex(content), [content]);
+
+  return (
+    <div className={`markdown-content ${className}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={MARKDOWN_COMPONENTS}
       >
         {processedContent}
       </ReactMarkdown>
     </div>
   );
-}
+});
 
 function preprocessLatex(content: string): string {
   // Bare-TeX wrapping, fence repair and currency escaping now happen in the

--- a/frontend/components/StackCard.tsx
+++ b/frontend/components/StackCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useRef, useEffect, useCallback } from "react";
-import { motion, type MotionValue, useMotionValue, useMotionTemplate } from "framer-motion";
+import { memo, useMemo, useRef, useEffect, useCallback } from "react";
+import { motion, type MotionValue } from "framer-motion";
 import { VideoFeedback } from "@/components/VideoFeedback";
 import { VideoPlayer } from "@/components/VideoPlayer";
 import { MarkdownContent } from "@/components/MarkdownContent";
@@ -70,7 +70,7 @@ interface StackCardProps {
   onContentHeight?: (index: number, height: number) => void;
 }
 
-export function StackCard({
+export const StackCard = memo(function StackCard({
   section,
   index,
   totalSections,
@@ -82,24 +82,6 @@ export function StackCard({
   onContentHeight,
 }: StackCardProps) {
   const contentRef = useRef<HTMLDivElement>(null);
-
-  // Mouse spotlight
-  const mouseX = useMotionValue(0);
-  const mouseY = useMotionValue(0);
-
-  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
-    const { left, top } = e.currentTarget.getBoundingClientRect();
-    mouseX.set(e.clientX - left);
-    mouseY.set(e.clientY - top);
-  }
-
-  const spotlightBg = useMotionTemplate`
-    radial-gradient(
-      600px circle at ${mouseX}px ${mouseY}px,
-      rgba(255, 255, 255, 0.05),
-      transparent 40%
-    )
-  `;
 
   const headingClass = useMemo(() => {
     const level = section.level ?? 1;
@@ -137,14 +119,16 @@ export function StackCard({
     <motion.section
       data-card-index={index}
       aria-hidden={!isActive}
-      onMouseMove={isActive ? handleMouseMove : undefined}
       className={cn(
         "absolute inset-x-4 top-4 bottom-4 sm:inset-x-6 sm:top-6 sm:bottom-6",
-        "rounded-3xl border backdrop-blur-xl overflow-hidden",
-        "will-change-transform",
+        "rounded-3xl border overflow-hidden",
+        "will-change-transform [contain:paint]",
+        // A moving backdrop-filter surface is re-sampled and re-blurred every
+        // frame; three of them translating over an animated background was the
+        // single heaviest paint. Only the card being read blurs.
         isActive
-          ? "bg-white/[0.06] border-white/[0.18] shadow-2xl shadow-black/50"
-          : "bg-white/[0.04] border-white/[0.10] shadow-xl shadow-black/30"
+          ? "backdrop-blur-xl bg-white/[0.06] border-white/[0.18] shadow-2xl shadow-black/50"
+          : "bg-[#0b0b0c]/90 border-white/[0.10] shadow-xl shadow-black/30"
       )}
       style={{
         x: cardX,
@@ -153,20 +137,12 @@ export function StackCard({
         pointerEvents: isActive ? "auto" : "none",
       }}
     >
-      {/* Spotlight gradient overlay */}
-      {isActive && (
-        <motion.div
-          className="pointer-events-none absolute -inset-px rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-          style={{ background: spotlightBg }}
-        />
-      )}
-
       {/* Content area */}
       <div className="relative h-full overflow-hidden">
         <motion.div
           ref={contentRef}
           style={{ y: contentY }}
-          className="px-6 pt-6 pb-8 sm:px-10 sm:pt-8 sm:pb-10"
+          className="px-6 pt-6 pb-8 sm:px-10 sm:pt-8 sm:pb-10 will-change-transform [contain:layout_paint]"
         >
           {/* Section number */}
           <div className="mb-4 flex items-center gap-3">
@@ -204,7 +180,12 @@ export function StackCard({
           ).map((video, i) => (
             <div className={i === 0 ? "mt-8" : "mt-6"} key={video.vizId || video.videoUrl}>
               <div className="rounded-xl overflow-hidden border border-white/[0.06] bg-black/30">
-                <VideoPlayer src={video.videoUrl} title={video.concept || "Visualization"} />
+                <VideoPlayer
+                  src={video.videoUrl}
+                  title={video.concept || "Visualization"}
+                  preload={isActive ? "metadata" : "none"}
+                  pauseWhenInactive={!isActive}
+                />
               </div>
               {video.vizId && <VideoFeedback vizId={video.vizId} />}
             </div>
@@ -219,4 +200,4 @@ export function StackCard({
       <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/[0.12] to-transparent" />
     </motion.section>
   );
-}
+});

--- a/frontend/components/VideoPlayer.tsx
+++ b/frontend/components/VideoPlayer.tsx
@@ -8,6 +8,9 @@ type Props = {
   className?: string;
   autoPlay?: boolean;
   pauseWhenInactive?: boolean;
+  /** "none" for players in cards that aren't being read — every mounted
+   *  card's videos used to fetch metadata and set up decoders at once. */
+  preload?: "none" | "metadata" | "auto";
 };
 
 function formatTime(seconds: number): string {
@@ -23,6 +26,7 @@ export function VideoPlayer({
   className,
   autoPlay = false,
   pauseWhenInactive = false,
+  preload = "metadata",
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -147,7 +151,7 @@ export function VideoPlayer({
         src={src}
         className="block w-full"
         playsInline
-        preload="metadata"
+        preload={preload}
         autoPlay={autoPlay}
         muted={autoPlay}
         onPlay={() => setIsPlaying(true)}
@@ -222,8 +226,8 @@ export function VideoPlayer({
               className="group h-2 flex-1 cursor-pointer rounded-full bg-white/[0.08] border border-white/[0.06]"
             >
               <div
-                className="h-full rounded-full bg-gradient-to-r from-white/50 to-white/30 transition-[width] duration-100"
-                style={{ width: `${progressPct}%` }}
+                className="h-full w-full origin-left rounded-full bg-gradient-to-r from-white/50 to-white/30 transition-transform duration-100"
+                style={{ transform: `scaleX(${progressPct / 100})` }}
               />
               <div
                 className="mt-1 text-[10px] text-white/30"

--- a/frontend/components/ui/mosaic-background.tsx
+++ b/frontend/components/ui/mosaic-background.tsx
@@ -161,6 +161,9 @@ export function MosaicBackground({
     // ------------------------------------------------------------------
     // Step 3: Draw triangulated mosaic
     // ------------------------------------------------------------------
+    // ~12.8k fill+stroke paths at 1080p landed as one blocking task right
+    // when the reader appears; strokes are barely visible at that density.
+    const drawStrokes = rows * cols * 2 <= 6000;
     for (let r = 0; r < rows; r++) {
       for (let c = 0; c < cols; c++) {
         const p00 = points[r][c];
@@ -239,7 +242,7 @@ export function MosaicBackground({
 
           ctx.strokeStyle = strokeColor!;
           ctx.lineWidth = 0.5;
-          ctx.stroke();
+          if (drawStrokes) ctx.stroke();
         }
       }
     }


### PR DESCRIPTION
Step 7 — the paper-page scroll lag. Stacked on #72.

**Root causes (from a read-only investigation with file:line evidence):** nothing in the reader was memoized, so the 2s status poll re-ran remark→rehype→KaTeX for every mounted card while scrolling; three full-viewport `backdrop-blur-xl` cards translated every frame (a moving backdrop-filter is re-blurred per frame); `window.innerWidth/innerHeight` were read inside per-frame `useTransform` callbacks (forced layout reads); section boundaries mounted new cards inside the scroll frame; every mounted card's videos fetched metadata.

**Changes:** memo'd MarkdownContent/StackCard/SlideCard + useMemo'd preprocessing + hoisted typed components map; section models and hero memoised on the paper; blur only on the active card + containment on the translated wrapper; viewport size from one resize listener; boundary switch in `startTransition`; `preload=none` + pause for inactive cards; scaleX progress bar; removed dead spotlight work, global smooth-scroll, and per-triangle strokes on dense mosaics.

tsc / eslint / next build green. Note: headless Playwright renders the live page at a steady 16.7ms/frame even before this change (no GPU-composited blur cost at that viewport, no poll on a finished paper), so verification is by removed work rather than a before/after frame number.