### PR TITLE
fix: 15-minute ingest ceiling, real failure reason on job rows, Temporal connect retry

### DIFF
--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -66,6 +66,15 @@ class RepairInput:
 
 
 @dataclass
+class FailInput:
+    job_id: str
+    arxiv_id: str
+    # The workflow's exception text: the job row used to carry only a generic
+    # "failed after retries", which hid the real cause from the site and logs.
+    reason: str = ""
+
+
+@dataclass
 class ProgressUpdate:
     job_id: str
     completed: int
@@ -468,16 +477,18 @@ async def record_render_failure(params: RenderInput) -> None:
 
 
 @activity.defn
-async def mark_job_failed(params: PipelineInput) -> None:
+async def mark_job_failed(params: FailInput) -> None:
     """Terminal failure marker for unrecoverable workflow errors."""
     from db import queries
     from db.connection import async_session_maker
 
+    reason = (params.reason or "").strip()[:500]
     async with async_session_maker() as db:
         await queries.update_job_status(
             db, params.job_id,
             status="failed",
-            error="Pipeline failed after retries. See worker logs for details.",
+            error=f"Pipeline failed: {reason}" if reason else
+                  "Pipeline failed after retries. See worker logs for details.",
         )
         # Rows the dead run never got to render would otherwise sit at
         # 'pending' forever and count as visuals in the gallery.

--- a/backend/temporal_app/worker.py
+++ b/backend/temporal_app/worker.py
@@ -74,7 +74,19 @@ async def main() -> None:
     )
     # Container Apps fronts gRPC with HTTP/2 ingress behind TLS (:443);
     # raw TCP ingress proved unroutable on this environment.
-    client = await Client.connect(address, namespace=namespace, tls=use_tls)
+    # Retry the connect: during a revision rollover the first attempt failed
+    # (exit 1, container restarted by the platform 10s later). Exiting on a
+    # transient gRPC error just adds a restart to every deploy.
+    client = None
+    for attempt in range(1, 7):
+        try:
+            client = await Client.connect(address, namespace=namespace, tls=use_tls)
+            break
+        except Exception as exc:
+            if attempt == 6:
+                raise
+            logger.warning("Temporal connect attempt %d failed (%s); retrying in %ds", attempt, exc, 5 * attempt)
+            await asyncio.sleep(5 * attempt)
     logger.info("Connected. Render concurrency: %d", render_concurrency)
 
     # Backpressure: observed in production that unbounded concurrent

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -33,6 +33,7 @@ from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from temporal_app.activities import (
+        FailInput,
         PipelineInput,
         ProgressUpdate,
         RenderInput,
@@ -64,6 +65,19 @@ _NO_RETRY = RetryPolicy(maximum_attempts=1)
 _GENERATION_RETRY = RetryPolicy(maximum_attempts=2)
 
 
+def _failure_reason(exc: BaseException) -> str:
+    """Human-readable cause for the job row: the innermost Temporal cause
+    (activity error message or timeout type) rather than the wrapper."""
+    parts: list[str] = []
+    cur: BaseException | None = exc
+    while cur is not None and len(parts) < 4:
+        msg = str(cur).strip()
+        if msg and msg not in parts:
+            parts.append(msg)
+        cur = cur.__cause__
+    return " <- ".join(parts)[:500]
+
+
 @workflow.defn
 class PaperPipelineWorkflow:
     """ingest → generate → parallel renders → honest finalize."""
@@ -71,10 +85,15 @@ class PaperPipelineWorkflow:
     @workflow.run
     async def run(self, params: PipelineInput) -> str:
         try:
+            # 15 min: a real full-length paper (5k words) goes through two LLM
+            # passes (summarize + organize), each retried once in-function,
+            # with 300s client timeouts. 5 min fit only the abstract-only
+            # ingests that #69 eliminated; the first real paper after it timed
+            # out twice and failed with no error line in the logs.
             await workflow.execute_activity(
                 ingest_paper,
                 params,
-                start_to_close_timeout=timedelta(minutes=5),
+                start_to_close_timeout=timedelta(minutes=15),
                 retry_policy=_INFRA_RETRY,
             )
 
@@ -137,12 +156,13 @@ class PaperPipelineWorkflow:
             await self._finalize(params.job_id, succeeded=succeeded, total=total)
             defective = sum(1 for r in results if r.severity == "major")
             return f"rendered {succeeded}/{total} ({defective} flagged, {len(to_repair)} repaired)"
-        except Exception:
-            # Mark the job failed so pollers see the truth, then let Temporal
-            # record the workflow failure with full history for debugging.
+        except Exception as exc:
+            # Mark the job failed so pollers see the truth — with the real
+            # reason — then let Temporal record the workflow failure with full
+            # history for debugging.
             await workflow.execute_activity(
                 mark_job_failed,
-                params,
+                FailInput(job_id=params.job_id, arxiv_id=params.arxiv_id, reason=_failure_reason(exc)),
                 start_to_close_timeout=timedelta(minutes=1),
                 retry_policy=_INFRA_RETRY,
             )


### PR DESCRIPTION
Follow-up from the first live run after the stack deploy. Job `job_fe124413df09` (2301.00001) failed at ingestion with only the generic *'Pipeline failed after retries'* and no error line in any log; the same paper ingests locally in 46s, and the next paper (2301.00002) went through the new pipeline cleanly in production. Three hardening changes so the next silent failure isn't silent:

- **Ingest activity ceiling 5 → 15 min.** Five minutes only ever fit the abstract-only ingests #69 eliminated; a real full-length paper does summarize + organize (each retried once in-function) with 300s client timeouts.
- **Job rows carry the real failure cause**: the workflow passes its innermost exception text (activity error or timeout type) to `mark_job_failed` via a new `FailInput`.
- **Worker retries the Temporal connect at startup** with backoff: the first container start after the rollover exited 1 on a transient gRPC failure and was restarted by the platform.

Tests: 219 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Paper ingestion now supports processing times of up to 15 minutes, improving handling of full-length papers.
  - Job failures now include a more specific reason when available, making errors easier to understand.
  - Temporary connection issues during service startup are handled with automatic retries, improving reliability during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->