### PR TITLE
fix: validate + normalize arXiv ids at the API; static camera.frame rule; 25-min render ceiling

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -35,7 +35,7 @@ POST /api/process  (api/routes.py: rate-limit + dedupe [api/throttle.py] + stale
 | 1 | SectionAnalyzer | `agents/section_analyzer.py` | LLM: pick concepts worth animating |
 | 2 | VisualizationPlanner | `agents/visualization_planner.py` | LLM: scene-by-scene storyboard |
 | 3 | ManimGenerator (voice-aware) | `agents/manim_generator.py` | LLM: full `VoiceoverScene` code, few-shot by viz type |
-| 4 | CodeValidator | `agents/code_validator.py` | gate: AST/structure/auto-fixes, no LLM |
+| 4 | CodeValidator | `agents/code_validator.py` | gate: AST/structure/auto-fixes + static rules (MathTex splitting, `camera.frame` outside MovingCameraScene), no LLM |
 | 5 | SpatialValidator | `agents/spatial_validator.py` | gate: bounds/overlap regex, no LLM |
 | 6 | VoiceoverScriptValidator | `agents/voiceover_script_validator.py` | gate: narration quality, heuristics + LLM judge |
 | 7 | RenderTester | `agents/render_tester.py` | gate: dry-run construct() execution in a stubbed subprocess (auto-skipped when `RENDER_MODE=modal`) |
@@ -97,6 +97,8 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
   `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_PER_IP_DAILY` (3/day), `RATE_LIMIT_PROCESS_GLOBAL`
   (30/h; prod sets 6), `RATE_LIMIT_PROCESS_WINDOW_SECONDS` (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600).
   `client_ip()` takes the RIGHTMOST `X-Forwarded-For` hop (the one the ingress appends) — never the first.
+  `ProcessRequest.arxiv_id` is validated and normalized (version suffix stripped) at the boundary — the paper is
+  stored under the base id, and non-arXiv identifiers are rejected with 422 before any budget is spent.
 - `RATE_LIMIT_FEEDBACK_PER_IP` (30) / `RATE_LIMIT_FEEDBACK_WINDOW_SECONDS` (3600) — bounds `POST /api/feedback` (viewer 👍/👎 per video + site
   suggestions → `feedback` table). Video votes are labeled ground truth for calibrating the visual-QA judge;
   `paper_id` is denormalized from the viz row, never trusted from the client.

--- a/backend/agents/code_validator.py
+++ b/backend/agents/code_validator.py
@@ -85,10 +85,17 @@ class CodeValidator:
         mathtex_issues = self._check_mathtex_splitting(fixed_code)
         if mathtex_issues:
             issues_found.extend(mathtex_issues)
-        
+
+        # Step 7: camera.frame outside MovingCameraScene. The dry-run gate
+        # does not catch this on 3D scenes (it surfaced only in the real
+        # render as "'ThreeDCamera' object has no attribute 'frame'").
+        camera_issues = self._check_camera_frame(fixed_code)
+        if camera_issues:
+            issues_found.extend(camera_issues)
+
         # Determine if regeneration is needed
-        # More than 1 unfixed issue OR MathTex issues = regenerate
-        needs_regeneration = len(issues_found) > 1 or bool(mathtex_issues)
+        # More than 1 unfixed issue OR MathTex/camera issues = regenerate
+        needs_regeneration = len(issues_found) > 1 or bool(mathtex_issues) or bool(camera_issues)
         
         return ValidatorOutput(
             is_valid=len(issues_found) == 0,
@@ -204,6 +211,20 @@ class CodeValidator:
             return fixed_code, fixes
         return None
     
+    _CAMERA_FRAME_RE = re.compile(r"\bself\.camera\.frame\b")
+    _MOVING_CAMERA_RE = re.compile(r"class\s+\w+\s*\([^)]*MovingCameraScene[^)]*\)")
+
+    def _check_camera_frame(self, code: str) -> list[str]:
+        """``self.camera.frame`` exists only on MovingCameraScene; on Scene,
+        ThreeDScene and VoiceoverScene it raises at render time."""
+        if self._CAMERA_FRAME_RE.search(code) and not self._MOVING_CAMERA_RE.search(code):
+            return [
+                "CRITICAL: self.camera.frame is used but the scene is not a MovingCameraScene "
+                "— it raises AttributeError at render time. Zoom/pan by animating the content "
+                "instead: self.play(group.animate.scale(1.5).shift(...))."
+            ]
+        return []
+
     def _check_mathtex_splitting(self, code: str) -> list[str]:
         """
         Check for dangerous MathTex splitting patterns that will crash Manim.

--- a/backend/agents/render_tester.py
+++ b/backend/agents/render_tester.py
@@ -124,7 +124,7 @@ class RenderTester:
          "which `from manim import *` already provides as `np`."),
         ("has no attribute 'add_coordinate_labels'",
          "Use axes.add_coordinates() — add_coordinate_labels does not exist in Manim CE."),
-        ("'Camera' object has no attribute 'frame'",
+        ("object has no attribute 'frame'",
          "self.camera.frame only exists in MovingCameraScene; this is a VoiceoverScene. "
          "Zoom/pan by animating the content instead: self.play(group.animate.scale(1.5).shift(...))."),
         ("'function' object has no attribute",

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 # === Enums ===
 
@@ -51,6 +51,24 @@ class ProcessRequest(BaseModel):
         description="arXiv paper ID (e.g., '1706.03762' or '1706.03762v1')",
         examples=["1706.03762", "2301.07041v2"]
     )
+
+    @field_validator("arxiv_id")
+    @classmethod
+    def _canonical_arxiv_id(cls, value: str) -> str:
+        """Reject non-arXiv identifiers before a job, a workflow and a
+        daily-cap slot are spent on them (a medRxiv DOI path was accepted
+        and failed at ingestion), and strip the version suffix: the paper is
+        stored under the base id, and a versioned id ('0805.3898v2') used to
+        crash generation with a None paper lookup."""
+        from ingestion.arxiv_fetcher import ARXIV_ID_PATTERN, normalize_arxiv_id
+
+        cleaned = value.strip().removeprefix("arXiv:").removeprefix("arxiv:").strip()
+        if not ARXIV_ID_PATTERN.match(cleaned):
+            raise ValueError(
+                "Not an arXiv identifier. Expected forms: 1706.03762, 1706.03762v1, or cs/0123456"
+            )
+        return normalize_arxiv_id(cleaned)
+
     turnstile_token: str | None = Field(
         None, max_length=4096,
         description="Cloudflare Turnstile response token; required when the server has verification enabled",

--- a/backend/temporal_app/activities.py
+++ b/backend/temporal_app/activities.py
@@ -175,6 +175,14 @@ async def generate_visualizations_for_paper(params: PipelineInput) -> list[Rende
             if r.manim_code
         ]
         db_paper = await queries.get_paper(db, params.arxiv_id)
+        if db_paper is None:
+            from temporalio.exceptions import ApplicationError
+
+            # Used to surface as "'NoneType' object has no attribute 'sections'".
+            raise ApplicationError(
+                f"Paper {params.arxiv_id} is not stored — ingestion did not complete for this id",
+                non_retryable=True,
+            )
         db_sections = sorted(db_paper.sections, key=lambda s: s.order_index)
         structured_paper = _build_structured_paper_from_db(db_paper, db_sections)
 

--- a/backend/temporal_app/workflows.py
+++ b/backend/temporal_app/workflows.py
@@ -170,11 +170,14 @@ class PaperPipelineWorkflow:
 
     async def _render_one(self, ri: RenderInput) -> RenderResult:
         try:
+            # 25 min: under multi-paper load (KEDA scaled out ten minutes into
+            # a two-paper burst) two renders that were on track hit the old
+            # 15-min ceiling and shipped as failed visualizations.
             return await workflow.execute_activity(
                 render_visualization,
                 ri,
                 task_queue=RENDER_TASK_QUEUE,
-                start_to_close_timeout=timedelta(minutes=15),
+                start_to_close_timeout=timedelta(minutes=25),
                 retry_policy=_INFRA_RETRY,
             )
         except Exception as exc:
@@ -219,7 +222,7 @@ class PaperPipelineWorkflow:
                     is_repair=True,
                 ),
                 task_queue=RENDER_TASK_QUEUE,
-                start_to_close_timeout=timedelta(minutes=15),
+                start_to_close_timeout=timedelta(minutes=25),
                 retry_policy=_NO_RETRY,  # original video already exists as fallback
             )
             return rerender.succeeded and rerender.severity != "major"

--- a/backend/tests/test_admission.py
+++ b/backend/tests/test_admission.py
@@ -226,3 +226,21 @@ async def test_turnstile_rejects_token_for_foreign_hostname(monkeypatch):
 async def test_turnstile_empty_token_rejected_when_configured(monkeypatch, token):
     monkeypatch.setenv("TURNSTILE_SECRET_KEY", "test-secret")
     assert await turnstile.verify_turnstile(token, "203.0.113.9") is False
+
+
+# --- id validation is enforced before any budget is spent ------------------
+
+async def test_non_arxiv_id_is_rejected_before_creating_a_job(client, db, monkeypatch):
+    from sqlalchemy import func, select
+
+    from db.models import ProcessingJob
+
+    resp = await client.post("/api/process", json={"arxiv_id": "10.64898/2026.06.29.26356713v1.full.pdf"})
+    assert resp.status_code == 422
+    assert (await db.execute(select(func.count()).select_from(ProcessingJob))).scalar_one() == 0
+
+
+async def test_versioned_id_is_normalized_on_the_job(client, db):
+    resp = await client.post("/api/process", json={"arxiv_id": "0805.3898v2"})
+    assert resp.status_code == 200
+    assert resp.json()["arxiv_id"] == "0805.3898"

--- a/backend/tests/test_arxiv_id_validation.py
+++ b/backend/tests/test_arxiv_id_validation.py
@@ -1,0 +1,36 @@
+"""arXiv id validation at the API boundary.
+
+From the first hour of real (Turnstile-verified) traffic: '0805.3898v2' was
+accepted with its version suffix and crashed generation with a None paper
+lookup (the row is stored under the base id), and a medRxiv DOI path was
+accepted, spent a job/workflow/daily-cap slot, then failed at ingestion.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.schemas import ProcessRequest
+
+
+@pytest.mark.parametrize("raw, canonical", [
+    ("1706.03762", "1706.03762"),
+    ("1706.03762v7", "1706.03762"),
+    ("0805.3898v2", "0805.3898"),
+    ("  arXiv:2301.00002 ", "2301.00002"),
+    ("cs/0123456v2", "cs/0123456"),
+    ("hep-th/9711200", "hep-th/9711200"),
+])
+def test_valid_ids_are_normalized(raw, canonical):
+    assert ProcessRequest(arxiv_id=raw).arxiv_id == canonical
+
+
+@pytest.mark.parametrize("raw", [
+    "10.64898/2026.06.29.26356713v1.full.pdf",
+    "https://arxiv.org/abs/1706.03762",
+    "attention is all you need",
+    "",
+    "1706",
+])
+def test_non_arxiv_ids_are_rejected(raw):
+    with pytest.raises(ValidationError, match="Not an arXiv identifier"):
+        ProcessRequest(arxiv_id=raw)

--- a/backend/tests/test_render_tester_execution.py
+++ b/backend/tests/test_render_tester_execution.py
@@ -184,3 +184,29 @@ class TestTargetedFixSuggestions:
     def test_real_latex_errors_still_detected(self):
         info = RenderTester()._refine_error("RuntimeError", "latex error converting to dvi")
         assert info["type"] == "LaTeXError"
+
+
+class TestCameraFrameStaticRule:
+    """Escaped the dry-run gate on a 3D scene in production (viz_2301_00002_4):
+    caught statically now, before any paid render."""
+
+    def test_frame_on_non_moving_camera_scene_is_critical(self):
+        from agents.code_validator import CodeValidator
+
+        code = (
+            "from manim import *\nfrom manim_voiceover import VoiceoverScene\n"
+            "class S(VoiceoverScene):\n    def construct(self):\n"
+            "        self.play(self.camera.frame.animate.scale(0.5))\n"
+        )
+        out = CodeValidator().validate(code)
+        assert any("camera.frame" in i for i in out.issues_found)
+        assert out.needs_regeneration
+
+    def test_frame_on_moving_camera_scene_is_fine(self):
+        from agents.code_validator import CodeValidator
+
+        code = (
+            "from manim import *\nclass S(MovingCameraScene):\n    def construct(self):\n"
+            "        self.play(self.camera.frame.animate.scale(0.5))\n"
+        )
+        assert not any("camera.frame" in i for i in CodeValidator().validate(code).issues_found)


### PR DESCRIPTION
Found by the first hour of real traffic after the stack deploy (all three reproduced from production logs):

- **Version-suffixed ids crashed generation** (`0805.3898v2` → paper stored as `0805.3898` → `'NoneType' object has no attribute 'sections'`), and a **medRxiv DOI path was accepted** as an arXiv id, spending a job/workflow/cap slot before ingestion rejected it. `ProcessRequest.arxiv_id` now rejects non-arXiv identifiers (422) and strips version suffixes; the activity raises a truthful non-retryable error if the paper row is missing.
- **`self.camera.frame` on a 3D scene passed the dry-run gate** and failed the real render. Static CodeValidator rule → regeneration with the exact fix; gate guidance now matches `ThreeDCamera`/`MovingCamera` too.
- **Render ceiling 15 → 25 min**: two renders on track during a two-paper burst hit the ceiling and shipped as failures (KEDA scaled out ten minutes in).

Tests: +12 (schema/API id validation, camera.frame rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ArXiv identifiers are now trimmed, normalized, and validated at submission. Invalid or non-arXiv identifiers are rejected before processing begins.
  * Versioned identifiers are normalized to their base arXiv ID.

* **Bug Fixes**
  * Improved detection and guidance for invalid camera-frame usage in generated animations.
  * Clearer errors are provided when paper data cannot be prepared for visualization.
  * Rendering and repair operations now have additional time to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->