### PR TITLE
fix: stop the gallery prefetch storm (Vercel edge requests); admission-log forensics

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -53,6 +53,7 @@ from .throttle import (
     per_ip_daily_limiter,
     per_ip_limiter,
     recent_jobs,
+    request_context,
 )
 from .turnstile import verify_turnstile
 
@@ -150,7 +151,8 @@ async def start_processing(
     #   3. per-IP hourly + daily, then global sliding windows (in-memory),
     #      peeked together and recorded only once every layer passes
     ip = client_ip(http_request)
-    client_tag = ip_fingerprint(ip)
+    # Fingerprint first (the log queries extract it), then request forensics.
+    client_tag = f"{ip_fingerprint(ip)} {request_context(http_request)}"
 
     now = _utcnow_naive()
     day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/backend/api/throttle.py
+++ b/backend/api/throttle.py
@@ -25,6 +25,7 @@ import threading
 import time
 from collections import deque
 from datetime import datetime, timedelta
+from urllib.parse import urlsplit
 
 from fastapi import HTTPException, Request
 
@@ -146,6 +147,18 @@ def client_ip(request: Request) -> str:
         if last:
             return last
     return request.client.host if request.client else "unknown"
+
+
+def request_context(request: Request) -> str:
+    """Compact forensics for admission logs, so a paced crawler on rotating
+    IPs can still be told apart from people: user agent, Accept-Language,
+    Referer host and Origin. Never the raw IP."""
+    h = request.headers
+    ua = h.get("user-agent", "-").replace('"', "'")[:90]
+    lang = h.get("accept-language", "-").replace('"', "'")[:24]
+    ref = urlsplit(h.get("referer", "")).netloc or "-"
+    origin = h.get("origin", "-")[:40]
+    return f'ua="{ua}" lang="{lang}" ref={ref} origin={origin}'
 
 
 def ip_fingerprint(ip: str) -> str:

--- a/backend/tests/test_admission.py
+++ b/backend/tests/test_admission.py
@@ -244,3 +244,26 @@ async def test_versioned_id_is_normalized_on_the_job(client, db):
     resp = await client.post("/api/process", json={"arxiv_id": "0805.3898v2"})
     assert resp.status_code == 200
     assert resp.json()["arxiv_id"] == "0805.3898"
+
+
+
+def test_request_context_is_compact_and_never_the_ip():
+    from starlette.requests import Request
+
+    from api.throttle import request_context
+
+    scope = {
+        "type": "http", "method": "POST", "path": "/api/process", "query_string": b"",
+        "client": ("203.0.113.9", 1234),
+        "headers": [
+            (b"user-agent", b'Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/128 "quoted"'),
+            (b"accept-language", b"en-US,en;q=0.9"),
+            (b"referer", b"https://www.arxivisual.org/abs/2301.00001"),
+            (b"origin", b"https://www.arxivisual.org"),
+            (b"x-forwarded-for", b"203.0.113.9"),
+        ],
+    }
+    ctx = request_context(Request(scope))
+    assert ctx.startswith('ua="Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/128 \'quoted\'"')
+    assert 'lang="en-US,en;q=0.9"' in ctx and "ref=www.arxivisual.org" in ctx
+    assert "origin=https://www.arxivisual.org" in ctx and "203.0.113.9" not in ctx

--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -186,8 +186,12 @@ function PaperCard({ paper, index }: { paper: PaperSummary; index: number }) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay: Math.min(index * 0.05, 0.4), ease: "easeOut" }}
     >
+      {/* prefetch={false}: each card entering the viewport otherwise fires two
+          RSC prefetches of the server-rendered paper route — ~300-1,300 Vercel
+          edge requests per gallery visit (measured 313 for one scroll). */}
       <Link
         href={`/abs/${encodeURIComponent(paper.paper_id)}`}
+        prefetch={false}
         className="block h-full"
       >
         <GlassCard animate={false} className="h-full p-6 flex flex-col">


### PR DESCRIPTION
## Why
Raj's Vercel Hobby team hit **75% of 1,000,000 Edge Requests**; exceeding it auto-pauses the site.

Measured on prod with Playwright: loading `/explore` and scrolling once fired **313 `GET /abs/<id>?_rsc=…` prefetches for 293 papers** — every card entering the viewport prefetches the server-rendered paper route twice. A full human scroll of the 665-card gallery is ~1,300 edge requests + function invocations. That is the bulk of the allowance.

Separately, the crawler is back: it passes Turnstile from a real browser, uses a fresh IP per request (78 fingerprints for 80 accepted papers on Sep 9) and paces itself at the 6/h global cap around the clock, so per-IP limits never fire. We only log HMAC fingerprints, so nothing identifies it.

## Changes
- `frontend/app/explore/page.tsx`: `prefetch={false}` on the card `<Link>`.
- `backend/api/throttle.py`: `request_context(request)` → `ua="…" lang="…" ref=<host> origin=<origin>` (no raw IP); appended to `client_tag` in `POST /api/process`, so accepted/denied/Turnstile/daily-cap log lines carry it. Fingerprint stays first and space-separated, so the existing Log Analytics extractions keep working.

## Test plan
- [x] backend ruff clean, 251 passed / 7 skipped (new `test_request_context_is_compact_and_never_the_ip`)
- [x] frontend tsc / eslint / build green
- [ ] after Vercel deploy: Playwright scroll of `/explore` fires ~0 `/abs/…?_rsc` requests
- [ ] after API deploy: "Accepted new paper" lines show `ua=… lang=…`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request admission logging with compact context from request headers while excluding client IP addresses.
  * Reduced redundant server requests when browsing paper cards in Explore.

* **Tests**
  * Added coverage validating request context formatting, included metadata, and IP exclusion.

* **Documentation**
  * Documented the reduced request behavior for Explore paper cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->