### PR TITLE
fix: bind Turnstile tokens to one paper + action; log token age

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -92,7 +92,9 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
 - **Admission control on `POST /api/process`** (`api/throttle.py`, `api/turnstile.py`) — layered, each layer
   assumes the previous is gamed (the code is public; a crawler ran ~250 papers/day through the old limits by
   spoofing `X-Forwarded-For`): (1) `TURNSTILE_SECRET_KEY`\* — server-verified Cloudflare Turnstile, skipped
-  when unset, fails CLOSED when set; (2) `DAILY_NEW_PAPER_CAP` (80) — durable per-UTC-day ceiling counted from
+  when unset, fails CLOSED when set; every token is minted with action `start-paper` and the paper id as cData
+  (`turnstile_cdata`, mirrored in `TurnstileWidget.tsx`) and the API refuses tokens for any other action/paper,
+  so one solved challenge starts one paper — deploy the frontend BEFORE the API when the binding changes; (2) `DAILY_NEW_PAPER_CAP` (80) — durable per-UTC-day ceiling counted from
   the jobs table (the spend guarantee; cached papers stay free; 0 disables); (3) in-memory sliding windows:
   `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_PER_IP_DAILY` (3/day), `RATE_LIMIT_PROCESS_GLOBAL`
   (30/h; prod sets 6), `RATE_LIMIT_PROCESS_WINDOW_SECONDS` (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600).

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -55,7 +55,7 @@ from .throttle import (
     recent_jobs,
     request_context,
 )
-from .turnstile import verify_turnstile
+from .turnstile import turnstile_cdata, verify_turnstile_detailed
 
 logger = logging.getLogger(__name__)
 
@@ -172,12 +172,17 @@ async def start_processing(
             headers={"Retry-After": str(retry_after)},
         )
 
-    if not await verify_turnstile(request.turnstile_token, ip):
-        logger.info("Turnstile check failed (client %s)", client_tag)
+    verdict = await verify_turnstile_detailed(
+        request.turnstile_token, ip, expected_cdata=turnstile_cdata(arxiv_id),
+    )
+    if not verdict.ok:
+        logger.info("Turnstile check failed: %s (client %s)", verdict.reason, client_tag)
         raise HTTPException(
             status_code=403,
             detail="Human verification failed. Reload the page and try again.",
         )
+    if verdict.token_age_s is not None:
+        logger.info("Turnstile ok token_age=%.1fs (client %s)", verdict.token_age_s, client_tag)
 
     enforce_all(
         [

--- a/backend/api/turnstile.py
+++ b/backend/api/turnstile.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import httpx
 
@@ -22,19 +25,48 @@ logger = logging.getLogger(__name__)
 SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 _DEFAULT_HOSTNAMES = "arxivisual.org,www.arxivisual.org,localhost"
 
+# The widget mints every token with this action and the paper id as cData
+# (frontend/components/TurnstileWidget.tsx mirrors both), so a token is only
+# good for starting THAT paper: one solved challenge cannot be replayed
+# across ids, and a token minted for anything else is refused.
+TURNSTILE_ACTION = "start-paper"
+_CDATA_MAX = 255
+_VERSION_SUFFIX_RE = re.compile(r"v\d+$")
+
+
+def turnstile_cdata(arxiv_id: str) -> str:
+    """Encode an arXiv id into Turnstile's cData alphabet ([A-Za-z0-9_-],
+    max 255): '.' -> '_', '/' -> '-', anything else dropped. Deterministic on
+    both sides, so ambiguity does not matter — only equality does."""
+    out = arxiv_id.replace(".", "_").replace("/", "-")
+    return re.sub(r"[^A-Za-z0-9_-]", "", out)[:_CDATA_MAX]
+
+
+@dataclass(frozen=True)
+class TurnstileVerdict:
+    ok: bool
+    reason: str | None = None
+    token_age_s: float | None = None
+
 
 def _allowed_hostnames() -> set[str]:
     raw = os.getenv("TURNSTILE_ALLOWED_HOSTNAMES", _DEFAULT_HOSTNAMES)
     return {h.strip() for h in raw.split(",") if h.strip()}
 
 
-async def verify_turnstile(token: str | None, remote_ip: str | None = None) -> bool:
-    """True if the token is valid for this site (or verification is off)."""
+async def verify_turnstile_detailed(
+    token: str | None, remote_ip: str | None = None, *, expected_cdata: str | None = None,
+) -> TurnstileVerdict:
+    """Verify with Cloudflare; when ``expected_cdata`` is given the token must
+    also carry our action and that cData (a trailing arXiv version suffix
+    on either side is ignored, the API normalizes ids). Token age comes
+    from siteverify's challenge_ts: a script submits at a near-constant
+    delay after minting, people vary."""
     secret = os.getenv("TURNSTILE_SECRET_KEY")
     if not secret:
-        return True
+        return TurnstileVerdict(True)
     if not token:
-        return False
+        return TurnstileVerdict(False, "missing token")
     payload = {"secret": secret, "response": token}
     if remote_ip and remote_ip != "unknown":
         payload["remoteip"] = remote_ip
@@ -49,13 +81,38 @@ async def verify_turnstile(token: str | None, remote_ip: str | None = None) -> b
         except Exception as exc:
             logger.warning("Turnstile siteverify unavailable (attempt %d): %s", attempt, exc)
     if body is None:
-        return False
+        return TurnstileVerdict(False, "siteverify unavailable")
     if not body.get("success"):
         logger.info("Turnstile rejected token: %s", body.get("error-codes"))
-        return False
+        return TurnstileVerdict(False, f"rejected {body.get('error-codes')}")
     # A token minted on another site is valid to Cloudflare but not to us.
     hostname = body.get("hostname")
     if hostname and hostname not in _allowed_hostnames():
         logger.warning("Turnstile token for unexpected hostname %r", hostname)
-        return False
-    return True
+        return TurnstileVerdict(False, f"hostname {hostname!r}")
+    if expected_cdata is not None:
+        if body.get("action") != TURNSTILE_ACTION:
+            return TurnstileVerdict(False, f"action {body.get('action')!r}")
+        got = _VERSION_SUFFIX_RE.sub("", str(body.get("cdata") or ""))
+        if got != _VERSION_SUFFIX_RE.sub("", expected_cdata):
+            return TurnstileVerdict(False, f"cdata {body.get('cdata')!r} != {expected_cdata!r}")
+    return TurnstileVerdict(True, None, _token_age_s(body.get("challenge_ts")))
+
+
+def _token_age_s(challenge_ts: str | None) -> float | None:
+    if not challenge_ts:
+        return None
+    try:
+        minted = datetime.fromisoformat(str(challenge_ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if minted.tzinfo is None:
+        minted = minted.replace(tzinfo=UTC)
+    return max(0.0, (datetime.now(UTC) - minted).total_seconds())
+
+
+async def verify_turnstile(
+    token: str | None, remote_ip: str | None = None, *, expected_cdata: str | None = None,
+) -> bool:
+    """True if the token is valid for this site (or verification is off)."""
+    return (await verify_turnstile_detailed(token, remote_ip, expected_cdata=expected_cdata)).ok

--- a/backend/tests/test_admission.py
+++ b/backend/tests/test_admission.py
@@ -181,10 +181,11 @@ async def test_turnstile_rejects_missing_token_when_configured(client, monkeypat
 async def test_turnstile_accepts_verified_token(client, monkeypatch):
     monkeypatch.setenv("TURNSTILE_SECRET_KEY", "test-secret")
 
-    async def fake_verify(token, remote_ip=None):
-        return token == "good-token"
+    async def fake_verify(token, remote_ip=None, *, expected_cdata=None):
+        assert expected_cdata in ("1706_03762", "1810_04805")  # token bound to the paper
+        return turnstile.TurnstileVerdict(token == "good-token", None, 12.0)
 
-    monkeypatch.setattr(routes_module, "verify_turnstile", fake_verify)
+    monkeypatch.setattr(routes_module, "verify_turnstile_detailed", fake_verify)
     ok = await client.post("/api/process", json={"arxiv_id": "1706.03762", "turnstile_token": "good-token"})
     bad = await client.post("/api/process", json={"arxiv_id": "1810.04805", "turnstile_token": "forged"})
     assert ok.status_code == 200
@@ -267,3 +268,49 @@ def test_request_context_is_compact_and_never_the_ip():
     assert ctx.startswith('ua="Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/128 \'quoted\'"')
     assert 'lang="en-US,en;q=0.9"' in ctx and "ref=www.arxivisual.org" in ctx
     assert "origin=https://www.arxivisual.org" in ctx and "203.0.113.9" not in ctx
+
+
+
+# --- token binding: one solved challenge starts one paper --------------------
+
+def test_cdata_encoding_is_deterministic_and_in_alphabet():
+    assert turnstile.turnstile_cdata("1706.03762") == "1706_03762"
+    assert turnstile.turnstile_cdata("math.GT/0309136") == "math_GT-0309136"
+    assert turnstile.turnstile_cdata("adap-org/9707006") == "adap-org-9707006"
+    assert turnstile.turnstile_cdata("1706.03762v2") == "1706_03762v2"
+
+
+def _client_returning(body):
+    class Resp:
+        def json(self): return body
+
+    class Client:
+        def __init__(self, *a, **k): ...
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def post(self, *a, **k): return Resp()
+    return Client
+
+
+async def test_token_bound_to_action_and_paper(monkeypatch):
+    monkeypatch.setenv("TURNSTILE_SECRET_KEY", "test-secret")
+    from datetime import UTC, datetime, timedelta
+
+    minted = (datetime.now(UTC) - timedelta(seconds=30)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    good = {"success": True, "hostname": "arxivisual.org", "action": "start-paper",
+            "cdata": "1706_03762v2", "challenge_ts": minted}
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning(good))
+    v = await turnstile.verify_turnstile_detailed("tok", "203.0.113.9", expected_cdata="1706_03762")
+    assert v.ok and 25 <= v.token_age_s <= 40  # version suffix ignored, age from challenge_ts
+
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning({**good, "cdata": "1810_04805"}))
+    v = await turnstile.verify_turnstile_detailed("tok", "203.0.113.9", expected_cdata="1706_03762")
+    assert not v.ok and v.reason.startswith("cdata")
+
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning({**good, "action": "login"}))
+    v = await turnstile.verify_turnstile_detailed("tok", "203.0.113.9", expected_cdata="1706_03762")
+    assert not v.ok and v.reason.startswith("action")
+
+    # Binding is only enforced when the caller asks for it (older callers/tests).
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning({"success": True, "hostname": "arxivisual.org"}))
+    assert await turnstile.verify_turnstile("tok", "203.0.113.9") is True

--- a/frontend/app/abs/[...id]/page.tsx
+++ b/frontend/app/abs/[...id]/page.tsx
@@ -6,7 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { CardStack } from "@/components/CardStack";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { SiteFeedback } from "@/components/SiteFeedback";
-import { TurnstileWidget, isTurnstileConfigured } from "@/components/TurnstileWidget";
+import { TURNSTILE_ACTION, TurnstileWidget, isTurnstileConfigured, turnstileCData } from "@/components/TurnstileWidget";
 import type { ScrollySectionModel } from "@/lib/section-model";
 import { GlassCard } from "@/components/ui/glass-card";
 import { MosaicBackground } from "@/components/ui/mosaic-background";
@@ -705,7 +705,7 @@ function NotFoundState({
           </p>
 
           <div className="mt-8 space-y-4">
-            <TurnstileWidget onToken={setTurnstileToken} />
+            <TurnstileWidget onToken={setTurnstileToken} action={TURNSTILE_ACTION} cData={turnstileCData(arxivId)} />
             <motion.button
               whileHover={{ scale: starting ? 1 : 1.02 }}
               whileTap={{ scale: starting ? 1 : 0.98 }}

--- a/frontend/components/TurnstileWidget.tsx
+++ b/frontend/components/TurnstileWidget.tsx
@@ -14,6 +14,8 @@ declare global {
           "error-callback"?: () => void;
           appearance?: "always" | "execute" | "interaction-only";
           theme?: "light" | "dark" | "auto";
+          action?: string;
+          cData?: string;
         }
       ) => string;
       remove: (widgetId: string) => void;
@@ -23,6 +25,16 @@ declare global {
 
 const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
 export const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
+
+/** Every token is minted for this action with the paper id as cData; the
+ *  backend (api/turnstile.py) refuses tokens for anything else, so one solved
+ *  challenge starts exactly one paper. */
+export const TURNSTILE_ACTION = "start-paper";
+
+/** Mirror of backend turnstile_cdata: '.' -> '_', '/' -> '-', else dropped. */
+export function turnstileCData(arxivId: string): string {
+  return arxivId.replace(/\./g, "_").replace(/\//g, "-").replace(/[^A-Za-z0-9_-]/g, "").slice(0, 255);
+}
 
 /** Single source of truth for "is human verification on in this build". */
 export function isTurnstileConfigured(): boolean {
@@ -41,8 +53,12 @@ const LOAD_HINT_MS = 10_000;
  */
 export function TurnstileWidget({
   onToken,
+  action,
+  cData,
 }: {
   onToken: (token: string | null) => void;
+  action?: string;
+  cData?: string;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const onTokenRef = useRef(onToken);
@@ -72,6 +88,8 @@ export function TurnstileWidget({
         // interaction-only: invisible for humans, a checkbox only when
         // Cloudflare is unsure — keeps the Start button one tap for readers.
         appearance: "interaction-only",
+        action,
+        cData,
         callback: (token) => {
           setSlow(false);
           onTokenRef.current(token);
@@ -98,7 +116,7 @@ export function TurnstileWidget({
       cancelled = true;
       if (widgetId !== null) window.turnstile?.remove(widgetId);
     };
-  }, []);
+  }, [action, cData]);
 
   if (!TURNSTILE_SITE_KEY) return null;
   return (


### PR DESCRIPTION
## Why
The crawler passes Turnstile from a real browser and rotates IPs (78 fingerprints for 80 accepted papers on Sep 9). Cheap hardening from the countermeasures review: make every token single-purpose and gather a timing signal.

## Changes
- `backend/api/turnstile.py`: `TURNSTILE_ACTION = "start-paper"`, `turnstile_cdata(arxiv_id)` (cData alphabet: `.`→`_`, `/`→`-`), `verify_turnstile_detailed()` → `TurnstileVerdict(ok, reason, token_age_s)`; when `expected_cdata` is given the token's `action` and `cdata` must match (trailing `v\d+` ignored on both sides). `verify_turnstile()` keeps its bool contract for existing callers.
- `backend/api/routes.py`: POST /api/process verifies with `expected_cdata=turnstile_cdata(arxiv_id)`; logs the refusal reason, and `Turnstile ok token_age=…s` next to the client forensics.
- `frontend/components/TurnstileWidget.tsx`: `action`/`cData` props + exported `TURNSTILE_ACTION`, `turnstileCData()` mirror; `NotFoundState` passes the paper id.
- `backend/CLAUDE.md`: documents the binding and the rollout order.

## Rollout order (matters)
1. Merge → Vercel deploys the frontend (tokens now carry action + cData).
2. Then `gh workflow run deploy-backend.yml` — an API rolled first would refuse tokens from the old bundle.

## Test plan
- [x] backend ruff clean, 253 passed / 7 skipped (cdata encoding; action/cdata mismatch refused; version suffix ignored; age from `challenge_ts`; binding only enforced when requested)
- [x] frontend tsc / eslint / build green
- [ ] live: browser Start still works; API log shows `Turnstile ok token_age=…`; script-minted/replayed tokens refused with reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved human verification when starting a paper by binding each challenge to the selected paper.
  - Verification now rejects challenges issued for a different paper or purpose.

- **Bug Fixes**
  - Added clearer handling and logging for failed verification attempts.
  - Token freshness is checked to help prevent reuse of outdated challenges.

- **Documentation**
  - Updated deployment guidance and verification behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->