### PR TITLE
fix: production refuses Turnstile tokens minted on localhost

### DIFF
--- a/backend/api/turnstile.py
+++ b/backend/api/turnstile.py
@@ -50,7 +50,15 @@ class TurnstileVerdict:
 
 
 def _allowed_hostnames() -> set[str]:
-    raw = os.getenv("TURNSTILE_ALLOWED_HOSTNAMES", _DEFAULT_HOSTNAMES)
+    """Hostnames a token may have been minted on. ``localhost`` is for local
+    development only: in production a copy of our widget on an attacker's
+    localhost page would mint tokens Cloudflare reports as ``localhost``,
+    so it is dropped there unless the env var names it explicitly."""
+    raw = os.getenv("TURNSTILE_ALLOWED_HOSTNAMES")
+    if raw is None:
+        raw = _DEFAULT_HOSTNAMES
+        if os.getenv("ENVIRONMENT", "development").lower() == "production":
+            raw = raw.replace(",localhost", "")
     return {h.strip() for h in raw.split(",") if h.strip()}
 
 

--- a/backend/tests/test_admission.py
+++ b/backend/tests/test_admission.py
@@ -314,3 +314,16 @@ async def test_token_bound_to_action_and_paper(monkeypatch):
     # Binding is only enforced when the caller asks for it (older callers/tests).
     monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning({"success": True, "hostname": "arxivisual.org"}))
     assert await turnstile.verify_turnstile("tok", "203.0.113.9") is True
+
+
+
+async def test_localhost_tokens_refused_in_production_by_default(monkeypatch):
+    monkeypatch.setenv("TURNSTILE_SECRET_KEY", "test-secret")
+    monkeypatch.delenv("TURNSTILE_ALLOWED_HOSTNAMES", raising=False)
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _client_returning({"success": True, "hostname": "localhost"}))
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    assert await turnstile.verify_turnstile("tok", "203.0.113.9") is True
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    assert await turnstile.verify_turnstile("tok", "203.0.113.9") is False
+    monkeypatch.setenv("TURNSTILE_ALLOWED_HOSTNAMES", "arxivisual.org,localhost")  # explicit opt-in still works
+    assert await turnstile.verify_turnstile("tok", "203.0.113.9") is True


### PR DESCRIPTION
The default \`TURNSTILE_ALLOWED_HOSTNAMES\` included \`localhost\` (needed for local dev). In production that means a copy of our widget served from an attacker's own localhost page mints tokens that Cloudflare reports as hostname \`localhost\`, which the API accepted — bypassing the page-bound action/cData check from #78, since the attacker controls the widget parameters on their page.

- \`backend/api/turnstile.py\`: when \`ENVIRONMENT=production\` and the env var is unset, the default drops \`localhost\`. An explicit \`TURNSTILE_ALLOWED_HOSTNAMES\` still wins.
- Test: dev accepts, production refuses, explicit opt-in accepts.

Backend-only; deploy with \`gh workflow run deploy-backend.yml\` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In production, localhost Turnstile tokens are now rejected by default.
  * Explicitly listing localhost in the allowed-hostnames configuration continues to permit those tokens.
  * Development environments continue to accept localhost tokens by default.

* **Tests**
  * Added coverage for Turnstile hostname behavior across development, production, and explicit configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->