### PR TITLE
fix: durable global new-paper window (was per replica); nav links stop prefetching

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ limits are designed to hold even when the attacker has read them:
    Direct API scripts never pass; verification fails closed if Cloudflare is unreachable.
 2. **Durable daily cap** — `DAILY_NEW_PAPER_CAP` new-paper jobs per UTC day, counted from Postgres so
    it survives restarts and replicas. Already-visualized papers are always served for free.
-3. **Sliding windows** — per-IP hourly, per-IP daily, and global. Client identity is the rightmost
+3. **Sliding windows** — per-IP hourly and per-IP daily in memory; the global window is counted from the jobs table so every replica enforces the same number. Client identity is the rightmost
    `X-Forwarded-For` hop (appended by the ingress); client-supplied prefixes are ignored.
 
 Submissions are logged with a hashed client fingerprint (never raw IPs) for abuse forensics.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -95,9 +95,11 @@ backend ruff and frontend eslint are both HARD gates). `security.yml` — gitlea
   when unset, fails CLOSED when set; every token is minted with action `start-paper` and the paper id as cData
   (`turnstile_cdata`, mirrored in `TurnstileWidget.tsx`) and the API refuses tokens for any other action/paper,
   so one solved challenge starts one paper — deploy the frontend BEFORE the API when the binding changes; (2) `DAILY_NEW_PAPER_CAP` (80) — durable per-UTC-day ceiling counted from
-  the jobs table (the spend guarantee; cached papers stay free; 0 disables); (3) in-memory sliding windows:
-  `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_PER_IP_DAILY` (3/day), `RATE_LIMIT_PROCESS_GLOBAL`
-  (30/h; prod sets 6), `RATE_LIMIT_PROCESS_WINDOW_SECONDS` (3600), `PROCESS_DEDUPE_TTL_SECONDS` (600).
+  the jobs table (the spend guarantee; cached papers stay free; 0 disables); (3) `RATE_LIMIT_PROCESS_GLOBAL`
+  (30 per `RATE_LIMIT_PROCESS_WINDOW_SECONDS`=3600; prod sets 6) — the global rolling window, ALSO counted from
+  the jobs table (it was an in-memory limiter, i.e. per replica: two replicas silently doubled it); (4) in-memory
+  per-IP sliding windows: `RATE_LIMIT_PROCESS_PER_IP` (5/h), `RATE_LIMIT_PROCESS_PER_IP_DAILY` (3/day),
+  `PROCESS_DEDUPE_TTL_SECONDS` (600).
   `client_ip()` takes the RIGHTMOST `X-Forwarded-For` hop (the one the ingress appends) — never the first.
   `ProcessRequest.arxiv_id` is validated and normalized (version suffix stripped) at the boundary — the paper is
   stored under the base id, and non-arXiv identifiers are rejected with 422 before any budget is spent.

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -48,7 +48,8 @@ from .throttle import (
     enforce,
     enforce_all,
     feedback_limiter,
-    global_limiter,
+    global_window_seconds,
+    global_window_verdict,
     ip_fingerprint,
     per_ip_daily_limiter,
     per_ip_limiter,
@@ -172,6 +173,22 @@ async def start_processing(
             headers={"Retry-After": str(retry_after)},
         )
 
+    # Durable global window (rolling, jobs-table-counted so every replica sees
+    # the same number). Before Turnstile for the same reason as the daily cap.
+    window_seconds = global_window_seconds()
+    started_in_window = await queries.count_jobs_created_since(db, now - timedelta(seconds=window_seconds))
+    saturated, retry_after = global_window_verdict(started_in_window)
+    if saturated:
+        logger.info(
+            "Rate limit denied: The service is at capacity for new papers right now (%d in %ds) (client %s)",
+            started_in_window, window_seconds, client_tag,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="The service is at capacity for new papers right now. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     verdict = await verify_turnstile_detailed(
         request.turnstile_token, ip, expected_cdata=turnstile_cdata(arxiv_id),
     )
@@ -189,8 +206,6 @@ async def start_processing(
             (per_ip_limiter, ip, "Rate limit reached for starting new papers. Try again later."),
             (per_ip_daily_limiter, ip,
              "You've started today's share of new papers from this address. Try again tomorrow."),
-            (global_limiter, "global",
-             "The service is at capacity for new papers right now. Try again later."),
         ],
         client_tag=client_tag,
     )

--- a/backend/api/throttle.py
+++ b/backend/api/throttle.py
@@ -201,16 +201,35 @@ def enforce_all(
 
 
 # Defaults: a person exploring the site can start 5 papers an hour; the whole
-# world combined is capped at 30/hour (~$3/hour worst-case LLM+render spend).
-# Set either env to 0 to disable that limiter.
+# world combined is capped by the durable global window below (30/hour default;
+# prod sets 6). Set either env to 0 to disable that limiter.
 per_ip_limiter = SlidingWindowLimiter(
     max_events=_int_env("RATE_LIMIT_PROCESS_PER_IP", 5),
     window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
 )
-global_limiter = SlidingWindowLimiter(
-    max_events=_int_env("RATE_LIMIT_PROCESS_GLOBAL", 30),
-    window_seconds=_int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600),
-)
+
+
+def global_window_cap() -> int:
+    """Ceiling on NEW-paper jobs per rolling window across the whole service.
+    Counted from the jobs table by the route (see ``global_window_verdict``),
+    not in memory: the in-memory limiter was per replica, so with two API
+    replicas "6/hour" was really up to 12. 0 disables."""
+    return _int_env("RATE_LIMIT_PROCESS_GLOBAL", 30)
+
+
+def global_window_seconds() -> int:
+    return _int_env("RATE_LIMIT_PROCESS_WINDOW_SECONDS", 3600)
+
+
+def global_window_verdict(started_in_window: int) -> tuple[bool, int]:
+    """(saturated, retry_after_seconds) for the durable global window, given
+    the number of jobs created within it. Like the daily cap: a fuse, not a
+    ledger — concurrency can overshoot by a request or two."""
+    cap = global_window_cap()
+    if cap <= 0 or started_in_window < cap:
+        return False, 0
+    return True, 60
+
 # A slower second per-IP window: 5/hour still allows 120/day from one patient
 # client. Daily quotas belong to a person, not a script.
 per_ip_daily_limiter = SlidingWindowLimiter(

--- a/backend/tests/test_admission.py
+++ b/backend/tests/test_admission.py
@@ -43,11 +43,11 @@ async def client(db, monkeypatch):
     monkeypatch.setattr(routes_module, "process_paper_job", _noop)
     monkeypatch.delenv("USE_TEMPORAL", raising=False)
     monkeypatch.delenv("TURNSTILE_SECRET_KEY", raising=False)
-    for lim in (throttle.per_ip_limiter, throttle.per_ip_daily_limiter, throttle.global_limiter):
+    for lim in (throttle.per_ip_limiter, throttle.per_ip_daily_limiter):
         lim.reset()
     monkeypatch.setattr(throttle.per_ip_limiter, "max_events", 100)
     monkeypatch.setattr(throttle.per_ip_daily_limiter, "max_events", 100)
-    monkeypatch.setattr(throttle.global_limiter, "max_events", 100)
+    monkeypatch.setenv("RATE_LIMIT_PROCESS_GLOBAL", "100")
     monkeypatch.setenv("DAILY_NEW_PAPER_CAP", "0")
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
@@ -104,7 +104,7 @@ async def test_spoofed_forwarded_header_cannot_mint_new_buckets(client, monkeypa
 async def test_global_denial_does_not_consume_per_ip_budget(client, monkeypatch):
     # Reviewer-reproduced lockout: chained record-and-check let three "at
     # capacity" answers exhaust a real user's 3/day quota with zero papers started.
-    monkeypatch.setattr(throttle.global_limiter, "max_events", 1)
+    monkeypatch.setenv("RATE_LIMIT_PROCESS_GLOBAL", "1")
     monkeypatch.setattr(throttle.per_ip_daily_limiter, "max_events", 3)
     xff = {"X-Forwarded-For": "203.0.113.77"}
     assert (await _submit(client, "1706.03762", **xff)).status_code == 200
@@ -113,8 +113,24 @@ async def test_global_denial_does_not_consume_per_ip_budget(client, monkeypatch)
         assert hit.status_code == 429 and "capacity" in hit.json()["detail"]
     # Three global denials must not have touched this client's daily budget.
     assert len(throttle.per_ip_daily_limiter._events["203.0.113.77"]) == 1
-    throttle.global_limiter.reset()
+    monkeypatch.setenv("RATE_LIMIT_PROCESS_GLOBAL", "100")
     assert (await _submit(client, "1810.04805", **xff)).status_code == 200
+
+
+async def test_global_window_is_counted_from_the_jobs_table(client, db, monkeypatch):
+    # Two API replicas used to keep two in-memory windows ("6/h" was really 12).
+    # A job created by anyone else — another replica, an earlier request —
+    # counts here too, and the answer carries Retry-After.
+    from db.models import ProcessingJob
+
+    monkeypatch.setenv("RATE_LIMIT_PROCESS_GLOBAL", "1")
+    db.add(ProcessingJob(id="job_other_replica", status="queued"))
+    await db.commit()
+    hit = await _submit(client, "1706.03762", **{"X-Forwarded-For": "203.0.113.5"})
+    assert hit.status_code == 429 and "capacity" in hit.json()["detail"]
+    assert hit.headers.get("Retry-After") == "60"
+    monkeypatch.setenv("RATE_LIMIT_PROCESS_GLOBAL", "0")  # 0 disables
+    assert (await _submit(client, "1706.03762", **{"X-Forwarded-For": "203.0.113.5"})).status_code == 200
 
 
 async def test_per_ip_daily_quota(client, monkeypatch):

--- a/frontend/app/abs/[...id]/page.tsx
+++ b/frontend/app/abs/[...id]/page.tsx
@@ -447,6 +447,7 @@ export default function PaperPage({
             >
               <Link
                 href="/"
+                prefetch={false}
                 className="group inline-flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-xl px-4 py-2.5 text-sm text-white/50 border border-white/[0.08] transition-all hover:bg-black/80 hover:text-white/80 hover:border-white/[0.15] shadow-lg shadow-black/30"
               >
                 <span className="transition-transform group-hover:-translate-x-0.5">&larr;</span>
@@ -634,7 +635,7 @@ function ReadyState({
             View on arXiv
           </a>
           <span className="w-1 h-1 rounded-full bg-white/20" />
-          <Link href="/" className="text-white/30 hover:text-white/60 transition-colors">
+          <Link href="/" prefetch={false} className="text-white/30 hover:text-white/60 transition-colors">
             Explore another paper
           </Link>
         </div>

--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -85,6 +85,7 @@ export default function ExplorePage() {
       >
         <Link
           href="/"
+          prefetch={false}
           className="group inline-flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-xl px-4 py-2.5 text-sm text-white/50 border border-white/[0.08] transition-all hover:bg-black/80 hover:text-white/80 hover:border-white/[0.15] shadow-lg shadow-black/30"
         >
           <span className="transition-transform group-hover:-translate-x-0.5">&larr;</span>
@@ -146,6 +147,7 @@ export default function ExplorePage() {
             action={
               <Link
                 href="/"
+                prefetch={false}
                 className="rounded-2xl bg-white/[0.08] hover:bg-white/[0.12] px-8 py-4 text-sm font-medium text-white border border-white/[0.15] hover:border-white/[0.25] transition-all"
               >
                 Visualize a paper

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -68,6 +68,7 @@ export default function Home() {
       >
         <Link
           href="/explore"
+          prefetch={false}
           className="group inline-flex items-center gap-2 rounded-full bg-black/60 backdrop-blur-xl px-4 py-2.5 text-sm text-white/50 border border-white/[0.08] transition-all hover:bg-black/80 hover:text-white/80 hover:border-white/[0.15] shadow-lg shadow-black/30"
         >
           <span className="text-white/40 select-none">&#9671;</span>


### PR DESCRIPTION
Two grafts from the crawler/hosting review panel that stand regardless of the sign-in decision.

- **Global window is now durable.** `RATE_LIMIT_PROCESS_GLOBAL` was an in-memory `SlidingWindowLimiter`, one per API replica; with `max_replicas=2` the "6/h" fuse could admit 12. `POST /api/process` now counts jobs created within `RATE_LIMIT_PROCESS_WINDOW_SECONDS` from the jobs table (`count_jobs_created_since`), returns 429 + `Retry-After: 60`, and runs before Turnstile (a full window must not burn a single-use token). Log line keeps the "at capacity for new papers" phrase the Log Analytics queries match. Per-IP windows unchanged.
- **Nav links no longer prefetch**: `prefetch={false}` on the Back/Explore/home links in `explore/page.tsx`, `abs/[...id]/page.tsx`, `app/page.tsx` (four `/?_rsc` requests per Explore visit measured).
- Docs: `backend/CLAUDE.md`, `SECURITY.md`.

## Test plan
- [x] backend ruff clean, 255 passed / 7 skipped — `test_global_window_is_counted_from_the_jobs_table` (a job row from "another replica" saturates the window; `Retry-After`; `0` disables), existing global-denial-does-not-consume-per-IP test rewritten against the env knob
- [x] frontend tsc / eslint / build green
- [ ] after deploy: API healthy; `Rate limit denied … (N in 3600s)` lines in Log Analytics